### PR TITLE
Add Icon Names 

### DIFF
--- a/.changeset/wise-berries-juggle.md
+++ b/.changeset/wise-berries-juggle.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Add missing accessible labels for Codeberg and YouTube social links

--- a/packages/starlight/components/SocialIcons.astro
+++ b/packages/starlight/components/SocialIcons.astro
@@ -10,7 +10,7 @@ const labels: Record<Platform, string> = {
   twitter: 'Twitter',
   mastodon: 'Mastodon',
   codeberg: 'Codeberg',
-  youtube: 'Youtube',  
+  youtube: 'YouTube',  
 };
 
 const links = Object.entries(config.social || {}).filter(([, url]) =>

--- a/packages/starlight/components/SocialIcons.astro
+++ b/packages/starlight/components/SocialIcons.astro
@@ -9,6 +9,8 @@ const labels: Record<Platform, string> = {
   discord: 'Discord',
   twitter: 'Twitter',
   mastodon: 'Mastodon',
+  codeberg: 'Codeberg',
+  youtube: 'Youtube',  
 };
 
 const links = Object.entries(config.social || {}).filter(([, url]) =>


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes

#### Description

- The PR complements the name in the `a `element of the social media icon. This is useful for accessibility. For codeberg I missed this in https://github.com/withastro/starlight/pull/264 (Youtube: https://github.com/withastro/starlight/pull/272)

