### PR TITLE
Encode heading id when finding current link

### DIFF
--- a/.changeset/orange-moose-impress.md
+++ b/.changeset/orange-moose-impress.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Encode heading id when finding current link

--- a/packages/starlight/components/TableOfContents/starlight-toc.ts
+++ b/packages/starlight/components/TableOfContents/starlight-toc.ts
@@ -60,7 +60,7 @@ export class StarlightTOC extends HTMLElement {
         if (!isIntersecting) continue;
         const heading = getElementHeading(target);
         if (!heading) continue;
-        const link = links.find((link) => link.hash === '#' + heading.id);
+        const link = links.find((link) => link.hash === '#' + encodeURIComponent(heading.id));
         if (link) {
           this.current = link;
           break;


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- Currently, highlighting in the right sidebar is partially not working for non-English languages (e.g. https://starlight.astro.build/es/getting-started/#agregar-p%C3%A1ginas, https://starlight.astro.build/ja/environmental-impact/#%E7%94%BB%E5%83%8F). This change will make the highlighting work properly.
  - The reason why the highlighting is not working correctly is that the `link.hash` in `starlight-toc.ts` is URL encoded, whereas the `heading.id` is not. As a result, the comparison between the two strings is not accurate sometimes. To address this issue, we can use the `encodeURIComponent` function on `heading.id` before performing the comparison. This ensures that both strings are encoded in the same way, allowing for proper comparison and accurate highlighting.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
