### PR TITLE
Fix logo/CSS non-relative path escaping

### DIFF
--- a/.changeset/cold-windows-swim.md
+++ b/.changeset/cold-windows-swim.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fix escaping of non-relative user config file paths for custom CSS and logos

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -18,8 +18,8 @@ export default defineConfig({
     starlight({
       title: 'Starlight',
       logo: {
-        light: './src/assets/logo-light.svg',
-        dark: './src/assets/logo-dark.svg',
+        light: '/src/assets/logo-light.svg',
+        dark: '/src/assets/logo-dark.svg',
         replacesTitle: true,
       },
       editLink: {

--- a/packages/starlight/index.ts
+++ b/packages/starlight/index.ts
@@ -89,7 +89,7 @@ function vitePluginStarlightUserConfig(
   { root }: AstroConfig
 ): NonNullable<ViteUserConfig['plugins']>[number] {
   const resolveRelativeId = (id: string) =>
-    id.startsWith('.') ? JSON.stringify(resolve(fileURLToPath(root), id)) : id;
+    JSON.stringify(id.startsWith('.') ? resolve(fileURLToPath(root), id) : id);
   const modules = {
     'virtual:starlight/user-config': `export default ${JSON.stringify(opts)}`,
     'virtual:starlight/project-context': `export default ${JSON.stringify({


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- Fixes #339 
- We switched to escape import strings with `JSON.stringify()` in #335 but forgot to also use it for non-relative paths resulting in JS like `import /src/style.css` which is invalid. This fixes that by always stringifying whether the path is relative or not.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
