### PR TITLE
Add query param to OG image because Twitter is bad

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -31,11 +31,11 @@ export default defineConfig({
         },
         {
           tag: 'meta',
-          attrs: { property: 'og:image', content: site + 'og.jpg' },
+          attrs: { property: 'og:image', content: site + 'og.jpg?v=1' },
         },
         {
           tag: 'meta',
-          attrs: { property: 'twitter:image', content: site + 'og.jpg' },
+          attrs: { property: 'twitter:image', content: site + 'og.jpg?v=1' },
         },
       ],
       customCss: process.env.NO_GRADIENTS ? [] : ['/src/assets/landing.css'],


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Something else!

#### Description

- Adds `?v=1` to the end of open-graph image metadata to try to kickstart Twitter.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
