### PR TITLE
Support setting an SVG as a hero image

### DIFF
--- a/.changeset/silent-feet-think.md
+++ b/.changeset/silent-feet-think.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Support setting an SVG as the hero image file

--- a/packages/starlight/components/Hero.astro
+++ b/packages/starlight/components/Hero.astro
@@ -17,6 +17,7 @@ const {
 
 const imageAttrs = {
   loading: 'eager' as const,
+  decoding: 'async' as const,
   width: 400,
   height: 400,
   alt: image?.alt,

--- a/packages/starlight/components/Hero.astro
+++ b/packages/starlight/components/Hero.astro
@@ -14,18 +14,23 @@ const {
   image,
   actions,
 } = Astro.props.hero;
+
+const imageAttrs = {
+  loading: 'eager' as const,
+  width: 400,
+  height: 400,
+  alt: image?.alt,
+};
 ---
 
 <div class="hero">
   {
     image?.file ? (
-      <Image
-        src={image.file}
-        loading="eager"
-        width={400}
-        height={400}
-        alt={image.alt}
-      />
+      image.file.format === 'svg' ? (
+        <img src={image.file.src} {...imageAttrs} />
+      ) : (
+        <Image src={image.file} {...imageAttrs} />
+      )
     ) : (
       image?.html && <div class="hero-html flex" set:html={image.html} />
     )


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

The hero image is currently blindly passed to Astro’s `<Image />` component which doesn’t support SVGs (because it doesn’t optimise them). @solelychloe noticed this meant it errored when setting an SVG as the hero image (thanks for the report!).

This PR fixes that by switching to a regular `<img>` tag when it detects an SVG.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
