### PR TITLE
Add Gitpod instructions to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Instead of working locally on your machine, you can also contribute using an onl
 
 **Prerequisites:** Developing Starlight using Gitpod requires a free [Gitpod account](https://gitpod.io).
 
-1. ** Open the Gitpod URL ** [https://gitpod.io/#https://github.com/withastro/starlight](https://gitpod.io/#https://github.com/withastro/starlight). You can alternatively install a [Gitpod browser extension](https://www.gitpod.io/docs/configure/user-settings/browser-extension) which will add a "Gitpod" button when viewing [Starlight's repo on GitHub](https://github.com/withastro/starlight).
+1. **Open the Gitpod URL** [https://gitpod.io/#https://github.com/withastro/starlight](https://gitpod.io/#https://github.com/withastro/starlight). You can alternatively install a [Gitpod browser extension](https://www.gitpod.io/docs/configure/user-settings/browser-extension) which will add a "Gitpod" button when viewing [Starlight's repo on GitHub](https://github.com/withastro/starlight).
 
 2. **Install dependencies** with `pnpm`:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,8 @@ This repo is a “monorepo,” meaning it contains several projects in one. It c
 
 ### Setting up a development environment
 
+#### Developing locally
+
 **Prerequisites:** Developing Starlight requires [Node.js](https://nodejs.org/en) and [pnpm](https://pnpm.io/). Make sure you have these installed before following these steps.
 
 1. **Fork Starlight** to your personal GitHub account by clicking <kbd>Fork</kbd> on the [main Starlight repo page][sl].
@@ -57,7 +59,7 @@ This repo is a “monorepo,” meaning it contains several projects in one. It c
    ```sh
    pnpm i
    ```
-#### Contributing using Gitpod
+#### Developing using Gitpod
 
 Instead of working locally on your machine, you can also contribute using an online coding development environment like Gitpod.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,19 @@ This repo is a “monorepo,” meaning it contains several projects in one. It c
    ```sh
    pnpm i
    ```
+#### Contributing using Gitpod
+
+Instead of working locally on your machine, you can also contribute using an online coding development environment like Gitpod.
+
+**Prerequisites:** Developing Starlight using Gitpod requires a free [Gitpod account](https://gitpod.io).
+
+1. ** Open the Gitpod URL ** [https://gitpod.io/#https://github.com/withastro/starlight](https://gitpod.io/#https://github.com/withastro/starlight). You can alternatively install a [Gitpod browser extension](https://www.gitpod.io/docs/configure/user-settings/browser-extension) which will add a "Gitpod" button when viewing [Starlight's repo on GitHub](https://github.com/withastro/starlight).
+
+2. **Install dependencies** with `pnpm`:
+
+   ```sh
+   pnpm i
+   ```
 
 ### Testing changes while you work
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,7 @@ This repo is a “monorepo,” meaning it contains several projects in one. It c
    ```sh
    pnpm i
    ```
+
 #### Developing using Gitpod
 
 Instead of working locally on your machine, you can also contribute using an online coding development environment like Gitpod.


### PR DESCRIPTION
Tested these instructions to open and start the dev server using Gitpod. You don't need to `cd` into `starlight`, just install dependencies right away, then run the dev server.

Edit as necessary!