### PR TITLE
Downgrade `vfile` to version `5.3.7`

### DIFF
--- a/packages/starlight/package.json
+++ b/packages/starlight/package.json
@@ -48,6 +48,6 @@
     "unified": "^10.1.2",
     "unist-util-remove": "^3.1.1",
     "unist-util-visit": "^4.1.2",
-    "vfile": "^6.0.0"
+    "vfile": "^5.3.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,8 +138,8 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2
       vfile:
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^5.3.7
+        version: 5.3.7
     devDependencies:
       '@types/node':
         specifier: ^18.15.11
@@ -5687,13 +5687,6 @@ packages:
       '@types/unist': 2.0.6
       unist-util-stringify-position: 3.0.3
 
-  /vfile-message@4.0.1:
-    resolution: {integrity: sha512-Z1WqUoIK6T6LLoyO64ncUapmjlA84JqKRQFjcG0kZnnyysfq2rMyg5NvKhkQ16GH9FRCRT+Rk4G0aMxgKYS16g==}
-    dependencies:
-      '@types/unist': 2.0.6
-      unist-util-stringify-position: 3.0.3
-    dev: false
-
   /vfile@5.3.7:
     resolution: {integrity: sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==}
     dependencies:
@@ -5701,14 +5694,6 @@ packages:
       is-buffer: 2.0.5
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
-
-  /vfile@6.0.0:
-    resolution: {integrity: sha512-wx7bOMmEl8bY5WPaXTGsK8YxPLoFiUiDg+m+lBACA1QGcagj3sUyxkX0F+W/Nmn4MHH7G4sXBekpYWRxQE2eHg==}
-    dependencies:
-      '@types/unist': 2.0.6
-      unist-util-stringify-position: 3.0.3
-      vfile-message: 4.0.1
-    dev: false
 
   /vite@4.3.5(@types/node@18.15.11):
     resolution: {integrity: sha512-0gEnL9wiRFxgz40o/i/eTBwm+NEbpUeTWhzKrZDSdKm6nplj+z4lKz8ANDgildxHm47Vg8EUia0aicKbawUVVA==}


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to Starlight code

#### Description

This PR downgrades the version of the `vfile` package to `^5.3.7`.

While working on the `<Tabs>` component, I noticed various TypeScript errors:

<img width="392" alt="SCR-20230630-otjz" src="https://github.com/withastro/starlight/assets/494699/2c56c475-b144-471b-b1e5-4e3d0e5f8389">

Turns out the following code from `packages/starlight/user-components/rehype-tabs.ts`:

```ts
declare module "vfile" {
  interface DataMap {
    panels: Panel[];
  }
}
```

fails with the following error:

```
error TS2664: Invalid module name in augmentation, module 'vfile' cannot be found.

10 declare module 'vfile' {
                  ~~~~~~~
```

This error appeared after [the upgrade](https://github.com/withastro/starlight/pull/208) from `vfile@5.3.7` to `vfile@6.0.0`. Downgrading to `vfile@5.3.7` fixes the issue.

<img width="394" alt="SCR-20230630-olnu" src="https://github.com/withastro/starlight/assets/494699/eafdcb00-e99c-4d0d-9161-692db6f98828">

I did not take the time to look into the issue in details yet but it looks like [this commit](https://github.com/vfile/vfile/commit/f72469b5412c2e2e8480993b2e4a7c2e1530c80f) totally dropped the type definitions from their package.json file.

In the meantime, I think it may be better to downgrade to `vfile@5.3.7` to avoid dealing with this issue (Astro is also still using this version).
