### PR TITLE
Add support for translating the Pagefind search modal

### DIFF
--- a/.changeset/funny-weeks-cry.md
+++ b/.changeset/funny-weeks-cry.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": minor
+---
+
+Add support for translating the Pagefind search modal

--- a/docs/src/content/docs/guides/i18n.mdx
+++ b/docs/src/content/docs/guides/i18n.mdx
@@ -59,7 +59,7 @@ Starlight provides built-in support for multilingual sites, including routing, f
 
    </FileTree>
 
-3. You can now add content files in your language directories. Use the same file name to associate pages across languages and take advantage of Starlight’s full set of i18n features, including fallback content, translation notices, and more. 
+3. You can now add content files in your language directories. Use the same file name to associate pages across languages and take advantage of Starlight’s full set of i18n features, including fallback content, translation notices, and more.
 
    For example, create `ar/index.md` and `en/index.md` to represent the homepage for Arabic and English respectively.
 
@@ -141,7 +141,7 @@ If a translation is not yet available for a language, Starlight will show reader
 
 ## Translate Starlight's UI
 
-In addition to hosting translated content files, Starlight allows you to translate the default UI strings (e.g. the "On this page" heading in the table of contents) so that your readers can experience your site entirely in the selected language. 
+In addition to hosting translated content files, Starlight allows you to translate the default UI strings (e.g. the "On this page" heading in the table of contents) so that your readers can experience your site entirely in the selected language.
 
 English, French, German, Japanese, Portuguese, and Spanish translated UI strings are provided out of the box, and we welcome [contributions to add more default languages](https://github.com/withastro/starlight/blob/main/CONTRIBUTING.md).
 
@@ -173,9 +173,9 @@ You can provide translations for additional languages you support — or overrid
 
    </FileTree>
 
-3. Add translations for the keys you want to translate to the JSON files. Translate only the values, leaving the keys in English (e.g. `"search.label": "Buscar"`). 
+3. Add translations for the keys you want to translate to the JSON files. Translate only the values, leaving the keys in English (e.g. `"search.label": "Buscar"`).
 
-    These are the English defaults of the existing strings Starlight ships with:
+   These are the English defaults of the existing strings Starlight ships with:
 
    ```json
    {
@@ -197,5 +197,23 @@ You can provide translations for additional languages you support — or overrid
      "page.lastUpdated": "Last updated:",
      "page.previousLink": "Next",
      "page.nextLink": "Previous"
+   }
+   ```
+
+   Starlight’s search modal is powered by the [Pagefind](https://pagefind.app/) library.
+   You can set translations for Pagefind’s UI in the same JSON file using `pagefind` keys:
+
+   ```json
+   {
+     "pagefind.clear_search": "Clear",
+     "pagefind.load_more": "Load more results",
+     "pagefind.search_label": "Search this site",
+     "pagefind.filters_label": "Filters",
+     "pagefind.zero_results": "No results for [SEARCH_TERM]",
+     "pagefind.many_results": "[COUNT] results for [SEARCH_TERM]",
+     "pagefind.one_result": "[COUNT] result for [SEARCH_TERM]",
+     "pagefind.alt_search": "No results for [SEARCH_TERM]. Showing results for [DIFFERENT_TERM] instead",
+     "pagefind.search_suggestion": "No results for [SEARCH_TERM]. Try one of the following searches:",
+     "pagefind.searching": "Searching for [SEARCH_TERM]..."
    }
    ```

--- a/packages/starlight/components/Search.astro
+++ b/packages/starlight/components/Search.astro
@@ -8,9 +8,18 @@ interface Props {
 }
 
 const t = useTranslations(Astro.props.locale);
+const pagefindTranslations = {
+  placeholder: t('search.label'),
+  ...Object.fromEntries(
+    Object.entries(t.pick('pagefind.')).map(([key, value]) => [
+      key.replace('pagefind.', ''),
+      value,
+    ])
+  ),
+};
 ---
 
-<site-search>
+<site-search data-translations={JSON.stringify(pagefindTranslations)}>
   <button data-open-modal disabled>
     {
       /* The span is `aria-hidden` because it is not shown on small screens. Instead, the icon label is used for accessibility purposes. */
@@ -96,23 +105,31 @@ const t = useTranslations(Astro.props.locale);
           e.preventDefault();
         }
       });
+
+      let translations = {};
+      try {
+        translations = JSON.parse(this.dataset.translations || '{}');
+      } catch {}
+
+      window.addEventListener('DOMContentLoaded', () => {
+        if (import.meta.env.DEV) return;
+        const onIdle =
+          window.requestIdleCallback || ((cb) => setTimeout(cb, 1));
+        onIdle(async () => {
+          const { PagefindUI } = await import('@pagefind/default-ui');
+          new PagefindUI({
+            element: '#starlight__search',
+            baseUrl: import.meta.env.BASE_URL,
+            bundlePath:
+              import.meta.env.BASE_URL.replace(/\/$/, '') + '/_pagefind/',
+            showImages: false,
+            translations,
+          });
+        });
+      });
     }
   }
   customElements.define('site-search', SiteSearch);
