### PR TITLE
Add base to Pagefind bundlePath

### DIFF
--- a/.changeset/violet-bags-carry.md
+++ b/.changeset/violet-bags-carry.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Add `bundlePath` option to Pagefind configuration

--- a/packages/starlight/components/Search.astro
+++ b/packages/starlight/components/Search.astro
@@ -108,6 +108,7 @@ const t = useTranslations(Astro.props.locale);
       new PagefindUI({
         element: '#starlight__search',
         baseUrl: import.meta.env.BASE_URL,
+        bundlePath: import.meta.env.BASE_URL.replace(/\/$/, '') + '/_pagefind/',
         showImages: false,
       });
     });


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

Currently if a `base` option has been set the search modal throws errors that it can't find `/_pagefind/pagefind.js`

![image](https://github.com/withastro/starlight/assets/19967622/1cb00721-36fb-43cf-b8b2-b00dfb94379a)
(Base option: `/testing`)

This PR adds a [`bundlePath`](https://pagefind.app/docs/search-config/#bundle-path) to the Pagefind config that includes the `base` option from Astro to fix this issue.
<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
