### PR TITLE
Fix disclosure caret rotation in sidebar sub-groups

### DIFF
--- a/.changeset/chilled-tools-hammer.md
+++ b/.changeset/chilled-tools-hammer.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fix disclosure caret rotation in sidebar sub-groups

--- a/packages/starlight/components/SidebarSublist.astro
+++ b/packages/starlight/components/SidebarSublist.astro
@@ -65,7 +65,7 @@ interface Props {
   :global([dir='rtl']) .caret {
     transform: rotateZ(180deg);
   }
-  [open] .caret {
+  [open] > summary .caret {
     transform: rotateZ(90deg);
   }
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- Fixes #182
- Fixes the CSS responsible for rotating the disclosure caret/arrow on sidebar groups to it works in sub-groups

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