-
-  window.addEventListener('DOMContentLoaded', () => {
-    if (import.meta.env.DEV) return;
-    const onIdle = window.requestIdleCallback || ((cb) => setTimeout(cb, 1));
-    onIdle(async () => {
-      const { PagefindUI } = await import('@pagefind/default-ui');
-      new PagefindUI({
-        element: '#starlight__search',
-        baseUrl: import.meta.env.BASE_URL,
-        bundlePath: import.meta.env.BASE_URL.replace(/\/$/, '') + '/_pagefind/',
-        showImages: false,
-      });
-    });
-  });
 </script>
 
 <style>

--- a/packages/starlight/schemas/i18n.ts
+++ b/packages/starlight/schemas/i18n.ts
@@ -1,6 +1,14 @@
 import { z } from 'astro/zod';
 
 export function i18nSchema() {
+  return starlightI18nSchema().merge(pagefindI18nSchema());
+}
+
+export function builtinI18nSchema() {
+  return starlightI18nSchema().required().strict().merge(pagefindI18nSchema());
+}
+
+function starlightI18nSchema() {
   return z
     .object({
       'skipLink.label': z
@@ -85,6 +93,72 @@ export function i18nSchema() {
         .string()
         .describe(
           'Label shown on the “next page” pagination arrow in the page footer.'
+        ),
+    })
+    .partial();
+}
+
+function pagefindI18nSchema() {
+  return z
+    .object({
+      'pagefind.clear_search': z
+        .string()
+        .describe(
+          'Pagefind UI translation. English default value: `"Clear"`. See https://pagefind.app/docs/ui/#translations'
+        ),
+
+      'pagefind.load_more': z
+        .string()
+        .describe(
+          'Pagefind UI translation. English default value: `"Load more results"`. See https://pagefind.app/docs/ui/#translations'
+        ),
+
+      'pagefind.search_label': z
+        .string()
+        .describe(
+          'Pagefind UI translation. English default value: `"Search this site"`. See https://pagefind.app/docs/ui/#translations'
+        ),
+
+      'pagefind.filters_label': z
+        .string()
+        .describe(
+          'Pagefind UI translation. English default value: `"Filters"`. See https://pagefind.app/docs/ui/#translations'
+        ),
+
+      'pagefind.zero_results': z
+        .string()
+        .describe(
+          'Pagefind UI translation. English default value: `"No results for [SEARCH_TERM]"`. See https://pagefind.app/docs/ui/#translations'
+        ),
+
+      'pagefind.many_results': z
+        .string()
+        .describe(
+          'Pagefind UI translation. English default value: `"[COUNT] results for [SEARCH_TERM]"`. See https://pagefind.app/docs/ui/#translations'
+        ),
+
+      'pagefind.one_result': z
+        .string()
+        .describe(
+          'Pagefind UI translation. English default value: `"[COUNT] result for [SEARCH_TERM]"`. See https://pagefind.app/docs/ui/#translations'
+        ),
+
+      'pagefind.alt_search': z
+        .string()
+        .describe(
+          'Pagefind UI translation. English default value: `"No results for [SEARCH_TERM]. Showing results for [DIFFERENT_TERM] instead"`. See https://pagefind.app/docs/ui/#translations'
+        ),
+
+      'pagefind.search_suggestion': z
+        .string()
+        .describe(
+          'Pagefind UI translation. English default value: `"No results for [SEARCH_TERM]. Try one of the following searches:"`. See https://pagefind.app/docs/ui/#translations'
+        ),
+
+      'pagefind.searching': z
+        .string()
+        .describe(
+          'Pagefind UI translation. English default value: `"Searching for [SEARCH_TERM]..."`. See https://pagefind.app/docs/ui/#translations'
         ),
     })
     .partial();

--- a/packages/starlight/translations/index.ts
+++ b/packages/starlight/translations/index.ts
@@ -1,4 +1,4 @@
-import { i18nSchema } from '../schemas/i18n';
+import { builtinI18nSchema } from '../schemas/i18n';
 import en from './en.json';
 import es from './es.json';
 import de from './de.json';
@@ -6,8 +6,15 @@ import ja from './ja.json';
 import pt from './pt.json';
 import fr from './fr.json';
 
-const parse = i18nSchema().required().strict().parse;
+const { parse } = builtinI18nSchema();
 
 export default Object.fromEntries(
-  Object.entries({ en, es, de, ja, pt, fr }).map(([key, dict]) => [key, parse(dict)])
+  Object.entries({
+    en,
+    es,
+    de,
+    ja,
+    pt,
+    fr,
+  }).map(([key, dict]) => [key, parse(dict)])
 );

--- a/packages/starlight/utils/translations.ts
+++ b/packages/starlight/utils/translations.ts
@@ -38,7 +38,12 @@ export function useTranslations(locale: string | undefined) {
     builtinTranslations[lang],
     userTranslations[lang]
   );
-  return (key: keyof typeof dictionary) => dictionary[key];
+  const t = <K extends keyof typeof dictionary>(key: K) => dictionary[key];
+  t.pick = (startOfKey: string) =>
+    Object.fromEntries(
+      Object.entries(dictionary).filter(([k]) => k.startsWith(startOfKey))
+    );
+  return t;
 }
 
 /** Build a dictionary by layering preferred translation sources. */


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- Adds Pagefind’s translation keys to the i18n schema and passes them to Pagefind UI if provided — adding support for languages that Pagefind doesn’t provide out of the box.
- Aliases our existing `search.label` string to Pagefind’s `placeholder` string, which fixes the input placeholder not being translated on non-English sites.
- Adds docs on the above to the i18n guide.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
