### PR TITLE
Split `withBase` to support both paths and files

### DIFF
--- a/packages/starlight/404.astro
+++ b/packages/starlight/404.astro
@@ -1,6 +1,6 @@
 ---
 import config from 'virtual:starlight/user-config';
-import { withBase } from './utils/base';
+import { pathWithBase } from './utils/base';
 
 // Built-in CSS styles.
 import './style/props.css';
@@ -40,7 +40,7 @@ const { lang = 'en', dir = 'ltr', locale } = config.defaultLocale || {};
           <p>Houston, we have a problem.</p>
           <p>
             We couldn’t find that link. Check the address or
-            <a href={withBase('/')}>head back home</a>.
+            <a href={pathWithBase('/')}>head back home</a>.
           </p>
         </MarkdownContent>
       </main>

--- a/packages/starlight/components/HeadSEO.astro
+++ b/packages/starlight/components/HeadSEO.astro
@@ -4,7 +4,7 @@ import config from 'virtual:starlight/user-config';
 import type { HeadConfigSchema } from '../schemas/head';
 import { createHead } from '../utils/head';
 import { localizedUrl } from '../utils/localizedUrl';
-import { withBase } from '../utils/base';
+import { fileWithBase } from '../utils/base';
 
 interface Props {
   data: CollectionEntry<'docs'>['data'];
@@ -33,7 +33,7 @@ const headDefaults: z.input<ReturnType<typeof HeadConfigSchema>> = [
     tag: 'link',
     attrs: {
       rel: 'shortcut icon',
-      href: withBase('/favicon.svg'),
+      href: fileWithBase('/favicon.svg'),
       type: 'image/svg+xml',
     },
   },
@@ -81,7 +81,7 @@ if (Astro.site) {
     tag: 'link',
     attrs: {
       rel: 'sitemap',
-      href: withBase('/sitemap-index.xml'),
+      href: fileWithBase('/sitemap-index.xml'),
     },
   });
 }

--- a/packages/starlight/components/SiteTitle.astro
+++ b/packages/starlight/components/SiteTitle.astro
@@ -1,7 +1,7 @@
 ---
 import { logos } from 'virtual:starlight/user-images';
 import config from 'virtual:starlight/user-config';
-import { withBase } from '../utils/base';
+import { pathWithBase } from '../utils/base';
 
 interface Props {
   locale: string | undefined;
@@ -23,7 +23,7 @@ if (config.logo) {
   if (err) throw new Error(err);
 }
 
-const href = withBase(Astro.props.locale || '/');
+const href = pathWithBase(Astro.props.locale || '/');
 ---
 
 <a {href} class="site-title flex">

--- a/packages/starlight/utils/base.ts
+++ b/packages/starlight/utils/base.ts
@@ -1,9 +1,15 @@
 const base = stripTrailingSlash(import.meta.env.BASE_URL);
 
 /** Get the a root-relative URL path with the site’s `base` prefixed. */
-export function withBase(path: string) {
+export function pathWithBase(path: string) {
   path = stripLeadingSlash(stripTrailingSlash(path));
   return path ? base + '/' + path + '/' : base + '/';
+}
+
+/** Get the a root-relative file URL path with the site’s `base` prefixed. */
+export function fileWithBase(path: string) {
+  path = stripLeadingSlash(stripTrailingSlash(path));
+  return path ? base + '/' + path : base;
 }
 
 function stripLeadingSlash(path: string) {

--- a/packages/starlight/utils/navigation.ts
+++ b/packages/starlight/utils/navigation.ts
@@ -1,6 +1,6 @@
 import { basename, dirname } from 'node:path';
 import config from 'virtual:starlight/user-config';
-import { withBase } from './base';
+import { pathWithBase } from './base';
 import { pickLang } from './i18n';
 import { Route, getLocaleRoutes, routes } from './routing';
 import { localeToLang, slugToPathname } from './slugs';
@@ -109,7 +109,7 @@ function linkFromConfig(
 
 /** Create a link entry. */
 function makeLink(href: string, label: string, currentPathname: string): Link {
-  if (!isAbsolute(href)) href = withBase(href);
+  if (!isAbsolute(href)) href = pathWithBase(href);
   const isCurrent = href === currentPathname;
   return { type: 'link', label, href, isCurrent };
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)
- Changes to Starlight code

#### Description

- Closes #166
- What does this PR change? Fixes how the base path is prepended to files by omitting the trailing slash.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
