### PR TITLE
Sidebar current page highlight with trailing slashes

### DIFF
--- a/.changeset/fifty-trees-approve.md
+++ b/.changeset/fifty-trees-approve.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fix current page highlight in sidebar for URLs with no trailing slash

--- a/packages/starlight/__tests__/basics/navigation.test.ts
+++ b/packages/starlight/__tests__/basics/navigation.test.ts
@@ -63,6 +63,13 @@ describe('getSidebar', () => {
 		}
 	});
 
+	test('ignore trailing slashes when marking current path with isCurrent', () => {
+		const pathWithoutTrailingSlash = '/environmental-impact';
+		const items = flattenSidebar(getSidebar(pathWithoutTrailingSlash, undefined));
+		const currentItems = items.filter((item) => item.type === 'link' && item.isCurrent);
+		expect(currentItems).toMatchObject([{ href: `${pathWithoutTrailingSlash}/`, type: 'link' }]);
+	});
+
 	test('nests files in subdirectory in group when autogenerating', () => {
 		const sidebar = getSidebar('/', undefined);
 		expect(sidebar.every((item) => item.type === 'group' || !item.href.startsWith('/guides/')));

--- a/packages/starlight/utils/base.ts
+++ b/packages/starlight/utils/base.ts
@@ -1,20 +1,15 @@
+import { stripLeadingAndTrailingSlashes, stripTrailingSlash } from './path';
+
 const base = stripTrailingSlash(import.meta.env.BASE_URL);
 
 /** Get the a root-relative URL path with the site’s `base` prefixed. */
 export function pathWithBase(path: string) {
-	path = stripLeadingSlash(stripTrailingSlash(path));
+	path = stripLeadingAndTrailingSlashes(path);
 	return path ? base + '/' + path + '/' : base + '/';
 }
 
 /** Get the a root-relative file URL path with the site’s `base` prefixed. */
 export function fileWithBase(path: string) {
-	path = stripLeadingSlash(stripTrailingSlash(path));
+	path = stripLeadingAndTrailingSlashes(path);
 	return path ? base + '/' + path : base;
-}
-
-function stripLeadingSlash(path: string) {
-	return path.replace(/^\//, '');
-}
-function stripTrailingSlash(path: string) {
-	return path.replace(/\/$/, '');
 }

--- a/packages/starlight/utils/navigation.ts
+++ b/packages/starlight/utils/navigation.ts
@@ -6,6 +6,7 @@ import { pickLang } from './i18n';
 import { getLocaleRoutes, type Route } from './routing';
 import { localeToLang, slugToPathname } from './slugs';
 import type { AutoSidebarGroup, SidebarItem, SidebarLinkItem } from './user-config';
+import { ensureLeadingAndTrailingSlashes, ensureTrailingSlash } from './path';
 
 const DirKey = Symbol('DirKey');
 
@@ -97,19 +98,6 @@ function groupFromAutogenerateConfig(
 
 /** Check if a string starts with one of `http://` or `https://`. */
 const isAbsolute = (link: string) => /^https?:\/\//.test(link);
-
-/** Ensure the passed path ends with a trailing slash. */
-function ensureTrailingSlash(href: string): string {
-	if (href[href.length - 1] !== '/') href += '/';
-	return href;
-}
-
-/** Ensure the passed path starts and ends with trailing slashes. */
-function ensureLeadingAndTrailingSlashes(href: string): string {
-	if (href[0] !== '/') href = '/' + href;
-	href = ensureTrailingSlash(href);
-	return href;
-}
 
 /** Create a link entry from a user config object. */
 function linkFromConfig(

--- a/packages/starlight/utils/navigation.ts
+++ b/packages/starlight/utils/navigation.ts
@@ -98,10 +98,16 @@ function groupFromAutogenerateConfig(
 /** Check if a string starts with one of `http://` or `https://`. */
 const isAbsolute = (link: string) => /^https?:\/\//.test(link);
 
+/** Ensure the passed path ends with a trailing slash. */
+function ensureTrailingSlash(href: string): string {
+	if (href[href.length - 1] !== '/') href += '/';
+	return href;
+}
+
 /** Ensure the passed path starts and ends with trailing slashes. */
 function ensureLeadingAndTrailingSlashes(href: string): string {
 	if (href[0] !== '/') href = '/' + href;
-	if (href[href.length - 1] !== '/') href += '/';
+	href = ensureTrailingSlash(href);
 	return href;
 }
 
@@ -124,7 +130,7 @@ function linkFromConfig(
 /** Create a link entry. */
 function makeLink(href: string, label: string, currentPathname: string): Link {
 	if (!isAbsolute(href)) href = pathWithBase(href);
-	const isCurrent = href === currentPathname;
+	const isCurrent = href === ensureTrailingSlash(currentPathname);
 	return { type: 'link', label, href, isCurrent };
 }
 

--- a/packages/starlight/utils/path.ts
+++ b/packages/starlight/utils/path.ts
@@ -1,0 +1,37 @@
+/** Ensure the passed path starts with a leading slash. */
+export function ensureLeadingSlash(href: string): string {
+	if (href[0] !== '/') href = '/' + href;
+	return href;
+}
+
+/** Ensure the passed path ends with a trailing slash. */
+export function ensureTrailingSlash(href: string): string {
+	if (href[href.length - 1] !== '/') href += '/';
+	return href;
+}
+
+/** Ensure the passed path starts and ends with slashes. */
+export function ensureLeadingAndTrailingSlashes(href: string): string {
+	href = ensureLeadingSlash(href);
+	href = ensureTrailingSlash(href);
+	return href;
+}
+
+/** Ensure the passed path does not start with a leading slash. */
+export function stripLeadingSlash(href: string) {
+	if (href[0] === '/') href = href.slice(1);
+	return href;
+}
+
+/** Ensure the passed path does not end with a trailing slash. */
+export function stripTrailingSlash(href: string) {
+	if (href[href.length - 1] === '/') href = href.slice(0, -1);
+	return href;
+}
+
+/** Ensure the passed path does not start and end with slashes. */
+export function stripLeadingAndTrailingSlashes(href: string): string {
+	href = stripLeadingSlash(href);
+	href = stripTrailingSlash(href);
+	return href;
+}


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to Starlight code

#### Description

As [discussed](https://discord.com/channels/830184174198718474/1070481941863878697/1136652592026497024) on Discord, this PR fixes the current page highlight in the sidebar for URLs with no trailing slash.

This [Discord thread](https://discord.com/channels/830184174198718474/1136696964281532417) also discusses why this PR does not handle Astro `trailingSlash` and `build.format` options for the sidebar `isCurrent` check which is purposefully lenient. These options should be handled in #207.

My initial suggestion on Discord was to use `const isCurrent = href === currentPathname.replace(/\/?$/, '/');` but instead I used the same approach as the existing `ensureLeadingAndTrailingSlashes()` function for multiple reasons:

- Consistency
- Might be slightly easier to understand for someone not used to regex
- According to this [bench](https://jsperf.app/kivusa/1/preview), this is faster. Not sure it's properly benchmarked or if it even matters in this case but might as well use the faster option ^^
