### PR TITLE
Include additional instructions for using custom fonts

### DIFF
--- a/docs/src/content/docs/guides/customization.mdx
+++ b/docs/src/content/docs/guides/customization.mdx
@@ -449,3 +449,28 @@ main {
   font-family: 'IBM Plex Serif', serif;
 }
 ```
+
+Finally, add your custom CSS file to Starlight’s `customCss` array in `astro.config.mjs` after the CSS file containing your `@font-face` declarations:
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import starlight from '@astrojs/starlight'
+
+export default defineConfig({
+  integrations: [
+    starlight({
+      title: 'Docs With a Custom Typeface',
+      customCss: [
+        // Path to your @font-face CSS file (if using local fonts)
+        '/src/fonts/font-face.css',
+        // Path to your @font-face CSS file (if using Fontsource)
+        '@fontsource/ibm-plex-serif/400.css',
+        '@fontsource/ibm-plex-serif/600.css',
+        // Path to your custom CSS file
+        '/src/styles/custom.css'
+      ],
+    }),
+  ],
+});
+```

--- a/docs/src/content/docs/guides/customization.mdx
+++ b/docs/src/content/docs/guides/customization.mdx
@@ -450,27 +450,4 @@ main {
 }
 ```
 
-Finally, add your custom CSS file to Starlight’s `customCss` array in `astro.config.mjs` after the CSS file containing your `@font-face` declarations:
-
-```js
-// astro.config.mjs
-import { defineConfig } from 'astro/config';
-import starlight from '@astrojs/starlight'
-
-export default defineConfig({
-  integrations: [
-    starlight({
-      title: 'Docs With a Custom Typeface',
-      customCss: [
-        // Path to your @font-face CSS file (if using local fonts)
-        '/src/fonts/font-face.css',
-        // Path to your @font-face CSS file (if using Fontsource)
-        '@fontsource/ibm-plex-serif/400.css',
-        '@fontsource/ibm-plex-serif/600.css',
-        // Path to your custom CSS file
-        '/src/styles/custom.css'
-      ],
-    }),
-  ],
-});
-```
+Follow the [custom CSS instructions](#custom-css-styles) to add your styles to your site.


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

Hey everyone. It's not explicitly mentioned that the user needs to also include their custom CSS file (containing font families and other variable overrides) within `astro.config.mjs` under the [Use fonts](https://starlight.astro.build/guides/customization/#use-fonts) section in the docs.

I think it's a good idea to have this step outlined, as starting the Astro dev server without including the custom CSS in the config will result in the fonts not being loaded. This may lead to some head-scratching for new users, and so removing any potential points of friction or ambiguity is a good thing IMHO.