### PR TITLE
Fix background color on select component

### DIFF
--- a/.changeset/light-dingos-fry.md
+++ b/.changeset/light-dingos-fry.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fix background color on select component

--- a/packages/starlight/components/Select.astro
+++ b/packages/starlight/components/Select.astro
@@ -72,6 +72,10 @@ interface Props {
     appearance: none;
   }
 
+  option {
+    background-color: var(--sl-color-bg-nav);
+  }
+
   @media (min-width: 50rem) {
     select {
       font-size: var(--sl-text-sm);


### PR DESCRIPTION
- Closes #65 
- Doesn't address [this comment](https://github.com/withastro/starlight/issues/65#issuecomment-1551771078) because I don't think we want to disable an outline.
> Yeah I also think that the focus state should be removed, I was trying to look if the astro.build website had this same behavior but they don't

After change (viewed in chromium):
![image](https://github.com/withastro/starlight/assets/64310361/54daae2c-ace3-4eb0-8982-240df3428fd5)
![image](https://github.com/withastro/starlight/assets/64310361/5d9b3bc7-13dd-4381-8d43-821021133902)
