### PR TITLE
Fix: Prevent keypress from firing on inputs

### DIFF
--- a/.changeset/quick-peas-deny.md
+++ b/.changeset/quick-peas-deny.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Prevent keydown event from firing on input elements

--- a/packages/starlight/components/Search.astro
+++ b/packages/starlight/components/Search.astro
@@ -95,11 +95,16 @@ const pagefindTranslations = {
       closeBtn.addEventListener('click', closeModal);
 
       // Listen for `/` and `cmd + k` keyboard shortcuts.
+      const inputs = ["input", "select", "textarea"];
+      const isInput =
+        document.activeElement &&
+        inputs.indexOf(document.activeElement.tagName.toLowerCase()) !== -1;
+      
       window.addEventListener('keydown', (e) => {
         if (e.metaKey === true && e.key === 'k') {
           dialog.open ? closeModal() : openModal();
           e.preventDefault();
-        } else if (e.key === '/' && !dialog.open) {
+        } else if (e.key === '/' && !dialog.open && !isInput) {
           openModal();
           e.preventDefault();
         }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

Currently, when `/` is pressed, regardless of whether the active element is an input or not, the search modal will pop up. If the input field requires things like a URL, this is a disruptive behaviour. This PR adds an input check on the active element, and if it is an input, the search modal will not pop up.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
