### PR TITLE
feat: Added `isOpen` option to ManualSideBarGroup

### DIFF
--- a/packages/starlight/components/SidebarSublist.astro
+++ b/packages/starlight/components/SidebarSublist.astro
@@ -1,5 +1,5 @@
 ---
-import type { SidebarEntry } from '../utils/navigation';
+import type { SidebarEntry, Link } from '../utils/navigation';
 import Icon from './Icon.astro';
 
 interface Props {
@@ -10,7 +10,7 @@ interface Props {
 
 <ul class:list={{ 'top-level': !Astro.props.nested }}>
   {
-    Astro.props.sublist.map((entry) => (
+    Astro.props.sublist.map((entry : SidebarEntry) => (
       <li>
         {entry.type === 'link' ? (
           <a
@@ -21,7 +21,7 @@ interface Props {
             {entry.label}
           </a>
         ) : (
-          <details open>
+          <details open={entry.entries.filter((e): e is Link => e.type === 'link').some(e => e.isCurrent) || entry.isOpen}>
             <summary>
               <h2 class="large">{entry.label}</h2>
               <Icon name="right-caret" class="caret" size="1.25rem" />

--- a/packages/starlight/utils/navigation.ts
+++ b/packages/starlight/utils/navigation.ts
@@ -20,6 +20,7 @@ export interface Link {
 interface Group {
   type: 'group';
   label: string;
+  isOpen: boolean;
   entries: (Link | Group)[];
 }
 
@@ -50,6 +51,7 @@ function configItemToEntry(
     return {
       type: 'group',
       label: pickLang(item.translations, localeToLang(locale)) || item.label,
+      isOpen: item.isOpen,
       entries: item.items.map((i) =>
         configItemToEntry(i, currentPathname, locale, routes)
       ),
@@ -77,6 +79,7 @@ function groupFromAutogenerateConfig(
   return {
     type: 'group',
     label: pickLang(item.translations, localeToLang(locale)) || item.label,
+    isOpen: true,
     entries: sidebarFromDir(tree, currentPathname, locale),
   };
 }

--- a/packages/starlight/utils/user-config.ts
+++ b/packages/starlight/utils/user-config.ts
@@ -54,6 +54,7 @@ const AutoSidebarGroupSchema = SidebarBaseSchema.extend({
 export type AutoSidebarGroup = z.infer<typeof AutoSidebarGroupSchema>;
 
 type ManualSidebarGroupInput = z.input<typeof SidebarBaseSchema> & {
+  isOpen: boolean;
   /** Array of links and subcategories to display in this category. */
   items: Array<
     | z.input<typeof SidebarLinkItemSchema>
@@ -63,6 +64,7 @@ type ManualSidebarGroupInput = z.input<typeof SidebarBaseSchema> & {
 };
 
 type ManualSidebarGroupOutput = z.output<typeof SidebarBaseSchema> & {
+  isOpen: boolean;
   /** Array of links and subcategories to display in this category. */
   items: Array<
     | z.output<typeof SidebarLinkItemSchema>
@@ -76,6 +78,7 @@ const ManualSidebarGroupSchema: z.ZodType<
   z.ZodTypeDef,
   ManualSidebarGroupInput
 > = SidebarBaseSchema.extend({
+  isOpen: z.boolean().default(true).describe('Whether this group is open in the sidebar.'),
   /** Array of links and subcategories to display in this category. */
   items: z.lazy(() =>
     z


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

Added an `isOpen` option to the groups in the sidebar. Sometimes you don't want a group to be expanded/open by default only if a user navigates to it or needs to see the topics.

Example:
![image](https://github.com/withastro/starlight/assets/24605285/448ddc58-d664-48cc-bf11-1e4d2887fa9d)

The first `Start Here` group is without the option to defaults to `true` and acts like before. The second `Start Here` group has `isOpen` set to `false` in the `astro.config.mjs`.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
