### PR TITLE
[docs] Add Troubleshooting to Getting Started

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -129,4 +129,4 @@ Both Starlight [project configuration](/reference/configuration/) and [individua
 
 See the growing list of guides in the sidebar for help adding content and customizing your Starlight site.
 
-If your answer cannot be found in these docs, please visit the [full Astro Docs](https://docs.astro.build) for complete Astro documentation. Your question may be answerd by understanding how Astro works in general, underneath this Starlight theme.
+If your answer cannot be found in these docs, please visit the [full Astro Docs](https://docs.astro.build) for complete Astro documentation. Your question may be answered by understanding how Astro works in general, underneath this Starlight theme.

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -122,3 +122,11 @@ yarn upgrade @astrojs/starlight --latest
 </Tabs>
 
 You can see a full list of the changes made in each release in [the Starlight changelog](https://github.com/withastro/starlight/blob/main/packages/starlight/CHANGELOG.md).
+
+## Troubleshooting Starlight
+
+Both Starlight [project configuration](/reference/configuration/) and [individual page frontmatter configuration](/reference/frontmatter/) information is available in the Reference section of this site. Use these pages to ensure that your Starlight site is configured and functioning properly.
+
+See the growing list of guides in the sidebar for help adding content and customizing your Starlight site.
+
+If your answer cannot be found in these docs, please visit the [full Astro Docs](https://docs.astro.build) for complete Astro documentation. Your question may be answerd by understanding how Astro works in general, underneath this Starlight theme.

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -130,3 +130,5 @@ Both Starlight [project configuration](/reference/configuration/) and [individua
 See the growing list of guides in the sidebar for help adding content and customizing your Starlight site.
 
 If your answer cannot be found in these docs, please visit the [full Astro Docs](https://docs.astro.build) for complete Astro documentation. Your question may be answered by understanding how Astro works in general, underneath this Starlight theme.
+
+You can also get help in the [Astro Discord](https://astro.build/chat/) from our active, friendly community! You can post questions in our `#support` forum or visit our dedicated `#starlight` channel to discuss current development and more!


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content


#### Description

Adds a "Troubleshooting" section to the bottom of the Getting Started page, which really is my way of sneaking in a prominent link to Astro Docs.

The section briefly explains the other sections (Reference - make sure your project is literally configured and functioning; Guides - to add content and customize your site) and then emphasizes that you might need to visit Astro Docs for content not covered here, in this documentation for this one particular Astro theme.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
