### PR TITLE
Improve code block and inline code default font stack

### DIFF
--- a/.changeset/itchy-pugs-live.md
+++ b/.changeset/itchy-pugs-live.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fix use of default monospace font stack

--- a/docs/src/components/file-tree.astro
+++ b/docs/src/components/file-tree.astro
@@ -29,7 +29,7 @@ const processedContent = await fileTreeProcessor.process({
     padding: 1rem;
     background-color: var(--sl-color-gray-6);
     font-size: var(--sl-text-xs);
-    font-family: var(--__sb-font-mono);
+    font-family: var(--__sl-font-mono);
     overflow-x: auto;
   }
 

--- a/packages/starlight/components/MarkdownContent.astro
+++ b/packages/starlight/components/MarkdownContent.astro
@@ -87,6 +87,7 @@
 
   .content :global(pre code) {
     all: unset;
+    font-family: var(--__sb-font-mono);
   }
 
   .content :global(blockquote) {

--- a/packages/starlight/components/MarkdownContent.astro
+++ b/packages/starlight/components/MarkdownContent.astro
@@ -87,7 +87,7 @@
 
   .content :global(pre code) {
     all: unset;
-    font-family: var(--__sb-font-mono);
+    font-family: var(--__sl-font-mono);
   }
 
   .content :global(blockquote) {

--- a/packages/starlight/components/MarkdownContent.astro
+++ b/packages/starlight/components/MarkdownContent.astro
@@ -77,6 +77,10 @@
     background-color: var(--sl-color-bg-inline-code);
     margin-block: -0.125rem;
     padding: 0.125rem 0.375rem;
+    font-size: var(--sl-text-code-sm);
+  }
+  .content :global(:is(h1, h2, h3, h4, h5, h6) code) {
+    font-size: inherit;
   }
 
   .content :global(pre) {

--- a/packages/starlight/style/props.css
+++ b/packages/starlight/style/props.css
@@ -89,8 +89,8 @@
     'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --sl-font-system-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     'Liberation Mono', 'Courier New', monospace;
-  --__sb-font: var(--sl-font, ''), var(--sl-font-system);
-  --__sb-font-mono: var(--sl-font-mono, ''), var(--sl-font-system-mono);
+  --__sl-font: var(--sl-font, ''), var(--sl-font-system);
+  --__sl-font-mono: var(--sl-font-mono, ''), var(--sl-font-system-mono);
 
   /** Key layout values */
   --sl-nav-height: 3.5rem;

--- a/packages/starlight/style/reset.css
+++ b/packages/starlight/style/reset.css
@@ -41,3 +41,7 @@ h5,
 h6 {
   overflow-wrap: break-word;
 }
+
+code {
+  font-family: var(--__sb-font-mono);
+}

--- a/packages/starlight/style/reset.css
+++ b/packages/starlight/style/reset.css
@@ -18,7 +18,7 @@ html[data-theme='light'] {
 }
 
 body {
-  font-family: var(--__sb-font);
+  font-family: var(--__sl-font);
   line-height: var(--sl-line-height);
   -webkit-font-smoothing: antialiased;
   color: var(--sl-color-text);
@@ -43,5 +43,5 @@ h6 {
 }
 
 code {
-  font-family: var(--__sb-font-mono);
+  font-family: var(--__sl-font-mono);
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- I forgot to wire up our default monospace fontstack to be used in code blocks and inline code. This resulted in some browsers using suboptimal fonts like Courier. This PR fixes that.
- I also renamed a couple of internal CSS custom properties which were using an outdated prefix.
- Closes #304 by mostly using a better font that risks less confusion than Courier when combined with link underlines. This is not a silver bullet, but other options would require targeting all link styles in a way that doesn’t seem desirable. Will be curious to hear if this change seems sufficient or if more work is needed to properly address #304.

Here are some before/after comparisons on macOS using the live site and the branch preview:
- https://starlight.astro.build/reference/configuration/#sidebar
- https://deploy-preview-308--astro-starlight.netlify.app/reference/configuration/#sidebar

Would be curious if anyone wants to share on a different platform/browser combo!

| Browser | Before | After |
|---|---|---|
| Safari | <img width="440" alt="image" src="https://github.com/withastro/starlight/assets/357379/38b30191-441a-4ac2-9866-b1795ba06782"> | <img width="424" alt="image" src="https://github.com/withastro/starlight/assets/357379/bc73393d-5f6b-4f89-ba45-720ae07624e2"> |
| Edge​/​Chrome | <img width="387" alt="image" src="https://github.com/withastro/starlight/assets/357379/9dfc7fb8-8b59-4e43-85ba-c3a8f4516bb2"> | <img width="395" alt="image" src="https://github.com/withastro/starlight/assets/357379/b4cb5d7e-a35b-438a-86ea-f152360f5071"> |
| Firefox | <img width="410" alt="image" src="https://github.com/withastro/starlight/assets/357379/ab4bacab-e3f2-457f-bfc5-7327518ec0c4"> | <img width="407" alt="image" src="https://github.com/withastro/starlight/assets/357379/2856f17e-ebe8-4d9e-a948-44e0fcd8ad6a"> |

One additional thing to call out is that this now means that Japanese pages also use this fontstack now, whereas the default monospace before was quite different:

| Before | After |
|---|---|
| <img width="746" alt="image" src="https://github.com/withastro/starlight/assets/357379/e318662e-5417-4245-bd05-af55259e6d41"> | <img width="747" alt="image" src="https://github.com/withastro/starlight/assets/357379/5094b6b1-e265-4f11-ac2e-d8ce52460d11"> |

I’d love to hear from @morinokami or @Kyosuke whether this is an issue and whether the old behaviour is more expected in Japanese text.
