### PR TITLE
i18n(ja): Add Japanese translation for `search.devWarning`

### DIFF
--- a/.changeset/shy-bats-yell.md
+++ b/.changeset/shy-bats-yell.md
@@ -1,0 +1,6 @@
+---
+"@astrojs/starlight": patch
+"starlight-docs": patch
+---
+
+Add Japanese translation for `search.devWarning`

--- a/.changeset/shy-bats-yell.md
+++ b/.changeset/shy-bats-yell.md
@@ -1,6 +1,5 @@
 ---
 "@astrojs/starlight": patch
-"starlight-docs": patch
 ---
 
 Add Japanese translation for `search.devWarning`

--- a/docs/src/content/docs/ja/guides/i18n.mdx
+++ b/docs/src/content/docs/ja/guides/i18n.mdx
@@ -180,6 +180,7 @@ Starlightでは、読者が選択した言語でサイト全体を体験でき�
      "search.label": "Search",
      "search.shortcutLabel": "(Press / to Search)",
      "search.cancelLabel": "Cancel",
+     "search.devWarning": "Search is only available in production builds. \nTry building and previewing the site to test it out locally.",
      "themeSelect.accessibleLabel": "Select theme",
      "themeSelect.dark": "Dark",
      "themeSelect.light": "Light",

--- a/packages/starlight/translations/ja.json
+++ b/packages/starlight/translations/ja.json
@@ -3,7 +3,7 @@
   "search.label": "検索",
   "search.shortcutLabel": "（/を押して検索）",
   "search.cancelLabel": "キャンセル",
-  "search.devWarning": "Search is only available in production builds. \nTry building and previewing the site to test it out locally.",
+  "search.devWarning": "検索はプロダクションビルドでのみ利用可能です。\nローカルでテストするには、サイトをビルドしてプレビューしてください。",
   "themeSelect.accessibleLabel": "テーマの選択",
   "themeSelect.dark": "ダーク",
   "themeSelect.light": "ライト",


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes or translations of Starlight docs site content
- Changes to Starlight code

#### Description

- Add Japanese translation for `search.devWarning` based on https://github.com/withastro/starlight/pull/227.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
