### PR TITLE
Automatically bump example deps versions on release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,5 +9,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["starlight-docs"]
+  "ignore": ["starlight-docs", "@example/*"]
 }

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+prefer-workspace-packages=true
+link-workspace-packages=true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,15 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2
 
+  examples/basics:
+    dependencies:
+      '@astrojs/starlight':
+        specifier: ^0.1.0
+        version: link:../../packages/starlight
+      astro:
+        specifier: ^2.5.0
+        version: 2.5.0(@types/node@18.15.11)
+
   packages/starlight:
     dependencies:
       '@astrojs/mdx':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'packages/**/*'
+  - 'examples/**/*'
   - 'docs'


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- Make `examples/*` part of pnpm workspace
- Automatically bump example deps versions

This is super strange, but it turns out changesets would auto bump the example deps by itself? I tested it with `pnpm changeset version` locally. I think something must be up in the Astro core repo that's preventing this.

But anyways this PR should be good to go.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
