### PR TITLE
Fix bottom padding for sidebar on larger screens

### DIFF
--- a/.changeset/thirty-emus-check.md
+++ b/.changeset/thirty-emus-check.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fix bottom padding for sidebar on larger screen sizes

--- a/packages/starlight/components/Sidebar.astro
+++ b/packages/starlight/components/Sidebar.astro
@@ -39,7 +39,7 @@ const { sidebar, locale } = Astro.props;
   }
 
   @media (min-width: 50rem) {
-    .sidebar > :global(:nth-last-child(-n+2)) {
+    .sidebar > :global(:nth-last-child(2)) {
       padding-bottom: 1rem;
     }
   }

--- a/packages/starlight/components/Sidebar.astro
+++ b/packages/starlight/components/Sidebar.astro
@@ -37,4 +37,10 @@ const { sidebar, locale } = Astro.props;
     border-top: 1px solid var(--sl-color-gray-6);
     padding: 0.5rem 0;
   }
+
+  @media (min-width: 50rem) {
+    .sidebar > :global(:nth-last-child(-n+2)) {
+      padding-bottom: 1rem;
+    }
+  }
 </style>

--- a/packages/starlight/components/Sidebar.astro
+++ b/packages/starlight/components/Sidebar.astro
@@ -28,10 +28,6 @@ const { sidebar, locale } = Astro.props;
     gap: 1rem;
   }
 
-  .sidebar > :global(:last-child) {
-    padding-bottom: 1rem;
-  }
-
   .mobile-preferences {
     justify-content: space-between;
     border-top: 1px solid var(--sl-color-gray-6);


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

This PR https://github.com/withastro/starlight/pull/168 added `padding-bottom` to the `:last-child` in the sidebar, but the last child is the `mobile-preferences` element which is hidden on larger screen sizes making the padding only work in the mobile view.

This PR adds a `padding-bottom` to the second to last element on larger screen sizes so that the padding works for both mobile and non-mobile views.

**Before**:

![image](https://github.com/withastro/starlight/assets/19967622/88982ba1-c14d-48c0-8ea7-682ef8b9bd88)


**After**: 

![image](https://github.com/withastro/starlight/assets/19967622/15b7c6da-4bbd-4aea-b690-f77dc2d24f13)


<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
