### PR TITLE
Ignore type error in integration

### DIFF
--- a/.changeset/tough-balloons-nail.md
+++ b/.changeset/tough-balloons-nail.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fix type error for downstream `tsc` users

--- a/docs/src/components/icons-list.astro
+++ b/docs/src/components/icons-list.astro
@@ -19,10 +19,10 @@ const icons = Object.keys(Icons) as (keyof typeof Icons)[];
 </div>
 
 <script>
-	const icons = document.querySelectorAll('.icon-preview');
+	const icons = document.querySelectorAll<HTMLButtonElement>('.icon-preview');
 	icons.forEach((icon) => {
 		icon.addEventListener('click', () => {
-			const iconName = icon.dataset.name;
+			const iconName = icon.dataset.name!;
 			const copiedValue = `<Icon name="${iconName}" />`;
 			navigator.clipboard.writeText(copiedValue);
 

--- a/docs/src/components/internal/file-tree-icons.ts
+++ b/docs/src/components/internal/file-tree-icons.ts
@@ -730,14 +730,12 @@ const icons = rawIcons as unknown as {
 };
 
 const getDetails = (fileName: string): IconDetails => {
-	if (definitions.files[fileName]) {
-		return definitions.files[fileName];
-	}
+	const details = definitions.files[fileName];
+	if (details) return details;
 	let extension = fileName.slice(fileName.indexOf('.'));
 	while (extension !== '') {
-		if (definitions.extensions[extension]) {
-			return definitions.extensions[extension];
-		}
+		const details = definitions.extensions[extension];
+		if (details) return details;
 		// look for next "."
 		extension = extension.slice(1);
 		extension = extension.slice(extension.indexOf('.'));

--- a/packages/starlight/index.ts
+++ b/packages/starlight/index.ts
@@ -44,7 +44,11 @@ export default function StarlightIntegration(opts: StarlightUserConfig): AstroIn
 							config.markdown.shikiConfig.theme !== 'github-dark' ? {} : { theme: 'css-variables' },
 					},
 					build: { inlineStylesheets: 'auto' },
-					experimental: { assets: true, inlineStylesheets: 'auto' },
+					experimental: {
+						assets: true,
+						// @ts-ignore - Needed for older versions of Astro, but an error since astro@2.6.0
+						inlineStylesheets: 'auto',
+					},
 				};
 				updateConfig(newConfig);
 			},


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

Fixes an (intentional) type error in the Starlight integration (by explicitly ignoring it). The code that errors is required to support versions of Astro below v2.6, but can be picked up as an error by users running `tsc` in some circumstances.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
