### PR TITLE
Fix build warnings when using the TypeScript `verbatimModuleSyntax` compiler option

### DIFF
--- a/.changeset/silver-suits-relate.md
+++ b/.changeset/silver-suits-relate.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fix build warnings when using the TypeScript [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax) compiler option

--- a/packages/starlight/components/Footer.astro
+++ b/packages/starlight/components/Footer.astro
@@ -1,6 +1,6 @@
 ---
 import config from 'virtual:starlight/user-config';
-import { SidebarEntry, getPrevNextLinks } from '../utils/navigation';
+import { type SidebarEntry, getPrevNextLinks } from '../utils/navigation';
 import type { StarlightDocsEntry } from '../utils/routing';
 import type { LocaleData } from '../utils/slugs';
 

--- a/packages/starlight/utils/head.ts
+++ b/packages/starlight/utils/head.ts
@@ -1,4 +1,4 @@
-import { HeadConfig, HeadConfigSchema, HeadUserConfig } from '../schemas/head';
+import { type HeadConfig, HeadConfigSchema, type HeadUserConfig } from '../schemas/head';
 
 const HeadSchema = HeadConfigSchema();
 

--- a/packages/starlight/utils/navigation.ts
+++ b/packages/starlight/utils/navigation.ts
@@ -2,7 +2,7 @@ import { basename, dirname } from 'node:path';
 import config from 'virtual:starlight/user-config';
 import { pathWithBase } from './base';
 import { pickLang } from './i18n';
-import { Route, getLocaleRoutes, routes } from './routing';
+import { type Route, getLocaleRoutes, routes } from './routing';
 import { localeToLang, slugToPathname } from './slugs';
 import type {
   AutoSidebarGroup,

--- a/packages/starlight/utils/routing.ts
+++ b/packages/starlight/utils/routing.ts
@@ -1,8 +1,8 @@
 import type { GetStaticPathsItem } from 'astro';
-import { CollectionEntry, getCollection } from 'astro:content';
+import { type CollectionEntry, getCollection } from 'astro:content';
 import config from 'virtual:starlight/user-config';
 import {
-  LocaleData,
+  type LocaleData,
   localizedId,
   localizedSlug,
   slugToLocaleData,

--- a/packages/starlight/utils/translations.ts
+++ b/packages/starlight/utils/translations.ts
@@ -1,4 +1,4 @@
-import { CollectionEntry, getCollection } from 'astro:content';
+import { type CollectionEntry, getCollection } from 'astro:content';
 import config from 'virtual:starlight/user-config';
 import builtinTranslations from '../translations';
 import { localeToLang } from './slugs';


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to Starlight code

#### Description

I noticed that when building a Starlight website with the TypeScript [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax) compiler option enabled, the build would output various warnings during the `Building static entrypoints...` step:

```
> astro build

01:50:23 PM [content] The "i18n" collection does not have an associated folder in your `content` directory. Make sure the folder exists, or check your content config for typos.
01:50:23 PM [content] Types generated 161ms
01:50:23 PM [build] output target: static
01:50:23 PM [build] Collecting build info...
01:50:23 PM [build] Completed in 329ms.
01:50:23 PM [build] Building static entrypoints...
node_modules/.pnpm/file+..+..+starlight-verbatim+starlight+packages+starlight_astro@2.8.5/node_modules/@astrojs/starlight/utils/routing.ts (2:9) "CollectionEntry" is not exported by "astro:content", imported by "node_modules/.pnpm/file+..+..+starlight-verbatim+starlight+packages+starlight_astro@2.8.5/node_modules/@astrojs/starlight/utils/routing.ts".
node_modules/.pnpm/file+..+..+starlight-verbatim+starlight+packages+starlight_astro@2.8.5/node_modules/@astrojs/starlight/utils/routing.ts (5:2) "LocaleData" is not exported by "node_modules/.pnpm/file+..+..+starlight-verbatim+starlight+packages+starlight_astro@2.8.5/node_modules/@astrojs/starlight/utils/slugs.ts", imported by "node_modules/.pnpm/file+..+..+starlight-verbatim+starlight+packages+starlight_astro@2.8.5/node_modules/@astrojs/starlight/utils/routing.ts".
node_modules/.pnpm/file+..+..+starlight-verbatim+starlight+packages+starlight_astro@2.8.5/node_modules/@astrojs/starlight/utils/navigation.ts (5:9) "Route" is not exported by "node_modules/.pnpm/file+..+..+starlight-verbatim+starlight+packages+starlight_astro@2.8.5/node_modules/@astrojs/starlight/utils/routing.ts", imported by "node_modules/.pnpm/file+..+..+starlight-verbatim+starlight+packages+starlight_astro@2.8.5/node_modules/@astrojs/starlight/utils/navigation.ts".
node_modules/.pnpm/file+..+..+starlight-verbatim+starlight+packages+starlight_astro@2.8.5/node_modules/@astrojs/starlight/utils/translations.ts (1:9) "CollectionEntry" is not exported by "astro:content", imported by "node_modules/.pnpm/file+..+..+starlight-verbatim+starlight+packages+starlight_astro@2.8.5/node_modules/@astrojs/starlight/utils/translations.ts".
node_modules/.pnpm/file+..+..+starlight-verbatim+starlight+packages+starlight_astro@2.8.5/node_modules/@astrojs/starlight/utils/head.ts (1:9) "HeadConfig" is not exported by "node_modules/.pnpm/file+..+..+starlight-verbatim+starlight+packages+starlight_astro@2.8.5/node_modules/@astrojs/starlight/schemas/head.ts", imported by "node_modules/.pnpm/file+..+..+starlight-verbatim+starlight+packages+starlight_astro@2.8.5/node_modules/@astrojs/starlight/utils/head.ts".
node_modules/.pnpm/file+..+..+starlight-verbatim+starlight+packages+starlight_astro@2.8.5/node_modules/@astrojs/starlight/utils/head.ts (1:39) "HeadUserConfig" is not exported by "node_modules/.pnpm/file+..+..+starlight-verbatim+starlight+packages+starlight_astro@2.8.5/node_modules/@astrojs/starlight/schemas/head.ts", imported by "node_modules/.pnpm/file+..+..+starlight-verbatim+starlight+packages+starlight_astro@2.8.5/node_modules/@astrojs/starlight/utils/head.ts".
01:50:25 PM [build] Completed in 1.44s.
```

Note that the build does __not__ fail.

A quick repro using the Starlight starter can be setup with the following steps:

1. Setup a basic Starlight project using `pnpm create astro --template starlight`
2. Build and see that no warnings are output: `pnpm build`
3. Edit the `tsconfig.json` file to add the `verbatimModuleSyntax` compiler option:

```json
{
  "extends": "astro/tsconfigs/strict",
  "compilerOptions": {
    "verbatimModuleSyntax": true
  }
}
```

4. Build again and see the warnings: `pnpm build`

This pull request removes these warnings by adding the `type` modifier to the various `import` statements referenced in the warnings.

To test the changes, I used the repro from above that has the warnings:

1. Use the file protocol in the `package.json` file to use the local version of `@astrojs/starlight` with the fix from this pull request:

```json
"dependencies": {
  "@astrojs/starlight": "file:../starlight/packages/starlight",
  "astro": "2.7.0",
  "sharp": "^0.32.1"
}
```

2. Install with `pnpm i` and build with `pnpm build` to see that the warnings are no longer output.
