### PR TITLE
Fix labeler action config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,8 +4,8 @@
 - .github/workflows/**
 
 i18n:
-  - src/content/docs/de/**/*
-  - src/content/docs/es/**/*
-  - src/content/docs/fr/**/*
-  - src/content/docs/it/**/*
-  - src/content/docs/ja/**/*
+  - docs/src/content/docs/de/**/*
+  - docs/src/content/docs/es/**/*
+  - docs/src/content/docs/fr/**/*
+  - docs/src/content/docs/it/**/*
+  - docs/src/content/docs/ja/**/*


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Something else!

#### Description

- What does this PR change? Fixes the action configured paths to allow it to label things with `i18n`

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
