### PR TITLE
Add support for generating sitemap

### DIFF
--- a/.changeset/lovely-papayas-sip.md
+++ b/.changeset/lovely-papayas-sip.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Generate sitemaps for Starlight sites

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -3,6 +3,7 @@ import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
+  site: 'https://starlight.astro.build',
   integrations: [
     starlight({
       title: 'Starlight Docs',

--- a/packages/starlight/components/HeadSEO.astro
+++ b/packages/starlight/components/HeadSEO.astro
@@ -40,6 +40,8 @@ const description = data.description || config.description;
   href={import.meta.env.BASE_URL + 'favicon.svg'}
   type="image/svg+xml"
 />
+{/* Link to sitemap, but only when `site` is set. */}
+{Astro.site && <link rel="sitemap" href="/sitemap-index.xml" />}
 
 <!-- OpenGraph Tags -->
 <meta property="og:title" content={title} />

--- a/packages/starlight/index.ts
+++ b/packages/starlight/index.ts
@@ -9,6 +9,7 @@ import { spawn } from 'node:child_process';
 import { dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { starlightAsides } from './integrations/asides';
+import { starlightSitemap } from './integrations/sitemap';
 import {
   StarlightUserConfig,
   StarlightConfig,
@@ -63,7 +64,7 @@ export default function StarlightIntegration(
     },
   };
 
-  return [Starlight, mdx()];
+  return [starlightSitemap(userConfig), Starlight, mdx()];
 }
 
 function resolveVirtualModuleId(id: string) {

--- a/packages/starlight/integrations/sitemap.ts
+++ b/packages/starlight/integrations/sitemap.ts
@@ -1,0 +1,22 @@
+import sitemap, { SitemapOptions } from '@astrojs/sitemap';
+import type { StarlightConfig } from '../types';
+
+/**
+ * A wrapped version of the `@astrojs/sitemap` integration configured based
+ * on Starlight i18n config.
+ */
+export function starlightSitemap(opts: StarlightConfig) {
+  const sitemapConfig: SitemapOptions = {};
+  if (opts.isMultilingual) {
+    sitemapConfig.i18n = {
+      defaultLocale: opts.defaultLocale.locale! || 'root',
+      locales: Object.fromEntries(
+        Object.entries(opts.locales).map(([locale, config]) => [
+          locale,
+          config?.lang!,
+        ])
+      ),
+    };
+  }
+  return sitemap(sitemapConfig);
+}

--- a/packages/starlight/package.json
+++ b/packages/starlight/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^0.19.1",
+    "@astrojs/sitemap": "^1.3.1",
     "@pagefind/default-ui": "^0.12.0",
     "@types/mdast": "^3.0.11",
     "bcp-47": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       '@astrojs/mdx':
         specifier: ^0.19.1
         version: 0.19.1(astro@2.4.3)(rollup@3.21.5)
+      '@astrojs/sitemap':
+        specifier: ^1.3.1
+        version: 1.3.1
       '@pagefind/default-ui':
         specifier: ^0.12.0
         version: 0.12.0
@@ -157,6 +160,13 @@ packages:
     engines: {node: '>=16.12.0'}
     dependencies:
       prismjs: 1.29.0
+
+  /@astrojs/sitemap@1.3.1:
+    resolution: {integrity: sha512-4ZBug4ml+2Nl5/Uh4VSja8Kij/DU7/RaNMciXCNm1EzQkP/jm+nqMG1liDDcQK5zXPAoLeaat06IbhNlruvQjg==}
+    dependencies:
+      sitemap: 7.1.1
+      zod: 3.21.4
+    dev: false
 
   /@astrojs/telemetry@2.1.1:
     resolution: {integrity: sha512-4pRhyeQr0MLB5PKYgkdu+YE8sSpMbHL8dUuslBWBIdgcYjtD1SufPMBI8pgXJ+xlwrQJHKKfK2X1KonHYuOS9A==}
@@ -1015,6 +1025,10 @@ packages:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
 
+  /@types/node@17.0.45:
+    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
+    dev: false
+
   /@types/node@18.15.11:
     resolution: {integrity: sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==}
 
@@ -1027,6 +1041,12 @@ packages:
 
   /@types/resolve@1.20.2:
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
+  /@types/sax@1.2.4:
+    resolution: {integrity: sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==}
+    dependencies:
+      '@types/node': 18.15.11
+    dev: false
 
   /@types/semver@6.2.3:
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
@@ -1115,6 +1135,10 @@ packages:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  /arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+    dev: false
 
   /argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -3742,6 +3766,10 @@ packages:
     dependencies:
       suf-log: 2.5.3
 
+  /sax@1.2.4:
+    resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
+    dev: false
+
   /section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
@@ -3815,6 +3843,17 @@ packages:
 
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  /sitemap@7.1.1:
+    resolution: {integrity: sha512-mK3aFtjz4VdJN0igpIJrinf3EO8U8mxOPsTBzSsy06UtjZQJ3YY3o3Xa7zSc5nMqcMrRwlChHZ18Kxg0caiPBg==}
+    engines: {node: '>=12.0.0', npm: '>=5.6.0'}
+    hasBin: true
+    dependencies:
+      '@types/node': 17.0.45
+      '@types/sax': 1.2.4
+      arg: 5.0.2
+      sax: 1.2.4
+    dev: false
 
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}


### PR DESCRIPTION
Uses `@astrojs/sitemap` to build a sitemap with appropriate i18n config based on Starlight locales. Skipped if the user hasn’t set `site` in their `astro.config.mjs`.