### PR TITLE
Refactor collection helper to only return the schema

### DIFF
--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -1,5 +1,8 @@
-import { defineDocsCollection } from 'starbook/schema';
+import { defineCollection } from 'astro:content';
+import { docsSchema } from 'starbook/schema';
 
 export const collections = {
-  docs: defineDocsCollection(),
+  docs: defineCollection({
+    schema: docsSchema(),
+  }),
 };

--- a/packages/starbook/schema.ts
+++ b/packages/starbook/schema.ts
@@ -1,28 +1,23 @@
-import { defineCollection, z } from 'astro:content';
+import { z } from 'astro:content';
 
-export function defineDocsCollection() {
-  return defineCollection({
-    schema: z.object({
-      /** The title of the current page. Required. */
-      title: z.string(),
+export function docsSchema() {
+  return z.object({
+    /** The title of the current page. Required. */
+    title: z.string(),
 
-      /**
-       * A short description of the current page’s content. Optional, but recommended.
-       * A good description is 150–160 characters long and outlines the key content
-       * of the page in a clear and engaging way.
-       */
-      description: z.string().optional(),
+    /**
+     * A short description of the current page’s content. Optional, but recommended.
+     * A good description is 150–160 characters long and outlines the key content
+     * of the page in a clear and engaging way.
+     */
+    description: z.string().optional(),
 
-      /**
-       * Custom URL where a reader can edit this page.
-       * Overrides the `editLink.baseUrl` global config if set.
-       *
-       * Can also be set to `false` to disable showing an edit link on this page.
-       */
-      editUrl: z
-        .union([z.string().url(), z.boolean()])
-        .optional()
-        .default(true),
-    }),
+    /**
+     * Custom URL where a reader can edit this page.
+     * Overrides the `editLink.baseUrl` global config if set.
+     *
+     * Can also be set to `false` to disable showing an edit link on this page.
+     */
+    editUrl: z.union([z.string().url(), z.boolean()]).optional().default(true),
   });
 }


### PR DESCRIPTION
```js
// BEFORE
import { defineDocsCollection } from 'starbook/schema';

export const collections = {
  docs: defineDocsCollection(),
};
```
```js
// AFTER
import { defineCollection } from 'astro:content';
import { docsSchema } from 'starbook/schema';

export const collections = {
  docs: defineCollection({
    schema: docsSchema(),
  }),
};
```