### PR TITLE
Fix Nested content css styles

### DIFF
--- a/.changeset/happy-files-buy.md
+++ b/.changeset/happy-files-buy.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fix nested elements in markdown content

--- a/packages/starlight/components/MarkdownContent.astro
+++ b/packages/starlight/components/MarkdownContent.astro
@@ -2,7 +2,7 @@
 
 <style>
   .content
-    > :global(
+    :global(
       :not(a, strong, em, del, span, input)
         + :not(a, strong, em, del, span, input, :where(.not-content *))
     ) {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- Fixes an issue where the CSS property `margin-top` isn't applied to content within imported components

Before:
<img width="757" alt="Screenshot 2023-07-23 at 16 00 39" src="https://github.com/withastro/starlight/assets/15347255/c1d61c24-b942-4271-b1cd-25e576b96073">

After:
<img width="757" alt="Screenshot 2023-07-23 at 16 00 15" src="https://github.com/withastro/starlight/assets/15347255/645f623f-e129-40f3-b2e3-b8738d7733f7">



<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
