### PR TITLE
fix: set sl-color-purple-high to 90% saturation in light theme

### DIFF
--- a/.changeset/rich-melons-return.md
+++ b/.changeset/rich-melons-return.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fix saturation of purple text in light theme

--- a/packages/starlight/style/props.css
+++ b/packages/starlight/style/props.css
@@ -135,7 +135,7 @@
   --sl-color-blue-high: hsl(var(--sl-hue-blue), 80%, 30%);
   --sl-color-blue: hsl(var(--sl-hue-blue), 90%, 60%);
   --sl-color-blue-low: hsl(var(--sl-hue-blue), 88%, 90%);
-  --sl-color-purple-high: hsl(var(--sl-hue-purple), 39%, 30%);
+  --sl-color-purple-high: hsl(var(--sl-hue-purple), 90%, 30%);
   --sl-color-purple: hsl(var(--sl-hue-purple), 90%, 60%);
   --sl-color-purple-low: hsl(var(--sl-hue-purple), 80%, 90%);
   --sl-color-red-high: hsl(var(--sl-hue-red), 80%, 30%);


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- Closes #278 <!-- Add an issue number if this PR will close it. -->
- What does this PR change? Give us a brief description.

Updated `--sl-color-purple-high` to 90% saturation in light theme. This helps improve legibility of the light theme's code syntax highlighting, specifically distinguishing between purple and black text.

- Did you change something visual? A before/after screenshot can be helpful.

##### Before update

syntax highlighting:
![image](https://github.com/withastro/starlight/assets/14223394/a344d1c6-a373-4111-a93a-6b8dccc82f8e)

tips:
![image](https://github.com/withastro/starlight/assets/14223394/73ac292b-4762-40fa-868a-d40f42a6cea0)

##### After update

syntax highlighting: 
![image](https://github.com/withastro/starlight/assets/14223394/cebb418a-3d28-4570-8b06-8ce92fa48fd5)

tips:
![image](https://github.com/withastro/starlight/assets/14223394/cc1c4c57-b415-481d-88e4-58c222d86abe)


<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
