### PR TITLE
Fix relative path resolution on Windows

### DIFF
--- a/.changeset/fluffy-lions-yell.md
+++ b/.changeset/fluffy-lions-yell.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fix relative path resolution on Windows

--- a/.changeset/friendly-lobsters-share.md
+++ b/.changeset/friendly-lobsters-share.md
@@ -1,5 +1,0 @@
----
-"@astrojs/starlight": patch
----
-
-Fix relative path resolution on Windows

--- a/packages/starlight/index.ts
+++ b/packages/starlight/index.ts
@@ -6,7 +6,7 @@ import type {
   ViteUserConfig,
 } from 'astro';
 import { spawn } from 'node:child_process';
-import { dirname, relative } from 'node:path';
+import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { starlightAsides } from './integrations/asides';
 import { starlightSitemap } from './integrations/sitemap';
@@ -89,19 +89,19 @@ function vitePluginStarlightUserConfig(
   { root }: AstroConfig
 ): NonNullable<ViteUserConfig['plugins']>[number] {
   const resolveRelativeId = (id: string) =>
-    id.startsWith('.') ? '/' + id : id;
+    id.startsWith('.') ? JSON.stringify(resolve(fileURLToPath(root), id)) : id;
   const modules = {
     'virtual:starlight/user-config': `export default ${JSON.stringify(opts)}`,
     'virtual:starlight/project-context': `export default ${JSON.stringify({
       root,
     })}`,
     'virtual:starlight/user-css': opts.customCss
-      .map((id) => `import "${resolveRelativeId(id)}";`)
+      .map((id) => `import ${resolveRelativeId(id)};`)
       .join(''),
     'virtual:starlight/user-images': opts.logo
       ? 'src' in opts.logo
-        ? `import src from "${resolveRelativeId(opts.logo.src)}"; export const logos = { dark: src, light: src };`
-        : `import dark from "${resolveRelativeId(opts.logo.dark)}"; import light from "${resolveRelativeId(opts.logo.light)}"; export const logos = { dark, light };`
+        ? `import src from ${resolveRelativeId(opts.logo.src)}; export const logos = { dark: src, light: src };`
+        : `import dark from ${resolveRelativeId(opts.logo.dark)}; import light from ${resolveRelativeId(opts.logo.light)}; export const logos = { dark, light };`
       : 'export const logos = {};',
   };
   const resolutionMap = Object.fromEntries(

--- a/packages/starlight/index.ts
+++ b/packages/starlight/index.ts
@@ -89,7 +89,7 @@ function vitePluginStarlightUserConfig(
   { root }: AstroConfig
 ): NonNullable<ViteUserConfig['plugins']>[number] {
   const resolveRelativeId = (id: string) =>
-    id.startsWith('.') ? fileURLToPath(new URL(id, root)) : id;
+    id.startsWith('.') ? '/' + id : id;
   const modules = {
     'virtual:starlight/user-config': `export default ${JSON.stringify(opts)}`,
     'virtual:starlight/project-context': `export default ${JSON.stringify({


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- Closes #331 <!-- Add an issue number if this PR will close it. -->
- Fixes relative path resolution on Windows by relying on Vite to resolve `/./foo` or `/../foo` as if they were relative to the project root.
- Tested in #334 — https://github.com/withastro/starlight/actions/runs/5553362403/jobs/10141818019

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
