### PR TITLE
Set tab-size on content code blocks

### DIFF
--- a/.changeset/purple-apples-ring.md
+++ b/.changeset/purple-apples-ring.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Set `tab-size: 2` on content code blocks to override default browser value of `8`

--- a/packages/starlight/components/MarkdownContent.astro
+++ b/packages/starlight/components/MarkdownContent.astro
@@ -90,6 +90,7 @@
 		border: 1px solid var(--sl-color-gray-5);
 		padding: 0.75rem 1rem;
 		font-size: var(--sl-text-code);
+		tab-size: 2;
 	}
 
 	.content :global(pre code:not(:where(.not-content *))) {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- Small styling tweak so that tabs aren’t as wide in code blocks. Browser defaults are often 1 tab == 8 spaces, which can be a lot in a content context. This PR reduces that to 2.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
