### PR TITLE
Use file-system path in auto-generated sidebar item configuration

### DIFF
--- a/.changeset/five-cooks-develop.md
+++ b/.changeset/five-cooks-develop.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": minor
+---
+
+Use path instead of slugified path for auto-generated sidebar item configuration

--- a/.changeset/five-cooks-develop.md
+++ b/.changeset/five-cooks-develop.md
@@ -3,3 +3,12 @@
 ---
 
 Use path instead of slugified path for auto-generated sidebar item configuration
+
+⚠️ Potentially breaking change. If your docs directory names don’t match their URLs, for example they contain whitespace like `docs/my docs/`, and you were referencing these in an `autogenerate` sidebar group as `my-docs`, update your config to reference these with the directory name instead of the slugified version:
+
+```diff
+autogenerate: {
+- directory: 'my-docs',
++ directory: 'my docs',
+}
+```

--- a/packages/starlight/utils/navigation.ts
+++ b/packages/starlight/utils/navigation.ts
@@ -69,7 +69,7 @@ function groupFromAutogenerateConfig(
   const dirDocs = routes.filter(
     (doc) =>
       // Match against `foo.md` or `foo/index.md`.
-      stripSupportedExtension(doc.entry.id) === localeDir ||
+      stripExtension(doc.entry.id) === localeDir ||
       // Match against `foo/anything/else.md`.
       doc.entry.id.startsWith(localeDir + '/')
   );
@@ -117,7 +117,7 @@ function makeLink(href: string, label: string, currentPathname: string): Link {
 /** Get the segments leading to a page. */
 function getBreadcrumbs(path: string, baseDir: string): string[] {
   // Strip extension from path.
-  const pathWithoutExt = stripSupportedExtension(path);
+  const pathWithoutExt = stripExtension(path);
   // Index paths will match `baseDir` and don’t include breadcrumbs.
   if (pathWithoutExt === baseDir) return [];
   // Ensure base directory ends in a trailing slash.
@@ -239,5 +239,5 @@ export function getPrevNextLinks(sidebar: SidebarEntry[]): {
   return { prev, next };
 }
 
-/** Remove an extension supported by Starlight from a path. */
-const stripSupportedExtension = (path: string) => path.replace(/\.mdx?$/, '');
+/** Remove the extension from a path. */
+const stripExtension = (path: string) => path.replace(/\.\w+$/, '');


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to Starlight code

#### Description

This pull request fixes an issue that I reported [on Discord](https://discord.com/channels/830184174198718474/1120359166574338058/1120359226372526100) regarding auto-generated sidebar items. The `directory` configuration property is currently expecting the slugified version of the path and not the actual path on disk.

For example, for a `test test` directory on disk, one would need to use `test-test` in the Astro configuration to auto-generate the sidebar items for this directory.

This PR changes this behavior to use the actual directory name on disk by using the [Astro Content Collection `id`](https://docs.astro.build/en/reference/api-reference/#id) which is the relative nested path which includes the file extension as we are using a collection defined as `type: 'content'`.

I did not find any tests so I tested the following scenarios manually. Let me know if you think I should add tests for this.

With the default locale:

1. Rename `docs/src/content/docs/reference` to `docs/src/content/docs/reference reference`.
1. Update the reference sidebar item group in `docs/astro.config.mjs` to auto-generate from the directory `reference reference`.
1. Navigate to `http://localhost:3000/getting-started/` and ensure the expected pages are listed in the sidebar with proper links.

---

1. Rename `docs/src/content/docs/reference` to `docs/src/content/docs/reference reference`.
1. Update the reference sidebar item group in `docs/astro.config.mjs` to auto-generate from the directory `reference reference`.
1. Add a new file `docs/src/content/docs/reference reference/index.md`.
1. Navigate to `http://localhost:3000/getting-started/` and ensure the expected pages are listed in the sidebar with proper links.

---

1. Rename `docs/src/content/docs/reference` to `docs/src/content/docs/reference reference`.
1. Update the reference sidebar item group in `docs/astro.config.mjs` to auto-generate from the directory `reference reference`.
1. Add a new file `docs/src/content/docs/reference reference.md`.
1. Navigate to `http://localhost:3000/getting-started/` and ensure the expected pages are listed in the sidebar with proper links.

With the `fr` locale:

1. Rename `docs/src/content/docs/fr/reference` to `docs/src/content/docs/fr/reference reference`.
1. Update the reference sidebar item group in `docs/astro.config.mjs` to auto-generate from the directory `reference reference`.
1. Navigate to `http://localhost:3000/fr/getting-started/` and ensure the expected pages are listed in the sidebar with proper links.

---

1. Rename `docs/src/content/docs/fr/reference` to `docs/src/content/docs/fr/reference reference`.
1. Update the reference sidebar item group in `docs/astro.config.mjs` to auto-generate from the directory `reference reference`.
1. Add a new file `docs/src/content/docs/fr/reference reference/index.md`.
1. Navigate to `http://localhost:3000/fr/getting-started/` and ensure the expected pages are listed in the sidebar with proper links.

---

1. Rename `docs/src/content/docs/fr/reference` to `docs/src/content/docs/fr/reference reference`.
1. Update the reference sidebar item group in `docs/astro.config.mjs` to auto-generate from the directory `reference reference`.
1. Add a new file `docs/src/content/docs/fr/reference reference.md`.
1. Navigate to `http://localhost:3000/fr/getting-started/` and ensure the expected pages are listed in the sidebar with proper links.

I also tested including a `nested nested` directory in both the `docs/src/content/docs/reference reference` and `docs/src/content/docs/fr/reference reference` directories and the sidebar items were generated as expected.

Regarding versionning, I guess this is a breaking change if some people were relying on the current behavior and explicitely used the slugified version of the path. Altho, as semver [states](https://semver.org/#spec-item-4) that major version zero is for initial development and that anything may change at any time, I decided to mark this change as a minor version bump. Please let me know if you think this should not be the case.
