### PR TITLE
Allow to not include site-search component in desired docs (feature)

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -2,6 +2,7 @@
 title: Starlight 🌟 Build documentation sites with Astro
 description: Starlight helps you build beautiful, high-performance documentation websites with Astro.
 template: splash
+showSearch: false
 hero:
   title: Make your docs shine with Starlight
   tagline: Everything you need to build a stellar documentation website. Fast, accessible, and easy-to-use.

--- a/packages/starlight/components/Header.astro
+++ b/packages/starlight/components/Header.astro
@@ -7,18 +7,21 @@ import ThemeSelect from './ThemeSelect.astro';
 
 interface Props {
   locale: string | undefined;
+  showSearch: boolean | undefined
 }
 
-const { locale } = Astro.props;
+const { locale, showSearch } = Astro.props;
 ---
 
 <div class="header flex">
   <SiteTitle {locale} />
-  <Search {locale} />
-  <div class="hidden md:flex right-group">
-    <SocialIcons />
-    <ThemeSelect {locale} />
-    <LanguageSelect {locale} />
+  <div class="subheader">
+    {showSearch && <Search {locale} />}
+    <div class="hidden md:flex right-group" >
+      <SocialIcons />
+      <ThemeSelect {locale} />
+      <LanguageSelect {locale} />
+    </div>
   </div>
 </div>
 
@@ -42,6 +45,7 @@ const { locale } = Astro.props;
     :global(:root:not([data-has-toc])) {
       --__toc-width: 0rem;
     }
+
     .header {
       --__sidebar-width: max(
         0rem,
@@ -55,7 +59,16 @@ const { locale } = Astro.props;
               var(--sl-content-inline-start, 0rem) - var(--sl-content-width)
           ) / 2
       );
+
+      --__sitetitle-width:  max(
+        var(--sl-title-min-width),
+        calc(
+          var(--__sidebar-width) +
+            max(0rem, var(--__main-column-fr) - var(--sl-nav-gap))
+        )
+      );
       display: grid;
+
       grid-template-columns:
         /* 1 (site title): runs up until the main content column’s left edge.  */
         max(
@@ -65,11 +78,25 @@ const { locale } = Astro.props;
               max(0rem, var(--__main-column-fr) - var(--sl-nav-gap))
           )
         )
-        /* 2 (search box): all free space that is available. */
-        1fr
-        /* 3 (right items): use the space that these need. */
-        auto;
+        
+        1fr;
+
       align-content: center;
     }
+
+    .subheader {
+      display: grid;
+
+      grid-template-columns: 
+      /* 2 (search box): all free space that is available. */
+      1fr 
+      /* 3 (right items): use the space that these need. */
+      auto;
+    }
+
+    .subheader > div:only-child {
+      justify-self: self-end;
+    }
+    
   }
 </style>

--- a/packages/starlight/layout/Page.astro
+++ b/packages/starlight/layout/Page.astro
@@ -44,6 +44,7 @@ const tocConfig = !hasSidebar
   : config.tableOfContents;
 const hasToC = Boolean(tocConfig);
 const hasHero = Boolean(entry.data.hero);
+const showSearch = Boolean(entry.data.showSearch);
 ---
 
 <html lang={lang} dir={dir} data-has-toc={hasToC} data-has-sidebar={hasSidebar} data-has-hero={hasHero}>
@@ -82,7 +83,7 @@ const hasHero = Boolean(entry.data.hero);
     <ThemeProvider />
     <SkipLink {locale} />
     <PageFrame {locale} {hasSidebar}>
-      <Header slot="header" {locale} />
+      <Header slot="header" {locale} {showSearch} />
       {hasSidebar && <Sidebar slot="sidebar" {sidebar} {locale} />}
       <TwoColumnContent {hasToC}>
         <RightSidebar slot="right-sidebar" {headings} {locale} {tocConfig} />

--- a/packages/starlight/schema.ts
+++ b/packages/starlight/schema.ts
@@ -61,6 +61,8 @@ export function docsSchema() {
        */
       template: z.enum(['doc', 'splash']).default('doc'),
 
+      showSearch: z.boolean().default(true).describe('Define if the search component should be visible in current doc'),
+
       /** Display a hero section on this page. */
       hero: z
         .object({


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to Starlight code

#### Description

Introduced **showSearch** prop in schemas. It allows a user to "hide" site-search component inside header element. 
Use case: index.mdx (or other docs) now can be more like landing pages than documentation front page.
![image](https://github.com/withastro/starlight/assets/25895065/07f1e066-8c17-4356-b51e-6af83611d7a5)
 