### PR TITLE
Improve table of contents intersection observer

### DIFF
--- a/.changeset/grumpy-trains-decide.md
+++ b/.changeset/grumpy-trains-decide.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fix table of contents intersection observer for all possible viewport sizes.

--- a/packages/starlight/components/TableOfContents/MobileTableOfContents.astro
+++ b/packages/starlight/components/TableOfContents/MobileTableOfContents.astro
@@ -121,7 +121,7 @@ const toc = generateToC(Astro.props.headings, config.tableOfContents);
     }
 
     constructor() {
-      super();
+      super({ smallViewport: true });
       const details = this.querySelector('details');
       if (!details) return;
       const closeToC = () => {

--- a/packages/starlight/components/TableOfContents/starlight-toc.ts
+++ b/packages/starlight/components/TableOfContents/starlight-toc.ts
@@ -12,7 +12,7 @@ export class StarlightTOC extends HTMLElement {
     this._current = link;
   }
 
-  constructor() {
+  constructor({ smallViewport = false } = {}) {
     super();
 
     /** All the links in the table of contents. */
@@ -68,8 +68,8 @@ export class StarlightTOC extends HTMLElement {
       }
     };
 
-    const headingsObserver = new IntersectionObserver(setCurrent, {
-      rootMargin: '-10% 0% -85%',
+    const observer = new IntersectionObserver(setCurrent, {
+      rootMargin: smallViewport ? '-20% 0% -75%' : '-10% 0% -85%',
     });
 
     // Observe elements with an `id` (most likely headings) and their siblings.
@@ -78,7 +78,7 @@ export class StarlightTOC extends HTMLElement {
     const toObserve = document.querySelectorAll(
       'main [id], main [id] ~ *, main .content > *'
     );
-    toObserve.forEach((h) => headingsObserver.observe(h));
+    toObserve.forEach((h) => observer.observe(h));
   }
 }
 


### PR DESCRIPTION
I’ve played with a couple different strategies.

This PR adds code to actually recreate the intersection observer entirely when the window resizes. This lets us use really specific margins based on the window’s `clientHeight` instead of trying to get percentage margins to work OK across all viewport heights. It’s slightly more JS, but we’re debouncing the resize event & waiting for idle in browsers that support that, so should be pretty performant.