### PR TITLE
i18n(es): Fix typo in `i18n.mdx`

### DIFF
--- a/docs/src/content/docs/es/guides/i18n.mdx
+++ b/docs/src/content/docs/es/guides/i18n.mdx
@@ -61,7 +61,7 @@ Starlight proporciona soporte incorporado para sitios multilingües, incluidas l
 
 3. Ahora puedes agregar archivos de contenido en los directorios de tu idioma. Utiliza el mismo nombre de archivo para asociar páginas entre idiomas y aprovechar todas las características de internacionalización (i18n) de Starlight, como contenido de respaldo, avisos de traducción y más.
 
-Por ejemplo, crea `ar/index.md` y `en/index.md` para representar la página de inicio en árabe e inglés, respectivamente.
+   Por ejemplo, crea `ar/index.md` y `en/index.md` para representar la página de inicio en árabe e inglés, respectivamente.
 
 ### Usa una raíz de configuración regional
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

- What does this PR change? Give us a brief description.
The missing space has been added so that the text has the same formatting as the original page. The page where this happens is `/es/guides/i18n/#configura-i18n`.

## Original Page 
![image](https://github.com/withastro/starlight/assets/78129249/cb4d575d-d216-4d2a-95b1-4dcd4254bba1)

## Page translated into Spanish

* **Before**
![image](https://github.com/withastro/starlight/assets/78129249/ae27653e-7870-420c-a154-f3ed5eab3482)
* **Now**
![image](https://github.com/withastro/starlight/assets/78129249/ed4a9d31-0110-45d8-a74a-c7e429164863)
