### PR TITLE
Configure issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/---01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/---01-bug-report.yml
@@ -1,0 +1,67 @@
+name: "\U0001F41B Bug Report"
+description: Report an issue or possible bug
+labels: []
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to file a bug report! Please fill out this form as completely as possible.
+
+        ✅ I am using the **latest versions of Starlight and Astro**.
+        ✅ I am using a version of Node that supports ESM (`v14.18.0+`, or `v16.12.0+`).
+  - type: input
+    id: starlight-version
+    attributes:
+      label: What version of `starlight` are you using?
+      placeholder: 0.0.0
+    validations:
+      required: true
+  - type: input
+    id: astro-version
+    attributes:
+      label: What version of `astro` are you using?
+      placeholder: 0.0.0
+    validations:
+      required: true
+  - type: input
+    id: package-manager
+    attributes:
+      label: What package manager are you using?
+      placeholder: npm, yarn, pnpm
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: What operating system are you using?
+      placeholder: Mac, Windows, Linux
+    validations:
+      required: true
+  - type: input
+    id: browser
+    attributes:
+      label: What browser are you using?
+      placeholder: Chrome, Firefox, Safari
+    validations:
+      required: true
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the Bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: input
+    id: bug-reproduction
+    attributes:
+      label: Link to Minimal Reproducible Example
+      description: 'Use [astro.new](https://astro.new) to create a minimal reproduction of the problem. **A minimal reproduction is required** so that others can help debug your issue. If a report is vague (e.g. just a generic error message) and has no reproduction, it may be auto-closed. Not sure how to create a minimal example? [Read our guide](https://docs.astro.build/en/guides/troubleshooting/#creating-minimal-reproductions)'
+      placeholder: 'https://stackblitz.com/abcd1234'
+  - type: checkboxes
+    id: will-pr
+    attributes:
+      label: Participation
+      options:
+        - label: I am willing to submit a pull request for this issue.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 👾 Chat
+    url: https://astro.build/chat
+    about: Our Discord server is active, come join us!
+  - name: 💁 Support
+    url: https://astro.build/chat
+    about: 'This issue tracker is not for support questions. Join us on Discord for assistance!'


### PR DESCRIPTION
- Adds a bug report template
- Adds config for the “new issue” page, modelled after the main astro repo