### PR TITLE
Clip site title when text overflows

### DIFF
--- a/.changeset/clean-camels-love.md
+++ b/.changeset/clean-camels-love.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fix site title overflow bug for longer titles on narrow screens

--- a/packages/starlight/components/SiteTitle.astro
+++ b/packages/starlight/components/SiteTitle.astro
@@ -58,6 +58,8 @@ const href = pathWithBase(Astro.props.locale || '/');
 <style>
 	.site-title {
 		justify-self: flex-start;
+		max-width: 100%;
+		overflow: hidden;
 		align-items: center;
 		gap: var(--sl-nav-gap);
 		font-size: var(--sl-text-h4);


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- Clips the site title text when it gets too long and overflows (current behaviour is that it is visible behind other elements in the site header)
- Fixes an issue reported on Discord: https://discord.com/channels/830184174198718474/1070481941863878697/1133543263387791491

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
