### PR TITLE
Add Portuguese language support

### DIFF
--- a/.changeset/popular-crews-lie.md
+++ b/.changeset/popular-crews-lie.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Add Portuguese language support

--- a/docs/src/content/docs/guides/i18n.mdx
+++ b/docs/src/content/docs/guides/i18n.mdx
@@ -120,7 +120,7 @@ If a translation is not yet available for a language, Starlight will show reader
 
 Some of Starlight’s default UI requires text labels to work.
 For example, the table of contents on this page has an “On this page” heading in English.
-We aim to ship these labels in as many languages as possible but currently only have support for English, German, Japanese, Spanish, and Portuguese.
+We aim to ship these labels in as many languages as possible. Currently, English, German, Japanese, Portuguese, and Spanish are supported out of the box.
 
 You can provide translations for additional languages you support — or override our default labels — via the `i18n` data collection.
 

--- a/docs/src/content/docs/guides/i18n.mdx
+++ b/docs/src/content/docs/guides/i18n.mdx
@@ -120,7 +120,7 @@ If a translation is not yet available for a language, Starlight will show reader
 
 Some of Starlight’s default UI requires text labels to work.
 For example, the table of contents on this page has an “On this page” heading in English.
-We aim to ship these labels in as many languages as possible but currently only have support for English, German, Japanese, and Spanish.
+We aim to ship these labels in as many languages as possible but currently only have support for English, German, Japanese, Spanish, and Portuguese.
 
 You can provide translations for additional languages you support — or override our default labels — via the `i18n` data collection.
 

--- a/packages/starlight/translations/index.ts
+++ b/packages/starlight/translations/index.ts
@@ -3,9 +3,10 @@ import en from './en.json';
 import es from './es.json';
 import de from './de.json';
 import ja from './ja.json';
+import pt from './pt.json';
 
 const parse = i18nSchema().required().strict().parse;
 
 export default Object.fromEntries(
-  Object.entries({ en, es, de, ja }).map(([key, dict]) => [key, parse(dict)])
+  Object.entries({ en, es, de, ja, pt }).map(([key, dict]) => [key, parse(dict)])
 );

--- a/packages/starlight/translations/pt.json
+++ b/packages/starlight/translations/pt.json
@@ -1,0 +1,20 @@
+{
+  "skipLink.label": "Pular para o conteúdo",
+  "search.label": "Pesquisar",
+  "search.shortcutLabel": "(Pressione / para Pesquisar)",
+  "search.cancelLabel": "Cancelar",
+  "themeSelect.accessibleLabel": "Selecionar tema",
+  "themeSelect.dark": "Escuro",
+  "themeSelect.light": "Claro",
+  "themeSelect.auto": "Auto",
+  "languageSelect.accessibleLabel": "Selecionar língua",
+  "menuButton.accessibleLabel": "Menu",
+  "sidebarNav.accessibleLabel": "Principal",
+  "tableOfContents.onThisPage": "Nesta página",
+  "tableOfContents.overview": "Visão geral",
+  "i18n.untranslatedContent": "Este conteúdo não está disponível em sua língua ainda.",
+  "page.editLink": "Editar página",
+  "page.lastUpdated": "Última atualização:",
+  "page.previousLink": "Anterior",
+  "page.nextLink": "Próximo"
+}


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content
- Changes to Starlight code

#### Description

Added Portuguese UI labels to Starlight and updated the i18n page in docs to account for the change.
