### PR TITLE
Add pagination configuration

### DIFF
--- a/.changeset/green-jars-march.md
+++ b/.changeset/green-jars-march.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": minor
+---
+
+Add new global `pagination` option defaulting to `true` to define whether or not the previous and next page links are shown in the footer. A page can override this setting or the link text and/or URL using the new `prev` and `next` frontmatter fields.

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -366,3 +366,5 @@ By default, this feature relies on your repository’s Git history and may not b
 **default:** `true`
 
 Define if the footer should include previous and next page links.
+
+A page can override this setting or the link text and/or URL using the [`prev`](/reference/frontmatter/#prev) and [`next`](/reference/frontmatter/#next) frontmatter fields.

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -359,3 +359,10 @@ interface HeadConfig {
 Control whether the footer shows when the page was last updated.
 
 By default, this feature relies on your repository’s Git history and may not be accurate on some deployment platforms performing [shallow clones](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt). A page can override this setting or the Git-based date using the [`lastUpdated` frontmatter field](/reference/frontmatter/#lastupdated).
+
+### `pagination`
+
+**type:** `boolean`  
+**default:** `true`
+
+Define if the footer should include previous and next page links.

--- a/docs/src/content/docs/reference/frontmatter.md
+++ b/docs/src/content/docs/reference/frontmatter.md
@@ -149,7 +149,7 @@ lastUpdated: 2022-08-09
 
 ### `prev`
 
-**type:** `boolean | string | { href?: string; label?: string }`
+**type:** `boolean | string | { link?: string; label?: string }`
 
 Overrides the [global `pagination` option](/reference/configuration/#pagination). If a string is specified, the generated link text will be replaced and if an object is specified, both the link and the text will can be overridden.
 
@@ -171,14 +171,14 @@ prev: Continue the tutorial
 ---
 # Override both the previous page link and text
 prev: 
-  href: /unrelated-page/
+  link: /unrelated-page/
   label: Check out this other page
 ---
 ```
 
 ### `next`
 
-**type:** `boolean | string | { href?: string; label?: string }`
+**type:** `boolean | string | { link?: string; label?: string }`
 
 Same as [`prev`](#prev) but for the next page link.
 

--- a/docs/src/content/docs/reference/frontmatter.md
+++ b/docs/src/content/docs/reference/frontmatter.md
@@ -146,3 +146,45 @@ title: Page with a custom last update date
 lastUpdated: 2022-08-09
 ---
 ```
+
+### `prev`
+
+**type:** `boolean | string | { href?: string; label?: string }`
+
+Overrides the [global `pagination` option](/reference/configuration/#pagination). If a string is specified, the generated link text will be replaced and if an object is specified, both the link and the text will can be overridden.
+
+```md
+---
+# Hide the previous page link
+prev: false
+---
+```
+
+```md
+---
+# Override the previous page link text
+prev: Continue the tutorial
+---
+```
+
+```md
+---
+# Override both the previous page link and text
+prev: 
+  href: /unrelated-page/
+  label: Check out this other page
+---
+```
+
+### `next`
+
+**type:** `boolean | string | { href?: string; label?: string }`
+
+Same as [`prev`](#prev) but for the next page link.
+
+```md
+---
+# Hide the next page link
+next: false
+---
+```

--- a/packages/starlight/components/Footer.astro
+++ b/packages/starlight/components/Footer.astro
@@ -14,7 +14,10 @@ interface Props extends LocaleData {
 }
 
 const { entry, dir, lang, locale, sidebar } = Astro.props;
-const prevNextLinks = getPrevNextLinks(sidebar);
+const prevNextLinks = getPrevNextLinks(sidebar, config.pagination, {
+  prev: entry.data.prev,
+  next: entry.data.next
+});
 ---
 
 <footer>
@@ -39,7 +42,7 @@ const prevNextLinks = getPrevNextLinks(sidebar);
       )
     }
   </div>
-  {config.pagination && <PrevNextLinks {...prevNextLinks} {dir} {locale} />}
+  <PrevNextLinks {...prevNextLinks} {dir} {locale} />
 </footer>
 
 <style>

--- a/packages/starlight/components/Footer.astro
+++ b/packages/starlight/components/Footer.astro
@@ -39,7 +39,7 @@ const prevNextLinks = getPrevNextLinks(sidebar);
       )
     }
   </div>
-  <PrevNextLinks {...prevNextLinks} {dir} {locale} />
+  {config.pagination && <PrevNextLinks {...prevNextLinks} {dir} {locale} />}
 </footer>
 
 <style>

--- a/packages/starlight/schema.ts
+++ b/packages/starlight/schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'astro/zod';
 import { HeadConfigSchema } from './schemas/head';
+import { PrevNextLinkConfigSchema } from './schemas/prevNextLink';
 import { TableOfContentsSchema } from './schemas/tableOfContents';
 import { Icons } from './components/Icons';
 export { i18nSchema } from './schemas/i18n';
@@ -119,5 +120,16 @@ export function docsSchema() {
        * Overrides the `lastUpdated` global config or the date generated from the Git history.
        */
       lastUpdated: z.union([z.date(), z.boolean()]).optional(),
+
+      /**
+       * The previous navigation link configuration.
+       * Overrides the `pagination` global config or the link text and/or URL.
+       */
+      prev: PrevNextLinkConfigSchema(),
+      /**
+       * The next navigation link configuration.
+       * Overrides the `pagination` global config or the link text and/or URL.
+       */
+      next: PrevNextLinkConfigSchema(),
     });
 }

