### PR TITLE
config reference intro and example

### DIFF
--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -5,6 +5,22 @@ description: An overview of all the configuration options Starlight supports.
 
 ## Configure the `starlight` integration
 
+Starlight is an [Astro integration](https://docs.astro.build/en/guides/integrations-guide/), configured in `astro.config.mjs`.
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import starlight from '@astrojs/starlight';
+
+export default defineConfig({
+  integrations: [
+    starlight({
+      title: "My delightful docs site",
+    }),
+  ],
+});
+```
+
 You can pass the following options to the `starlight` integration.
 
 ### `title` (required)

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -5,7 +5,7 @@ description: An overview of all the configuration options Starlight supports.
 
 ## Configure the `starlight` integration
 
-Starlight is an [Astro integration](https://docs.astro.build/en/guides/integrations-guide/), configured in `astro.config.mjs`.
+Starlight is an integration built on top the [Astro](https://astro.build) web framework. You can configure your project inside the Astro `astro.config.mjs` configuration file:
 
 ```js
 // astro.config.mjs


### PR DESCRIPTION
Adds a short intro explaining that Starlight is an Astro integration, plus generic example for configuring it at the top of the page.
![deli](https://github.com/withastro/starlight/assets/5098874/fc94cb02-d9d5-4d4b-91de-87dea8f156cb)
