### PR TITLE
[docs] Include link to Astro Assets page from `authoring-content`

### DIFF
--- a/docs/src/content/docs/guides/authoring-content.md
+++ b/docs/src/content/docs/guides/authoring-content.md
@@ -29,7 +29,7 @@ You can highlight `inline code` with backticks.
 
 ## Images
 
-Images in Starlight use Astro's built-in optimized asset support.
+Images in Starlight use [Astro’s built-in optimized asset support](https://docs.astro.build/en/guides/assets/).
 
 Markdown and MDX support the Markdown syntax for displaying images that includes alt-text for screen readers and assistive technology.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->
- Changes or translations of Starlight docs site content

#### Description

Does not change existing text, but makes it a link back to Astro docs so that it's clear that Starlight is using experimental assets.

`[Astro’s built-in optimized asset support](https://docs.astro.build/en/guides/assets/)`

NB: This link will need to be updated when this page is updated for v3, but Astro Docs will have redirects in place, so less urgent.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
