### PR TITLE
i18n(es): Fix typos in `es.json`

### DIFF
--- a/.changeset/unlucky-deers-play.md
+++ b/.changeset/unlucky-deers-play.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fix typo in Spanish UI translations

--- a/packages/starlight/translations/es.json
+++ b/packages/starlight/translations/es.json
@@ -18,5 +18,5 @@
   "page.lastUpdated": "Última actualización:",
   "page.previousLink": "Página anterior",
   "page.nextLink": "Siguiente página",
-  "404.text": "Página no encontrada. Verifique la URL o intente usar la barra de búsqueda."
+  "404.text": "Página no encontrada. Verifica la URL o intenta usar la barra de búsqueda."
 }


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

- What does this PR change? Give us a brief description.
Fix typos in `es.json`, the use of `usted` has been replaced by the use of `tú`.