### PR TITLE
 `astro:content` -> `astro/zod` to import zod

### DIFF
--- a/.changeset/strange-walls-sneeze.md
+++ b/.changeset/strange-walls-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Import zod from `astro/zod` to fix an issue related to importing the `astro:content` virtual module

--- a/packages/starlight/schema.ts
+++ b/packages/starlight/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'astro:content';
+import { z } from 'astro/zod';
 
 export function docsSchema() {
   return z.object({


### PR DESCRIPTION
Import zod from `astro/zod` to fix an issue related to importing the `astro:content` virtual module