### PR TITLE
[i18nIgnore] Tweak internationalization documentation

### DIFF
--- a/docs/src/content/docs/de/reference/configuration.md
+++ b/docs/src/content/docs/de/reference/configuration.md
@@ -142,7 +142,7 @@ interface LinkItem {
 
 **Typ:** <code>{ \[dir: string\]: [LocaleConfig](#localeconfig) }</code>
 
-Konfiguriere die Internationalisierung (i18n) für Ihre Website, indem du festlegst, welche `Locales` unterstützt werden.
+[Konfiguriere die Internationalisierung (i18n)](/de/guides/i18n/) für Ihre Website, indem du festlegst, welche `Locales` unterstützt werden.
 
 Jeder Eintrag sollte das Verzeichnis, in dem die Dateien der jeweiligen Sprache gespeichert sind, als Schlüssel verwenden.
 

--- a/docs/src/content/docs/de/reference/configuration.md
+++ b/docs/src/content/docs/de/reference/configuration.md
@@ -140,7 +140,7 @@ interface LinkItem {
 
 ### `locales`
 
-**Typ:** `{ [dir: string]: LocaleConfig }`
+**Typ:** <code>{ \[dir: string\]: [LocaleConfig](#localeconfig) }</code>
 
 Konfiguriere die Internationalisierung (i18n) für Ihre Website, indem du festlegst, welche `Locales` unterstützt werden.
 
@@ -178,7 +178,15 @@ export default defineConfig({
 });
 ```
 
-#### Locale-Optionen
+#### `LocaleConfig`
+
+```ts
+interface LocaleConfig {
+  label: string;
+  lang?: string;
+  dir?: 'ltr' | 'rtl';
+}
+```
 
 Du kannst die folgenden Optionen für jedes Locale-Schema festlegen:
 

--- a/docs/src/content/docs/es/guides/i18n.mdx
+++ b/docs/src/content/docs/es/guides/i18n.mdx
@@ -9,7 +9,7 @@ Starlight proporciona soporte incorporado para sitios multilingües, incluidas l
 
 ## Configura i18n
 
-1. Indícale a Starlight los idiomas que admites pasando `locales` y `defaultLocale` a la integración de Starlight:
+1. Indícale a Starlight los idiomas que admites pasando [`locales`](/es/reference/configuration/#locales) y [`defaultLocale`](/es/reference/configuration/#defaultlocale) a la integración de Starlight:
 
    ```js
    // astro.config.mjs

--- a/docs/src/content/docs/es/reference/configuration.md
+++ b/docs/src/content/docs/es/reference/configuration.md
@@ -197,7 +197,7 @@ type SidebarItem = {
 
 **tipo:** <code>{ \[dir: string\]: [LocaleConfig](#localeconfig) }</code>
 
-Configura la internacionalización (i18n) para tu sitio estableciendo qué `locales` se admiten.
+[Configura la internacionalización (i18n)](/es/guides/i18n/) para tu sitio estableciendo qué `locales` se admiten.
 
 Cada entrada debe usar el directorio donde se guardan los archivos de ese idioma como clave.
 

--- a/docs/src/content/docs/es/reference/configuration.md
+++ b/docs/src/content/docs/es/reference/configuration.md
@@ -195,7 +195,7 @@ type SidebarItem = {
 
 ### `locales`
 
-**tipo:** `{ [dir: string]: LocaleConfig }`
+**tipo:** <code>{ \[dir: string\]: [LocaleConfig](#localeconfig) }</code>
 
 Configura la internacionalización (i18n) para tu sitio estableciendo qué `locales` se admiten.
 
@@ -233,7 +233,15 @@ export default defineConfig({
 });
 ```
 
-#### Opciones de configuración de idioma
+#### `LocaleConfig`
+
+```ts
+interface LocaleConfig {
+  label: string;
+  lang?: string;
+  dir?: 'ltr' | 'rtl';
+}
+```
 
 Puedes establecer las siguientes opciones para cada idioma:
 

--- a/docs/src/content/docs/fr/guides/i18n.mdx
+++ b/docs/src/content/docs/fr/guides/i18n.mdx
@@ -9,7 +9,7 @@ Starlight offre une prise en charge intégrée des sites multilingues, y compris
 
 ## Configurer i18n
 
-1. Indiquez à Starlight les langues que vous prenez en charge en passant `locales` et `defaultLocale` à l'intégration Starlight :
+1. Indiquez à Starlight les langues que vous prenez en charge en passant [`locales`](/fr/reference/configuration/#locales) et [`defaultLocale`](/fr/reference/configuration/#defaultlocale) à l'intégration Starlight :
 
    ```js
    // astro.config.mjs

--- a/docs/src/content/docs/fr/reference/configuration.md
+++ b/docs/src/content/docs/fr/reference/configuration.md
@@ -164,7 +164,7 @@ type SidebarItem = {
 
 ### `locales`
 
-**type:** `{ [dir: string]: LocaleConfig }`
+**type:** <code>{ \[dir: string\]: [LocaleConfig](#localeconfig) }</code>
 
 Configurez l'internationalisation (i18n) de votre site en définissant les `locales` supportées.
 
@@ -202,7 +202,15 @@ export default defineConfig({
 });
 ```
 
-#### Options des paramètres linguistiques
+#### `LocaleConfig`
+
+```ts
+interface LocaleConfig {
+  label: string;
+  lang?: string;
+  dir?: 'ltr' | 'rtl';
+}
+```
 
 Vous pouvez définir les options suivantes pour chaque locale :
 

--- a/docs/src/content/docs/fr/reference/configuration.md
+++ b/docs/src/content/docs/fr/reference/configuration.md
@@ -166,7 +166,7 @@ type SidebarItem = {
 
 **type:** <code>{ \[dir: string\]: [LocaleConfig](#localeconfig) }</code>
 
-Configurez l'internationalisation (i18n) de votre site en définissant les `locales` supportées.
+[Configurez l'internationalisation (i18n)](/fr/guides/i18n/) de votre site en définissant les `locales` supportées.
 
 Chaque entrée doit utiliser comme clé le répertoire dans lequel les fichiers de cette langue sont sauvegardés.
 

--- a/docs/src/content/docs/guides/i18n.mdx
+++ b/docs/src/content/docs/guides/i18n.mdx
@@ -9,7 +9,7 @@ Starlight provides built-in support for multilingual sites, including routing, f
 
 ## Configure i18n
 
-1. Tell Starlight about the languages you support by passing `locales` and `defaultLocale` to the Starlight integration:
+1. Tell Starlight about the languages you support by passing [`locales`](/reference/configuration/#locales) and [`defaultLocale`](/reference/configuration/#defaultlocale) to the Starlight integration:
 
    ```js
    // astro.config.mjs

--- a/docs/src/content/docs/it/guides/i18n.mdx
+++ b/docs/src/content/docs/it/guides/i18n.mdx
@@ -9,7 +9,7 @@ Starlight offre il supporto per siti multilingua, compreso di indirizzamento, co
 
 ## Configurare i18n
 
-1. Indicare a Starlight le lingue che si vuole supportare passando `locales` e `defaultLocale` all'integrazione Starlight:
+1. Indicare a Starlight le lingue che si vuole supportare passando [`locales`](/it/reference/configuration/#locales) e [`defaultLocale`](/it/reference/configuration/#defaultlocale) all'integrazione Starlight:
 
    ```js
    // astro.config.mjs

--- a/docs/src/content/docs/it/reference/configuration.md
+++ b/docs/src/content/docs/it/reference/configuration.md
@@ -171,7 +171,7 @@ interface LinkItem {
 
 ### `locales`
 
-**type:** `{ [dir: string]: LocaleConfig }`
+**type:** <code>{ \[dir: string\]: [LocaleConfig](#localeconfig) }</code>
 
 Configura l'internazionalizzazione (i18n) del sito impostando quali `locales` sono supportati.
 
@@ -209,7 +209,15 @@ export default defineConfig({
 });
 ```
 
-#### Opzioni per locale
+#### `LocaleConfig`
+
+```ts
+interface LocaleConfig {
+  label: string;
+  lang?: string;
+  dir?: 'ltr' | 'rtl';
+}
+```
 
 Puoi impostare le seguenti opzioni per ogni locale:
 

--- a/docs/src/content/docs/it/reference/configuration.md
+++ b/docs/src/content/docs/it/reference/configuration.md
@@ -173,7 +173,7 @@ interface LinkItem {
 
 **type:** <code>{ \[dir: string\]: [LocaleConfig](#localeconfig) }</code>
 
-Configura l'internazionalizzazione (i18n) del sito impostando quali `locales` sono supportati.
+[Configura l'internazionalizzazione (i18n)](/it/guides/i18n/) del sito impostando quali `locales` sono supportati.
 
 Ogni elemento deve utilizzare come chiave la cartella dove i file della lingua associata si trovano.
 

--- a/docs/src/content/docs/ja/guides/i18n.mdx
+++ b/docs/src/content/docs/ja/guides/i18n.mdx
@@ -9,7 +9,7 @@ Starlightは、ルーティング、フォールバックコンテンツ、右�
 
 ## i18nの設定
 
-1. `locales`と`defaultLocale`をStarlightインテグレーションに渡すことで、サポートする言語についてStarlightに伝えます。
+1. [`locales`](/ja/reference/configuration/#locales)と[`defaultLocale`](/ja/reference/configuration/#defaultlocale)をStarlightインテグレーションに渡すことで、サポートする言語についてStarlightに伝えます。
 
    ```js
    // astro.config.mjs

--- a/docs/src/content/docs/ja/reference/configuration.md
+++ b/docs/src/content/docs/ja/reference/configuration.md
@@ -192,7 +192,7 @@ type SidebarItem = {
 
 ### `locales`
 
-**type:** `{ [dir: string]: LocaleConfig }`
+**type:** <code>{ \[dir: string\]: [LocaleConfig](#localeconfig) }</code>
 
 サイトの国際化（i18n）をおこなうには、サポート対象の`locales`を設定します。
 
@@ -230,7 +230,15 @@ export default defineConfig({
 });
 ```
 
-#### ロケールオプション
+#### `LocaleConfig`
+
+```ts
+interface LocaleConfig {
+  label: string;
+  lang?: string;
+  dir?: 'ltr' | 'rtl';
+}
+```
 
 各ロケールに対し以下のオプションを設定できます。
 

--- a/docs/src/content/docs/ja/reference/configuration.md
+++ b/docs/src/content/docs/ja/reference/configuration.md
@@ -194,7 +194,7 @@ type SidebarItem = {
 
 **type:** <code>{ \[dir: string\]: [LocaleConfig](#localeconfig) }</code>
 
-サイトの国際化（i18n）をおこなうには、サポート対象の`locales`を設定します。
+[サイトの国際化（i18n）をおこなうには](/ja/guides/i18n/)、サポート対象の`locales`を設定します。
 
 各エントリは、その言語のファイルが保存されているディレクトリ名をキーとして使用する必要があります。
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -195,7 +195,7 @@ type SidebarItem = {
 
 ### `locales`
 
-**type:** `{ [dir: string]: LocaleConfig }`
+**type:** <code>{ \[dir: string\]: [LocaleConfig](#localeconfig) }</code>
 
 Configure internationalization (i18n) for your site by setting which `locales` are supported.
 
@@ -233,7 +233,15 @@ export default defineConfig({
 });
 ```
 
-#### Locale options
+#### `LocaleConfig`
+
+```ts
+interface LocaleConfig {
+  label: string;
+  lang?: string;
+  dir?: 'ltr' | 'rtl';
+}
+```
 
 You can set the following options for each locale:
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -197,7 +197,7 @@ type SidebarItem = {
 
 **type:** <code>{ \[dir: string\]: [LocaleConfig](#localeconfig) }</code>
 
-Configure internationalization (i18n) for your site by setting which `locales` are supported.
+[Configure internationalization (i18n)](/guides/i18n/) for your site by setting which `locales` are supported.
 
 Each entry should use the directory where that language’s files are saved as the key.
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

As [discussed](https://discord.com/channels/830184174198718474/1126169409648603266) on Discord, this PR adds a few changes to the internationalization documentation:

- Add a definition for the `LocaleConfig` configuration and link to it from the `locales` configuration reference.
- Add link to the internationalization guide from the `locales` configuration reference.
- Add links to the `locales` and `defaultLocale` configuration references from the internationalization guide.

A few notes:

- It has been mentioned that a link inside of `<code>` may not be valid. If I get this right, the inline code element [permitted content](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code#technical_summary) is [phrasing content](https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#phrasing_content) which includes `<a>` if it contains only phrasing content which should be the case here.
- The escaping with a `\` of the brackets in `<code>{ \[dir: string\]: [LocaleConfig](#localeconfig) }</code>` is not mandatory afaiu but avoid some linters, e.g. the one built into VS Code, to complain with a warning about a potentially missing link definition: `No link definition found: 'dir: string'(link.no-such-reference)`.
- These changes should not introduce translation changes for existing translations as I tried to update them all accordingly as it's mostly code and links.
