### PR TITLE
Prevent repeated table of contents mark on mobile

### DIFF
--- a/.changeset/old-ghosts-appear.md
+++ b/.changeset/old-ghosts-appear.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Prevent repeated table of contents mark on mobile

--- a/packages/starlight/components/TableOfContents/TableOfContentsList.astro
+++ b/packages/starlight/components/TableOfContents/TableOfContentsList.astro
@@ -74,5 +74,8 @@ const { toc, isMobile = false, depth = 0 } = Astro.props;
 		/* Check mark SVG icon */
 		-webkit-mask-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxNCAxNCc+PHBhdGggZD0nTTEwLjkxNCA0LjIwNmEuNTgzLjU4MyAwIDAgMC0uODI4IDBMNS43NCA4LjU1NyAzLjkxNCA2LjcyNmEuNTk2LjU5NiAwIDAgMC0uODI4Ljg1N2wyLjI0IDIuMjRhLjU4My41ODMgMCAwIDAgLjgyOCAwbDQuNzYtNC43NmEuNTgzLjU4MyAwIDAgMCAwLS44NTdaJy8+PC9zdmc+Cg==');
 		mask-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxNCAxNCc+PHBhdGggZD0nTTEwLjkxNCA0LjIwNmEuNTgzLjU4MyAwIDAgMC0uODI4IDBMNS43NCA4LjU1NyAzLjkxNCA2LjcyNmEuNTk2LjU5NiAwIDAgMC0uODI4Ljg1N2wyLjI0IDIuMjRhLjU4My41ODMgMCAwIDAgLjgyOCAwbDQuNzYtNC43NmEuNTgzLjU4MyAwIDAgMCAwLS44NTdaJy8+PC9zdmc+Cg==');
+		-webkit-mask-repeat: no-repeat;
+		mask-repeat: no-repeat;
+		flex-shrink: 0;
 	}
 </style>


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to Starlight code

#### Description

When having a fairly long title in a page and browsing it on a mobile device, the table of contents mark will shrink and also repeat:

<img width="744" alt="SCR-20230801-otwx" src="https://github.com/withastro/starlight/assets/494699/cba6e97a-39c5-44b0-bb2b-6f76a022e434">

With a shorter title:

<img width="739" alt="SCR-20230801-oubg" src="https://github.com/withastro/starlight/assets/494699/52c8e38e-ea45-48b5-9b9d-cdcbe12d3396">

This pull request prevents this behavior:

<img width="739" alt="SCR-20230801-ouvp" src="https://github.com/withastro/starlight/assets/494699/81f106b7-9730-4269-9a93-9b96c304dbca">

No changes for a shorter title:

<img width="739" alt="SCR-20230801-ouwx" src="https://github.com/withastro/starlight/assets/494699/0ccba42d-0703-40aa-905f-7a59c98c832c">