### PR TITLE
fix: change link for guides/i18n

### DIFF
--- a/docs/src/content/docs/reference/markdown-syntax.md
+++ b/docs/src/content/docs/reference/markdown-syntax.md
@@ -108,7 +108,7 @@ Your users may be more productive and find your product easier to use thanks to 
 
 - Clear navigation
 - User-configurable colour theme
-- [i18n support](./guides/i18n)
+- [i18n support](/guides/i18n)
 
 :::
 
@@ -122,7 +122,7 @@ Your users may be more productive and find your product easier to use thanks to 
 
 - Clear navigation
 - User-configurable colour theme
-- [i18n support](./guides/i18n)
+- [i18n support](/guides/i18n)
 
 :::
 ```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

Weirdly enough, clicking on the link "i18n support" here, will throw a 404 page. This fixes that (but will lose translation?) changing it to `../../guides/i18n` will also fix it.

![Screenshot 2023-05-23 at 18 03 25](https://github.com/withastro/starlight/assets/15145918/0bd46ee4-54d6-461e-9594-f9ba472559e4)
