### PR TITLE
Add required title to complete code snippets

### DIFF
--- a/docs/src/content/docs/de/reference/configuration.md
+++ b/docs/src/content/docs/de/reference/configuration.md
@@ -138,6 +138,7 @@ import starlight from '@astrojs/starlight';
 export default defineConfig({
   integrations: [
     starlight({
+      title: 'My Docs',
       // Englisch als Standardsprache festlegen.
       defaultLocale: 'en',
       locales: {

--- a/docs/src/content/docs/es/reference/configuration.md
+++ b/docs/src/content/docs/es/reference/configuration.md
@@ -138,6 +138,7 @@ import starlight from '@astrojs/starlight';
 export default defineConfig({
   integrations: [
     starlight({
+      title: 'My Docs',
       // Establece el inglés como el idioma predeterminado para este sitio.
       defaultLocale: 'en',
       locales: {

--- a/docs/src/content/docs/guides/i18n.md
+++ b/docs/src/content/docs/guides/i18n.md
@@ -17,6 +17,7 @@ Starlight provides built-in support for multilingual sites, including routing, f
    export default defineConfig({
      integrations: [
        starlight({
+         title: 'My Docs',
          // Set English as the default language for this site.
          defaultLocale: 'en',
          locales: {
@@ -68,6 +69,7 @@ import starlight from '@astrojs/starlight';
 export default defineConfig({
   integrations: [
     starlight({
+      title: 'My Docs',
       locales: {
         root: {
           label: 'English',

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -138,6 +138,7 @@ import starlight from '@astrojs/starlight';
 export default defineConfig({
   integrations: [
     starlight({
+      title: 'My Site',
       // Set English as the default language for this site.
       defaultLocale: 'en',
       locales: {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)

#### Description

- What does this PR change? Adds `title` field to "complete" code snippets.

I've left code snippets that are not complete run-able files, because I'm not sure the intention for these is to be used as a complete configuration, but I'm open to suggestions. If we wanted to emphasise that a snippet isn't "complete" configuration, would we instead use an elipsis `...` notation, or something of the like? Open to ideas if you think this needs to cover more.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
