### PR TITLE
Use `_top` instead of `starlight__overview` as page title ID

### DIFF
--- a/.changeset/mighty-wolves-jog.md
+++ b/.changeset/mighty-wolves-jog.md
@@ -2,6 +2,6 @@
 '@astrojs/starlight': minor
 ---
 
-Change page title ID to `top` for cleaner hash URLs
+Change page title ID to `_top` for cleaner hash URLs
 
-⚠️ Potentially breaking change if you were linking manually to `#starlight__overview` anywhere. If you were, update these links to use `#top` instead.
+⚠️ Potentially breaking change if you were linking manually to `#starlight__overview` anywhere. If you were, update these links to use `#_top` instead.

--- a/.changeset/mighty-wolves-jog.md
+++ b/.changeset/mighty-wolves-jog.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/starlight': minor
+---
+
+Change page title ID to `top` for cleaner hash URLs
+
+⚠️ Potentially breaking change if you were linking manually to `#starlight__overview` anywhere. If you were, update these links to use `#top` instead.

--- a/packages/starlight/404.astro
+++ b/packages/starlight/404.astro
@@ -36,7 +36,7 @@ const { lang = 'en', dir = 'ltr', locale } = config.defaultLocale || {};
       <Header slot="header" {locale} />
       <main>
         <MarkdownContent>
-          <h1 id="top" data-page-title>404</h1>
+          <h1 id="_top" data-page-title>404</h1>
           <p>Houston, we have a problem.</p>
           <p>
             We couldn’t find that link. Check the address or

--- a/packages/starlight/404.astro
+++ b/packages/starlight/404.astro
@@ -36,7 +36,7 @@ const { lang = 'en', dir = 'ltr', locale } = config.defaultLocale || {};
       <Header slot="header" {locale} />
       <main>
         <MarkdownContent>
-          <h1 id="starlight__overview">404</h1>
+          <h1 id="top" data-page-title>404</h1>
           <p>Houston, we have a problem.</p>
           <p>
             We couldn’t find that link. Check the address or

--- a/packages/starlight/components/Hero.astro
+++ b/packages/starlight/components/Hero.astro
@@ -38,7 +38,7 @@ const imageAttrs = {
   }
   <div class="flex stack">
     <div class="flex copy">
-      <h1 id="starlight__overview" set:html={title} />
+      <h1 id="top" data-page-title set:html={title} />
       {tagline && <div class="tagline" set:html={tagline} />}
     </div>
     {

--- a/packages/starlight/components/Hero.astro
+++ b/packages/starlight/components/Hero.astro
@@ -38,7 +38,7 @@ const imageAttrs = {
   }
   <div class="flex stack">
     <div class="flex copy">
-      <h1 id="top" data-page-title set:html={title} />
+      <h1 id="_top" data-page-title set:html={title} />
       {tagline && <div class="tagline" set:html={tagline} />}
     </div>
     {

--- a/packages/starlight/components/SkipLink.astro
+++ b/packages/starlight/components/SkipLink.astro
@@ -8,7 +8,7 @@ interface Props {
 const t = useTranslations(Astro.props.locale);
 ---
 
-<a href="#top">{t('skipLink.label')}</a>
+<a href="#_top">{t('skipLink.label')}</a>
 
 <style>
   a {

--- a/packages/starlight/components/SkipLink.astro
+++ b/packages/starlight/components/SkipLink.astro
@@ -8,7 +8,7 @@ interface Props {
 const t = useTranslations(Astro.props.locale);
 ---
 
-<a href="#starlight__overview">{t('skipLink.label')}</a>
+<a href="#top">{t('skipLink.label')}</a>
 
 <style>
   a {

--- a/packages/starlight/components/TableOfContents/generateToC.ts
+++ b/packages/starlight/components/TableOfContents/generateToC.ts
@@ -25,7 +25,7 @@ export function generateToC(
   headings: MarkdownHeading[],
   { minHeadingLevel, maxHeadingLevel, title = 'Overview' }: TocOpts
 ) {
-  const overview = { depth: 2, slug: 'starlight__overview', text: title };
+  const overview = { depth: 2, slug: 'top', text: title };
   headings = [
     overview,
     ...headings.filter(

--- a/packages/starlight/components/TableOfContents/generateToC.ts
+++ b/packages/starlight/components/TableOfContents/generateToC.ts
@@ -25,7 +25,7 @@ export function generateToC(
   headings: MarkdownHeading[],
   { minHeadingLevel, maxHeadingLevel, title = 'Overview' }: TocOpts
 ) {
-  const overview = { depth: 2, slug: 'top', text: title };
+  const overview = { depth: 2, slug: '_top', text: title };
   headings = [
     overview,
     ...headings.filter(

--- a/packages/starlight/components/TableOfContents/starlight-toc.ts
+++ b/packages/starlight/components/TableOfContents/starlight-toc.ts
@@ -22,7 +22,7 @@ export class StarlightTOC extends HTMLElement {
     const isHeading = (el: Element): el is HTMLHeadingElement => {
       if (el instanceof HTMLHeadingElement) {
         // Special case for page title h1
-        if (el.id === 'starlight__overview') return true;
+        if ('pageTitle' in el.dataset) return true;
         // Check the heading level is within the user-configured limits for the ToC
         const level = el.tagName[1];
         if (level) {

--- a/packages/starlight/index.astro
+++ b/packages/starlight/index.astro
@@ -102,7 +102,7 @@ const hasHero = Boolean(entry.data.hero);
           ) : (
             <ContentPanel>
               <h1
-                id="top"
+                id="_top"
                 data-page-title
                 style="font-size: var(--sl-text-h1); line-height: var(--sl-line-height-headings); font-weight: 600; color: var(--sl-color-white); margin-top: 1rem;"
               >

--- a/packages/starlight/index.astro
+++ b/packages/starlight/index.astro
@@ -102,7 +102,8 @@ const hasHero = Boolean(entry.data.hero);
           ) : (
             <ContentPanel>
               <h1
-                id="starlight__overview"
+                id="top"
+                data-page-title
                 style="font-size: var(--sl-text-h1); line-height: var(--sl-line-height-headings); font-weight: 600; color: var(--sl-color-white); margin-top: 1rem;"
               >
                 {entry.data.title}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

Updates the ID used on the page title to be `_top` instead of `starlight__overview`.

Got some feedback from @joshpollara that it’s a bit ugly for the URL to have `#starlight__overview` in when clicking back to the overview, which makes sense. Another option would be to make this customisable, but given it touches a few different spots, a more minimal ID seems a good quick compromise for now.

(For context, the original idea behind `starlight__overview` was to avoid conflicts with actual page headings. Using `_top` with an underscore here should hopefully achieve the same.)

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
