### PR TITLE
Fix page scroll on window resize

### DIFF
--- a/.changeset/lucky-pens-switch.md
+++ b/.changeset/lucky-pens-switch.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fix page scrolling when the window resizes, while the mobile nav is open

--- a/packages/starlight/components/MobileMenuToggle.astro
+++ b/packages/starlight/components/MobileMenuToggle.astro
@@ -92,4 +92,10 @@ const t = useTranslations(Astro.props.locale);
   [data-mobile-menu-expanded] {
     overflow: hidden;
   }
+
+  @media (min-width: 50rem) {
+    [data-mobile-menu-expanded] {
+      overflow: auto;
+    }
+  }
 </style>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

- Changes to Starlight code

#### Description

- Closes #350
- What does this PR change? Allows scrolling when not in a mobile view, with the mobile menu open.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
