### PR TITLE
Make site title width fit the content

### DIFF
--- a/.changeset/forty-rocks-lick.md
+++ b/.changeset/forty-rocks-lick.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Make site title width fit the content

--- a/packages/starlight/components/SiteTitle.astro
+++ b/packages/starlight/components/SiteTitle.astro
@@ -57,7 +57,7 @@ const href = withBase(Astro.props.locale || '/');
 
 <style>
   .site-title {
-    max-width: fit-content;
+    justify-self: flex-start;
     align-items: center;
     gap: var(--sl-nav-gap);
     font-size: var(--sl-text-h4);

--- a/packages/starlight/components/SiteTitle.astro
+++ b/packages/starlight/components/SiteTitle.astro
@@ -57,6 +57,7 @@ const href = withBase(Astro.props.locale || '/');
 
 <style>
   .site-title {
+    max-width: fit-content;
     align-items: center;
     gap: var(--sl-nav-gap);
     font-size: var(--sl-text-h4);


### PR DESCRIPTION
Because of flexbox:tm: the site title link was stretching out to the entire width available, so, I added `max-width: fit-content` to force the width to be the same as the actual link image/title.

Before:
![image](https://github.com/withastro/starlight/assets/61414485/340f7d3c-12b6-4cdb-8677-a9543d66aa53)

Now:
![image](https://github.com/withastro/starlight/assets/61414485/03462906-7ddb-425d-b332-84ba63d46225)
