### PR TITLE
Fix: Site title/logo overflow

### DIFF
--- a/.changeset/fresh-scissors-relax.md
+++ b/.changeset/fresh-scissors-relax.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fix visual overflow for wide logos

--- a/packages/starlight/components/Header.astro
+++ b/packages/starlight/components/Header.astro
@@ -57,14 +57,11 @@ const { locale } = Astro.props;
       );
       display: grid;
       grid-template-columns:
-        /* 1 (site title): runs up until the main content column’s left edge.  */
-        max(
-          var(--sl-title-min-width),
-          calc(
+        /* 1 (site title): runs up until the main content column’s left edge or the width of the title, whichever is the largest  */
+        minmax(calc(
             var(--__sidebar-width) +
               max(0rem, var(--__main-column-fr) - var(--sl-nav-gap))
-          )
-        )
+          ), auto)
         /* 2 (search box): all free space that is available. */
         1fr
         /* 3 (right items): use the space that these need. */

--- a/packages/starlight/style/props.css
+++ b/packages/starlight/style/props.css
@@ -96,7 +96,6 @@
   --sl-nav-height: 3.5rem;
   --sl-nav-pad-x: 1rem;
   --sl-nav-pad-y: 0.75rem;
-  --sl-title-min-width: 10rem;
   --sl-mobile-toc-height: 3rem;
   --sl-sidebar-width: 18.75rem;
   --sl-sidebar-pad-x: 1rem;


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- When you have along site title and/or logo it would overflow under the searchbar. This makes it where it does a minmax based on the sidebar width or the content's intrinsic size (screenshots below)

Before:
<img width="1299" alt="Screenshot 2023-07-21 at 13 41 42" src="https://github.com/withastro/starlight/assets/15347255/0fc90cfd-1bcc-4a71-9e0f-44e9bc3eebc6">

After:
<img width="1464" alt="Screenshot 2023-07-21 at 13 40 53" src="https://github.com/withastro/starlight/assets/15347255/ff09e167-06de-4771-adb8-88f692568297">


<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
