### PR TITLE
Stop function parameters mutation which may cause unexpected results

### DIFF
--- a/packages/starlight/utils/base.ts
+++ b/packages/starlight/utils/base.ts
@@ -2,14 +2,14 @@ const base = stripTrailingSlash(import.meta.env.BASE_URL);
 
 /** Get the a root-relative URL path with the site’s `base` prefixed. */
 export function pathWithBase(path: string) {
-  path = stripLeadingSlash(stripTrailingSlash(path));
-  return path ? base + '/' + path + '/' : base + '/';
+  let _path = stripLeadingSlash(stripTrailingSlash(path));
+  return _path ? base + '/' + _path + '/' : base + '/';
 }
 
 /** Get the a root-relative file URL path with the site’s `base` prefixed. */
 export function fileWithBase(path: string) {
-  path = stripLeadingSlash(stripTrailingSlash(path));
-  return path ? base + '/' + path : base;
+  let _path = stripLeadingSlash(stripTrailingSlash(path));
+  return _path ? base + '/' + _path : base;
 }
 
 function stripLeadingSlash(path: string) {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

- Changes to Starlight code

#### Description

- What does this PR change?
Prevent direct mutation of both `pathWithBase` and `fileWithBase` parameters, which may unexpected changes in passed variables to both functions.