### PR TITLE
Fix default locale routing bug when not using root locale

### DIFF
--- a/.changeset/kind-experts-explain.md
+++ b/.changeset/kind-experts-explain.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fix default locale routing bug when not using root locale

--- a/packages/starlight/utils/slugs.ts
+++ b/packages/starlight/utils/slugs.ts
@@ -82,6 +82,7 @@ export function localizedSlug(
   const slugLocale = slugToLocale(slug);
   if (slugLocale === locale) return slug;
   locale = locale || '';
+  if (slugLocale === slug) return locale;
   if (slugLocale) {
     return slug
       .replace(slugLocale + '/', locale ? locale + '/' : '')


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- During the bug bash several people hit a bug with i18n routing when not using a root locale. Basically, the `/index.md` for the default locale wasn’t getting its slug localized properly leading to weird things like `/es/` fallback content overwriting `/en/`. This PR fixes that.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
