### PR TITLE
Fix RegExp in i18n status tracker

### DIFF
--- a/docs-i18n-tracker/lib/translation-status/builder.ts
+++ b/docs-i18n-tracker/lib/translation-status/builder.ts
@@ -259,7 +259,7 @@ export class TranslationStatusBuilder {
     subpath: string;
     query?: string;
   }) {
-    const noDotSrcDir = this.pageSourceDir.replace(/^.+\//, '');
+    const noDotSrcDir = this.pageSourceDir.replace(/^\.+\//, '');
     const isSrcLang = lang === this.sourceLanguage;
     return `https://github.com/${
       this.githubRepo


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Something else!

#### Description

- `.+` and `\.+` are not the same thing in Regular Expression Land 😅 
- This fixes URLs in the i18n tracker. Hopefully for real this time 🤞 

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