--- a/packages/starlight/schemas/prevNextLink.ts
+++ b/packages/starlight/schemas/prevNextLink.ts
@@ -8,7 +8,7 @@ export const PrevNextLinkConfigSchema = () =>
       z
         .object({
           /** The navigation link URL. */
-          href: z.string().optional(),
+          link: z.string().optional(),
           /** The navigation link text. */
           label: z.string().optional(),
         })

--- a/packages/starlight/schemas/prevNextLink.ts
+++ b/packages/starlight/schemas/prevNextLink.ts
@@ -1,0 +1,20 @@
+import { z } from 'astro/zod';
+
+export const PrevNextLinkConfigSchema = () =>
+  z
+    .union([
+      z.boolean(),
+      z.string(),
+      z
+        .object({
+          /** The navigation link URL. */
+          href: z.string().optional(),
+          /** The navigation link text. */
+          label: z.string().optional(),
+        })
+        .strict(),
+    ])
+    .optional();
+
+export type PrevNextLinkUserConfig = z.input<ReturnType<typeof PrevNextLinkConfigSchema>>;
+export type PrevNextLinkConfig = z.output<ReturnType<typeof PrevNextLinkConfigSchema>>;

--- a/packages/starlight/utils/navigation.ts
+++ b/packages/starlight/utils/navigation.ts
@@ -281,12 +281,12 @@ function applyPrevNextLinkConfig(
       return {
         ...link,
         label: config.label ?? link.label,
-        href: config.href ?? link.href,
+        href: config.link ?? link.href,
       }
-    } else if (config.href && config.label) {
-      // If there is no link and the frontmatter contains both a href and a label,
+    } else if (config.link && config.label) {
+      // If there is no link and the frontmatter contains both a URL and a label,
       // create a new link.
-      return makeLink(config.href, config.label, config.href);
+      return makeLink(config.link, config.label, config.link);
     }
   }
   // Otherwise, if the global config is enabled, return the generated link if any.

--- a/packages/starlight/utils/navigation.ts
+++ b/packages/starlight/utils/navigation.ts
@@ -9,6 +9,7 @@ import type {
   SidebarItem,
   SidebarLinkItem,
 } from './user-config';
+import type { PrevNextLinkConfig } from '../schemas/prevNextLink';
 
 export interface Link {
   type: 'link';
@@ -234,16 +235,62 @@ export function flattenSidebar(sidebar: SidebarEntry[]): Link[] {
   );
 }
 
