### PR TITLE
Fix issue with nested `<Tabs>` components

### DIFF
--- a/.changeset/wise-boats-flow.md
+++ b/.changeset/wise-boats-flow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fix issue with nested `<Tabs>` components

--- a/packages/starlight/user-components/Tabs.astro
+++ b/packages/starlight/user-components/Tabs.astro
@@ -77,7 +77,7 @@ const { html, panels } = processPanels(panelHtml);
 			super();
 			const tablist = this.querySelector<HTMLUListElement>('[role="tablist"]')!;
 			this.tabs = [...tablist.querySelectorAll<HTMLAnchorElement>('[role="tab"]')];
-			this.panels = [...this.querySelectorAll<HTMLElement>('[role="tabpanel"]')];
+			this.panels = [...this.querySelectorAll<HTMLElement>(':scope > [role="tabpanel"]')];
 
 			this.tabs.forEach((tab, i) => {
 				// Handle clicks for mouse users


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to Starlight code

#### Description

This pull request fixes an issue [reported](https://discord.com/channels/830184174198718474/1070481941863878697/1138524019361075322) on Discord regarding nested tabs.

The panels `hidden` property was not being set correctly due to the query selector matching all nested panels instead of just the direct children.

I updated it to use the [:scope CSS pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:scope#direct_children) to only match the direct children.

I don't think we have a proper way to test this yet so here is a video of a manual test:

https://github.com/withastro/starlight/assets/494699/0c89c448-0daf-4b74-a8b2-c57871504f43

