### PR TITLE
Increase Markdown table border contrast

### DIFF
--- a/.changeset/itchy-bats-tease.md
+++ b/.changeset/itchy-bats-tease.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Increase Markdown table border contrast

--- a/packages/starlight/components/MarkdownContent.astro
+++ b/packages/starlight/components/MarkdownContent.astro
@@ -112,7 +112,7 @@
 		background-color: var(--sl-color-gray-7, var(--sl-color-gray-6));
 	}
 	.content :global(:is(th, td):not(:where(.not-content *))) {
-		border: 1px solid var(--sl-color-hairline);
+		border: 1px solid var(--sl-color-hairline-light);
 		padding: 0.375rem 0.8125rem;
 	}
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to Starlight code

#### Description

- Closes #390.

This pull request increases the contrast of the Markdown table borders:

<img width="742" alt="SCR-20230801-jwie" src="https://github.com/withastro/starlight/assets/494699/deeba1cc-ac42-4298-85cb-aedfc2d52906">

<img width="742" alt="SCR-20230801-jwju" src="https://github.com/withastro/starlight/assets/494699/747e6df3-5f72-4096-9169-a278bce84211">

More context and screenshots are available in #390.