### PR TITLE
Install dependencies after `changeset version` runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Create Release Pull Request
         uses: changesets/action@v1
         with:
+          version: pnpm changeset version && pnpm i
           publish: pnpm changeset publish
           commit: '[ci] release'
           title: '[ci] release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Create Release Pull Request
         uses: changesets/action@v1
         with:
-          version: pnpm changeset version && pnpm i
+          version: pnpm changeset version && pnpm i --no-frozen-lockfile
           publish: pnpm changeset publish
           commit: '[ci] release'
           title: '[ci] release'


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Something else!

#### Description

#195 made Changesets automatically bump example versions as part of release PRs, but looks like builds fail in the release PR now (e.g. #194) because the lockfile is out of date (Changesets bumped `package.json` in examples but _not_ the lock file).

This PR runs `pnpm i` after `changeset version` in the GitHub action, which I think should fix this?

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