-/** Get previous/next pages in the sidebar if there are any. */
-export function getPrevNextLinks(sidebar: SidebarEntry[]): {
+/** Get previous/next pages in the sidebar or the ones from the frontmatter if any. */
+export function getPrevNextLinks(
+  sidebar: SidebarEntry[],
+  paginationEnabled: boolean,
+  config: {
+    prev?: PrevNextLinkConfig;
+    next?: PrevNextLinkConfig;
+  }
+): {
   prev: Link | undefined;
   next: Link | undefined;
 } {
   const entries = flattenSidebar(sidebar);
   const currentIndex = entries.findIndex((entry) => entry.isCurrent);
-  const prev = entries[currentIndex - 1];
-  const next = currentIndex > -1 ? entries[currentIndex + 1] : undefined;
+  const prev = applyPrevNextLinkConfig(
+    entries[currentIndex - 1],
+    paginationEnabled,
+    config.prev
+  );
+  const next = applyPrevNextLinkConfig(
+    currentIndex > -1 ? entries[currentIndex + 1] : undefined,
+    paginationEnabled,
+    config.next
+  );
   return { prev, next };
+}
+
+/** Apply a prev/next link config to a navigation link. */
+function applyPrevNextLinkConfig(
+  link: Link | undefined,
+  paginationEnabled: boolean,
+  config: PrevNextLinkConfig | undefined
+): Link | undefined {
+  // Explicitly remove the link.
+  if (config === false) return undefined;
+  // Use the generated link if any.
+  else if (config === true) return link;
+  // If a link exists, update its label if needed.
+  else if (typeof config === 'string' && link) {
+    return { ...link, label: config };
+  } else if (typeof config === 'object') {
+    if (link) {
+      // If a link exists, update both its label and href if needed.
+      return {
+        ...link,
+        label: config.label ?? link.label,
+        href: config.href ?? link.href,
+      }
+    } else if (config.href && config.label) {
+      // If there is no link and the frontmatter contains both a href and a label,
+      // create a new link.
+      return makeLink(config.href, config.label, config.href);
+    }
+  }
+  // Otherwise, if the global config is enabled, return the generated link if any.
+  return paginationEnabled ? link : undefined;
 }
 
 /** Remove the extension from a path. */

--- a/packages/starlight/utils/user-config.ts
+++ b/packages/starlight/utils/user-config.ts
@@ -252,6 +252,14 @@ const UserConfigSchema = z.object({
     .default(false)
     .describe(
       'Define if the last update date should be visible in the page footer.'
+  ),
+  
+  /** Define if the previous and next page links should be visible in the page footer. */
+  pagination: z
+    .boolean()
+    .default(true)
+    .describe(
+      'Define if the previous and next page links should be visible in the page footer.'
     ),
 });
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content
- Changes to Starlight code

#### Description

As [discussed](https://discord.com/channels/830184174198718474/1120359166574338058/1120359226372526100) on Discord, this pull request adds configuration regarding the previous and next page links visible in the footer.

##### Global config

This PR adds a new global `pagination` option accepting a boolean and defaulting to `true` to define whether or not the previous and next page links are shown in the footer.

##### Frontmatter fields

Two new frontmatter fields are added to allow overriding the global configuration on a per-page basis: `prev` and `next`.

- If a boolean is provided, it will override the global configuration.
- If a string is provided, it will be used as the link text for the generated link if any. I think most users will want to modify the link text most of the time, so I think having this shorter syntax is nice to have instead of always having to provide an object.
- If an object is provided, both the link text and URL can be overridden for the generated link. If a page does not have a previous or next page and both a link text and URL are provided, a link will be generated.

##### Notes

We noted in #256 the benefits of having the config option and frontmatter fields having the same name but I think in this case, this could lead to a bit more confusing API. For example, if using two fields `prev` & `next`, if a user wants to quickly disable pagination, having to set both `prev` and `next` to `false` in the Astro config would not be that great imo. On the other hand, nesting everything under a `pagination` key in the frontmatter might be a bit too verbose / nested?

Considering that the frontmatter fields should be a sporadic use case / override, I think having a single global config option and two frontmatter fields makes sense. Any thoughts or suggestions?
