### PR TITLE
Better `base` URL support

### DIFF
--- a/.changeset/curvy-maps-care.md
+++ b/.changeset/curvy-maps-care.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Make `base` support consistent, including when `trailingSlash: 'never'` is set.

--- a/packages/starlight/404.astro
+++ b/packages/starlight/404.astro
@@ -17,6 +17,7 @@ import ThemeProvider from './components/ThemeProvider.astro';
 
 // Important that this is the last import so it can override built-in styles.
 import 'virtual:starlight/user-css';
+import { withBase } from './utils/base';
 
 const { lang = 'en', dir = 'ltr', locale } = config.defaultLocale || {};
 ---
@@ -37,7 +38,7 @@ const { lang = 'en', dir = 'ltr', locale } = config.defaultLocale || {};
           <p>Houston, we have a problem.</p>
           <p>
             We couldn’t find that link. Check the address or <a
-              href={import.meta.env.BASE_URL}>head back home</a
+              href={withBase('/')}>head back home</a
             >.
           </p>
         </MarkdownContent>

--- a/packages/starlight/components/HeadSEO.astro
+++ b/packages/starlight/components/HeadSEO.astro
@@ -4,6 +4,7 @@ import config from 'virtual:starlight/user-config';
 import type { HeadConfigSchema } from '../schemas/head';
 import { createHead } from '../utils/head';
 import { localizedUrl } from '../utils/localizedUrl';
+import { withBase } from '../utils/base';
 
 interface Props {
   data: CollectionEntry<'docs'>['data'];
@@ -32,7 +33,7 @@ const headDefaults: z.input<ReturnType<typeof HeadConfigSchema>> = [
     tag: 'link',
     attrs: {
       rel: 'shortcut icon',
-      href: import.meta.env.BASE_URL + 'favicon.svg',
+      href: withBase('/favicon.svg'),
       type: 'image/svg+xml',
     },
   },
@@ -80,7 +81,7 @@ if (Astro.site) {
     tag: 'link',
     attrs: {
       rel: 'sitemap',
-      href: import.meta.env.BASE_URL + 'sitemap-index.xml',
+      href: withBase('/sitemap-index.xml'),
     },
   });
 }

--- a/packages/starlight/components/SiteTitle.astro
+++ b/packages/starlight/components/SiteTitle.astro
@@ -1,6 +1,7 @@
 ---
 import { logos } from 'virtual:starlight/user-images';
 import config from 'virtual:starlight/user-config';
+import { withBase } from '../utils/base';
 
 interface Props {
   locale: string | undefined;
@@ -22,11 +23,7 @@ if (config.logo) {
   if (err) throw new Error(err);
 }
 
-const { locale } = Astro.props
-
-const href = locale
-  ? `${import.meta.env.BASE_URL.replace(/\/$/, '')}/${locale}/`
-  : import.meta.env.BASE_URL
+const href = withBase(Astro.props.locale || '/');
 ---
 
 <a {href} class="site-title flex">

--- a/packages/starlight/utils/base.ts
+++ b/packages/starlight/utils/base.ts
@@ -1,0 +1,14 @@
+const base = stripTrailingSlash(import.meta.env.BASE_URL);
+
+/** Get the a root-relative URL path with the site’s `base` prefixed. */
+export function withBase(path: string) {
+  path = stripLeadingSlash(stripTrailingSlash(path));
+  return path ? base + '/' + path + '/' : base + '/';
+}
+
+function stripLeadingSlash(path: string) {
+  return path.replace(/^\//, '');
+}
+function stripTrailingSlash(path: string) {
+  return path.replace(/\/$/, '');
+}

--- a/packages/starlight/utils/navigation.ts
+++ b/packages/starlight/utils/navigation.ts
@@ -1,7 +1,8 @@
 import { basename, dirname } from 'node:path';
 import config from 'virtual:starlight/user-config';
-import { slugToPathname } from './slugs';
+import { withBase } from './base';
 import { Route, getLocaleRoutes, routes } from './routing';
+import { slugToPathname } from './slugs';
 import type {
   AutoSidebarGroup,
   SidebarItem,
@@ -100,12 +101,7 @@ function linkFromConfig(
 
 /** Create a link entry. */
 function makeLink(href: string, label: string, currentPathname: string): Link {
-  if (!isAbsolute(href)) {
-    href = ensureLeadingAndTrailingSlashes(href);
-    /** Base URL with trailing `/` stripped. */
-    const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-    if (base) href = base + href;
-  }
+  if (!isAbsolute(href)) href = withBase(href);
   const isCurrent = href === currentPathname;
   return { type: 'link', label, href, isCurrent };
 }


### PR DESCRIPTION
Follow up to #57, making use of `import.meta.env.BASE_URL` more consistent so we always account for different Astro config options (e.g. `trailingSlash: 'never'` which was broken previously).