### PR TITLE
Fix default locale writing direction logic

### DIFF
--- a/.changeset/weak-lobsters-jog.md
+++ b/.changeset/weak-lobsters-jog.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fix bug setting writing direction from a single root locale

--- a/packages/starlight/utils/slugs.ts
+++ b/packages/starlight/utils/slugs.ts
@@ -49,7 +49,7 @@ function localeToDir(locale: string | undefined): 'ltr' | 'rtl' {
   const dir = locale
     ? config.locales?.[locale]?.dir
     : config.locales?.root?.dir;
-  return dir || 'ltr';
+  return dir || config.defaultLocale.dir;
 }
 
 export function slugToParam(slug: string): string | undefined {


### PR DESCRIPTION
Fixes #126

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- Closes #126
- Fixes a bug setting the writing direction (`dir`) when set via the `root` locale in monolingual sites

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
