### PR TITLE
Handle table overflow

### DIFF
--- a/packages/starlight/components/MarkdownContent.astro
+++ b/packages/starlight/components/MarkdownContent.astro
@@ -95,6 +95,8 @@
   }
 
   .content :global(table) {
+    display: block;
+    overflow: auto;
     border: 1px solid var(--sl-color-gray-5);
     border-collapse: collapse;
   }

--- a/packages/starlight/components/MarkdownContent.astro
+++ b/packages/starlight/components/MarkdownContent.astro
@@ -96,6 +96,9 @@
 
   .content :global(table) {
     display: block;
+    width: 100%;
+    width: max-content;
+    max-width: 100%;
     overflow: auto;
     border: 1px solid var(--sl-color-gray-5);
     border-collapse: collapse;

--- a/packages/starlight/components/MarkdownContent.astro
+++ b/packages/starlight/components/MarkdownContent.astro
@@ -96,11 +96,7 @@
 
   .content :global(table) {
     display: block;
-    width: 100%;
-    width: max-content;
-    max-width: 100%;
     overflow: auto;
-    border: 1px solid var(--sl-color-gray-5);
     border-collapse: collapse;
   }
   .content :global(tr:nth-child(2n)) {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Style fixes

#### Description

- Closes #176
- What does this PR change? Adds styles to allow table elements to hide their overflow without pushing out the body
- Did you change something visual? A before/after screenshot can be helpful.

Before:

<img width="494" alt="image" src="https://github.com/withastro/starlight/assets/1120896/1319dc03-6d55-400d-a13d-88234a077828">

After:

<img width="493" alt="image" src="https://github.com/withastro/starlight/assets/1120896/3ebea070-6c96-4d32-868f-b0a31e0acb65">


<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
