### PR TITLE
Fix broken link on 404 page when `defaultLocale: 'root'` is set

### DIFF
--- a/.changeset/many-tips-battle.md
+++ b/.changeset/many-tips-battle.md
@@ -2,4 +2,4 @@
 "@astrojs/starlight": patch
 ---
 
-fix broken link on 404 page when defaultLocale: 'root' is set in astro.config.mjs
+Fix broken link on 404 page when `defaultLocale: 'root'` is set in `astro.config.mjs`

--- a/.changeset/many-tips-battle.md
+++ b/.changeset/many-tips-battle.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+fix broken link on 404 page when defaultLocale: 'root' is set in astro.config.mjs

--- a/packages/starlight/404.astro
+++ b/packages/starlight/404.astro
@@ -6,7 +6,10 @@ import Page from './layout/Page.astro';
 import type { StarlightDocsEntry } from './utils/routing';
 import { useTranslations } from './utils/translations';
 
-const { lang = 'en', dir = 'ltr', locale } = config.defaultLocale || {};
+const { lang = 'en', dir = 'ltr' } = config.defaultLocale || {};
+let locale = config.defaultLocale?.locale;
+if (locale === 'root') locale = undefined;
+
 const entryMeta = { dir, lang, locale };
 const t = useTranslations(locale);
 
@@ -34,6 +37,6 @@ const entry = userEntry || fallbackEntry;
 const { Content, headings } = await entry.render();
 ---
 
-<Page {headings} entry={entry} slug={entry.slug} {...entryMeta} {entryMeta}>
+<Page {headings} entry={entry} id={entry.id} slug={entry.slug} {...entryMeta} {entryMeta}>
   <Content />
 </Page>

--- a/packages/starlight/components/SiteTitle.astro
+++ b/packages/starlight/components/SiteTitle.astro
@@ -23,8 +23,7 @@ if (config.logo) {
   if (err) throw new Error(err);
 }
 
-const locale =  Astro.props.locale === 'root' ? '' : Astro.props.locale;
-const href = pathWithBase(locale || '/');
+const href = pathWithBase(Astro.props.locale || '/');
 ---
 
 <a {href} class="site-title flex">

--- a/packages/starlight/components/SiteTitle.astro
+++ b/packages/starlight/components/SiteTitle.astro
@@ -23,7 +23,8 @@ if (config.logo) {
   if (err) throw new Error(err);
 }
 
-const href = pathWithBase(Astro.props.locale || '/');
+const locale =  Astro.props.locale === 'root' ? '' : Astro.props.locale;
+const href = pathWithBase(locale || '/');
 ---
 
 <a {href} class="site-title flex">


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- When `defaultLocale` is set to `root` in `astro.config.mjs` instead of just removing it, this results in broken site logo link on  the root language 404 page.
- To fix this, I reproduced the simple approach used in the `localizedUrl` function, which sets locale to an empty string if locale is `root`.
- I applied the fix to the `SiteTitle.astro` component in case the same situation arrises from other pages than 404.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
