### PR TITLE
pagefind: ignore inner file tree text

### DIFF
--- a/docs/src/components/file-tree.astro
+++ b/docs/src/components/file-tree.astro
@@ -17,7 +17,7 @@ const processedContent = await fileTreeProcessor.process({
 });
 ---
 
-<file-tree set:html={processedContent} />
+<file-tree set:html={processedContent} data-pagefind-ignore="index" />
 
 <style is:global>
   file-tree {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes or translations of Starlight docs site content

#### Description

- Ignore file tree inner text

| Before                                                                                                                          | After                                                                                                                           |
|---------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
| <img width="651" alt="image" src="https://github.com/withastro/starlight/assets/46791833/280c0a52-8621-4bf1-a4a1-730dafdf4c80"> | <img width="650" alt="image" src="https://github.com/withastro/starlight/assets/46791833/1ffbd01f-c864-46b3-8e21-e0790a61d2e4"> |

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
