### PR TITLE
[WIP] Respect Astro `build.format` when building URLs

### DIFF
--- a/packages/starlight/index.ts
+++ b/packages/starlight/index.ts
@@ -85,13 +85,11 @@ function resolveVirtualModuleId(id: string) {
 /** Expose the Starlight user config object via a virtual module. */
 function vitePluginStarlightUserConfig(
   opts: StarlightConfig,
-  { root }: AstroConfig
+  astroConfig: AstroConfig
 ): NonNullable<ViteUserConfig['plugins']>[number] {
   const modules = {
     'virtual:starlight/user-config': `export default ${JSON.stringify(opts)}`,
-    'virtual:starlight/project-context': `export default ${JSON.stringify({
-      root,
-    })}`,
+    'virtual:starlight/project-context': `export default ${JSON.stringify(astroConfig)}`,
     'virtual:starlight/user-css': opts.customCss
       .map((id) => `import "${id}";`)
       .join(''),

--- a/packages/starlight/utils/base.ts
+++ b/packages/starlight/utils/base.ts
@@ -1,9 +1,12 @@
+import { ensureLeadingAndTrailingSlashes } from "./url";
+
 const base = stripTrailingSlash(import.meta.env.BASE_URL);
 
 /** Get the a root-relative URL path with the site’s `base` prefixed. */
 export function pathWithBase(path: string) {
   path = stripLeadingSlash(stripTrailingSlash(path));
-  return path ? base + '/' + path + '/' : base + '/';
+  path = path ? base + '/' + path : base;
+  return ensureLeadingAndTrailingSlashes(path)
 }
 
 /** Get the a root-relative file URL path with the site’s `base` prefixed. */

--- a/packages/starlight/utils/navigation.ts
+++ b/packages/starlight/utils/navigation.ts
@@ -9,6 +9,7 @@ import type {
   SidebarItem,
   SidebarLinkItem,
 } from './user-config';
+import { ensureLeadingAndTrailingSlashes } from './url';
 
 export interface Link {
   type: 'link';
@@ -84,13 +85,6 @@ function groupFromAutogenerateConfig(
 /** Check if a string starts with one of `http://` or `https://`. */
 const isAbsolute = (link: string) => /^https?:\/\//.test(link);
 
-/** Ensure the passed path starts and ends with trailing slashes. */
-function ensureLeadingAndTrailingSlashes(href: string): string {
-  if (href[0] !== '/') href = '/' + href;
-  if (href[href.length - 1] !== '/') href += '/';
-  return href;
-}
-
 /** Create a link entry from a user config object. */
 function linkFromConfig(
   item: SidebarLinkItem,
@@ -99,8 +93,6 @@ function linkFromConfig(
 ) {
   let href = item.link;
   if (!isAbsolute(href)) {
-    href = ensureLeadingAndTrailingSlashes(href);
-    // Inject current locale into link.
     if (locale) href = '/' + locale + href;
   }
   const label = pickLang(item.translations, localeToLang(locale)) || item.label;
@@ -109,6 +101,7 @@ function linkFromConfig(
 
 /** Create a link entry. */
 function makeLink(href: string, label: string, currentPathname: string): Link {
+  href = ensureLeadingAndTrailingSlashes(href)
   if (!isAbsolute(href)) href = pathWithBase(href);
   const isCurrent = href === currentPathname;
   return { type: 'link', label, href, isCurrent };

--- a/packages/starlight/utils/url.ts
+++ b/packages/starlight/utils/url.ts
@@ -1,0 +1,19 @@
+import astroConfig from 'virtual:starlight/project-context';
+
+/**
+ * Ensure the passed path starts and ends with trailing slashes unless
+ * configured otherwise in the Astro config.
+ */
+export function ensureLeadingAndTrailingSlashes(href: string): string {
+  if (href[0] !== '/') href = '/' + href;
+
+  if (href === '/') return href
+
+  if (astroConfig.build.format === 'file') {
+    if (href[href.length - 1] === '/') href = href.slice(0, -1);
+    return href
+  }
+
+  if (href[href.length - 1] !== '/') href += '/';
+  return href;
+}

--- a/packages/starlight/virtual.d.ts
+++ b/packages/starlight/virtual.d.ts
@@ -3,7 +3,8 @@ declare module 'virtual:starlight/user-config' {
   export default Config;
 }
 declare module 'virtual:starlight/project-context' {
-  export default { root: string };
+  const Config: import('astro').AstroConfig;
+  export default Config;
 }
 
 declare module 'virtual:starlight/user-css' {}


### PR DESCRIPTION
🚧 WIP for #180 

This commit makes Starlight respect Astro's `build.format` when building URLs.

This is considered WIP because there is still more work to do with the routes; we should be seeing `https://localhost:3000/` without the trailing slash, but it's still there.