### PR TITLE
Run size limit checks against basics example

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -25,5 +25,5 @@ jobs:
         uses: andresz1/size-limit-action@dd31dce7dcc72a041fd3e49abf0502b13fc4ce05
         with:
           github_token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
-          directory: docs/
+          build_script: 'build:examples'
           package_manager: pnpm

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "start-server-and-test preview http://localhost:3000 pa11y",
     "pa11y": "pa11y-ci --sitemap 'http://localhost:3000/sitemap-index.xml' --sitemap-find 'https://starlight.astro.build' --sitemap-replace 'http://localhost:3000'",
-    "size": "size-limit",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",
@@ -19,31 +18,12 @@
     "sharp": "^0.32.3"
   },
   "devDependencies": {
-    "@size-limit/file": "^8.2.4",
     "hast-util-from-html": "^1.0.2",
     "hast-util-to-string": "^2.0.0",
     "hastscript": "^7.2.0",
     "pa11y-ci": "^3.0.1",
     "rehype": "^12.0.1",
-    "size-limit": "^8.2.4",
     "start-server-and-test": "^2.0.0",
     "unist-util-visit": "^4.1.2"
-  },
-  "size-limit": [
-    {
-      "name": "/index.html",
-      "path": "dist/index.html",
-      "limit": "14 kB"
-    },
-    {
-      "name": "/_astro/*.js",
-      "path": "dist/_astro/*.js",
-      "limit": "20 kB"
-    },
-    {
-      "name": "/_astro/*.css",
-      "path": "dist/_astro/*.css",
-      "limit": "10 kB"
-    }
-  ]
+  }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@astrojs/starlight": "workspace:*",
-    "astro": "^2.10.1",
+    "astro": "^2.10.4",
     "sharp": "^0.32.3"
   },
   "devDependencies": {

--- a/examples/basics/package.json
+++ b/examples/basics/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.6.1",
-    "astro": "^2.10.1",
+    "astro": "^2.10.4",
     "sharp": "^0.32.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
+    "size": "size-limit",
     "version": "pnpm changeset version && pnpm i --no-frozen-lockfile",
     "format": "prettier -w --cache --plugin prettier-plugin-astro ."
   },
@@ -11,9 +12,28 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.1",
+    "@size-limit/file": "^8.2.4",
     "astro": "^2.10.1",
     "prettier": "^3.0.0",
-    "prettier-plugin-astro": "^0.11.0"
+    "prettier-plugin-astro": "^0.11.0",
+    "size-limit": "^8.2.4"
   },
-  "packageManager": "pnpm@8.2.0"
+  "packageManager": "pnpm@8.2.0",
+  "size-limit": [
+    {
+      "name": "/index.html",
+      "path": "examples/basics/dist/index.html",
+      "limit": "14 kB"
+    },
+    {
+      "name": "/_astro/*.js",
+      "path": "examples/basics/dist/_astro/*.js",
+      "limit": "20 kB"
+    },
+    {
+      "name": "/_astro/*.css",
+      "path": "examples/basics/dist/_astro/*.css",
+      "limit": "10 kB"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.1",
     "@size-limit/file": "^8.2.4",
-    "astro": "^2.10.1",
+    "astro": "^2.10.4",
     "prettier": "^3.0.0",
     "prettier-plugin-astro": "^0.11.0",
     "size-limit": "^8.2.4"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
+    "build:examples": "pnpm --filter @example/* build",
     "size": "size-limit",
     "version": "pnpm changeset version && pnpm i --no-frozen-lockfile",
     "format": "prettier -w --cache --plugin prettier-plugin-astro ."

--- a/packages/starlight/package.json
+++ b/packages/starlight/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@types/node": "^18.16.19",
     "@vitest/coverage-v8": "^0.33.0",
-    "astro": "^2.10.1",
+    "astro": "^2.10.4",
     "vitest": "^0.33.0"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.26.1
         version: 2.26.1
+      '@size-limit/file':
+        specifier: ^8.2.4
+        version: 8.2.4(size-limit@8.2.4)
       astro:
         specifier: ^2.10.1
         version: 2.10.1(sharp@0.32.3)
@@ -23,6 +26,9 @@ importers:
       prettier-plugin-astro:
         specifier: ^0.11.0
         version: 0.11.0
+      size-limit:
+        specifier: ^8.2.4
+        version: 8.2.4
 
   docs:
     dependencies:
@@ -36,9 +42,6 @@ importers:
         specifier: ^0.32.3
         version: 0.32.3
     devDependencies:
-      '@size-limit/file':
-        specifier: ^8.2.4
-        version: 8.2.4(size-limit@8.2.4)
       hast-util-from-html:
         specifier: ^1.0.2
         version: 1.0.2
@@ -54,9 +57,6 @@ importers:
       rehype:
         specifier: ^12.0.1
         version: 12.0.1
-      size-limit:
-        specifier: ^8.2.4
-        version: 8.2.4
       start-server-and-test:
         specifier: ^2.0.0
         version: 2.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^8.2.4
         version: 8.2.4(size-limit@8.2.4)
       astro:
-        specifier: ^2.10.1
-        version: 2.10.1(sharp@0.32.3)
+        specifier: ^2.10.4
+        version: 2.10.4(sharp@0.32.3)
       prettier:
         specifier: ^3.0.0
         version: 3.0.0
@@ -36,8 +36,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/starlight
       astro:
-        specifier: ^2.10.1
-        version: 2.10.1(sharp@0.32.3)
+        specifier: ^2.10.4
+        version: 2.10.4(sharp@0.32.3)
       sharp:
         specifier: ^0.32.3
         version: 0.32.3
@@ -100,8 +100,8 @@ importers:
         specifier: ^0.6.1
         version: link:../../packages/starlight
       astro:
-        specifier: ^2.10.1
-        version: 2.10.1(sharp@0.32.3)
+        specifier: ^2.10.4
+        version: 2.10.4(sharp@0.32.3)
       sharp:
         specifier: ^0.32.3
         version: 0.32.3
@@ -110,7 +110,7 @@ importers:
     dependencies:
       '@astrojs/mdx':
         specifier: ^0.19.7
-        version: 0.19.7(astro@2.10.1)
+        version: 0.19.7(astro@2.10.4)
       '@astrojs/sitemap':
         specifier: ^1.3.3
         version: 1.3.3
@@ -161,8 +161,8 @@ importers:
         specifier: ^0.33.0
         version: 0.33.0(vitest@0.33.0)
       astro:
-        specifier: ^2.10.1
-        version: 2.10.1(@types/node@18.16.19)
+        specifier: ^2.10.4
+        version: 2.10.4(@types/node@18.16.19)
       vitest:
         specifier: ^0.33.0
         version: 0.33.0
@@ -200,13 +200,13 @@ packages:
       vscode-languageserver-types: 3.17.3
       vscode-uri: 3.0.7
 
-  /@astrojs/markdown-remark@2.2.1(astro@2.10.1):
+  /@astrojs/markdown-remark@2.2.1(astro@2.10.4):
     resolution: {integrity: sha512-VF0HRv4GpC1XEMLnsKf6jth7JSmlt9qpqP0josQgA2eSpCIAC/Et+y94mgdBIZVBYH/yFnMoIxgKVe93xfO2GA==}
     peerDependencies:
       astro: ^2.5.0
     dependencies:
       '@astrojs/prism': 2.1.2
-      astro: 2.10.1(sharp@0.32.3)
+      astro: 2.10.4(sharp@0.32.3)
       github-slugger: 1.5.0
       import-meta-resolve: 2.2.2
       rehype-raw: 6.1.1
@@ -222,11 +222,11 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@astrojs/mdx@0.19.7(astro@2.10.1):
+  /@astrojs/mdx@0.19.7(astro@2.10.4):
     resolution: {integrity: sha512-mfEbBD7oi8yBHhcJucEjnrquREkJ3os+jioURP8BR2B8tOV2rV2j8trvmLUgfS+P/+HevGObxCTjcRYxn6T7eg==}
     engines: {node: '>=16.12.0'}
     dependencies:
-      '@astrojs/markdown-remark': 2.2.1(astro@2.10.1)
+      '@astrojs/markdown-remark': 2.2.1(astro@2.10.4)
       '@astrojs/prism': 2.1.2
       '@mdx-js/mdx': 2.3.0
       acorn: 8.9.0
@@ -1656,8 +1656,8 @@ packages:
     hasBin: true
     dev: false
 
-  /astro@2.10.1(@types/node@18.16.19):
-    resolution: {integrity: sha512-t3y9laRaOZTAu6omVpI5x/wE80t2yTCWO/UTCPJYAYy2Aoi+snupwk8ZFBLgVd0lwO7KhjRKA0pUScfkn3bnXw==}
+  /astro@2.10.4(@types/node@18.16.19):
+    resolution: {integrity: sha512-6MQ2E25tvHFNVgZ2uaNm33w2DKTyurlDLU0UUcdnAxVQwldDD8Qq8KDHm+nBx1CAWycjdbjJi9VQVvX2TOCMeQ==}
     engines: {node: '>=16.12.0', npm: '>=6.14.0'}
     hasBin: true
     peerDependencies:
@@ -1669,7 +1669,7 @@ packages:
       '@astrojs/compiler': 1.8.0
       '@astrojs/internal-helpers': 0.1.2
       '@astrojs/language-server': 1.0.4
-      '@astrojs/markdown-remark': 2.2.1(astro@2.10.1)
+      '@astrojs/markdown-remark': 2.2.1(astro@2.10.4)
       '@astrojs/telemetry': 2.1.1
       '@astrojs/webapi': 2.2.0
       '@babel/core': 7.22.5
@@ -1735,8 +1735,8 @@ packages:
       - terser
     dev: true
 
-  /astro@2.10.1(sharp@0.32.3):
-    resolution: {integrity: sha512-t3y9laRaOZTAu6omVpI5x/wE80t2yTCWO/UTCPJYAYy2Aoi+snupwk8ZFBLgVd0lwO7KhjRKA0pUScfkn3bnXw==}
+  /astro@2.10.4(sharp@0.32.3):
+    resolution: {integrity: sha512-6MQ2E25tvHFNVgZ2uaNm33w2DKTyurlDLU0UUcdnAxVQwldDD8Qq8KDHm+nBx1CAWycjdbjJi9VQVvX2TOCMeQ==}
     engines: {node: '>=16.12.0', npm: '>=6.14.0'}
     hasBin: true
     peerDependencies:
@@ -1748,7 +1748,7 @@ packages:
       '@astrojs/compiler': 1.8.0
       '@astrojs/internal-helpers': 0.1.2
       '@astrojs/language-server': 1.0.4
-      '@astrojs/markdown-remark': 2.2.1(astro@2.10.1)
+      '@astrojs/markdown-remark': 2.2.1(astro@2.10.4)
       '@astrojs/telemetry': 2.1.1
       '@astrojs/webapi': 2.2.0
       '@babel/core': 7.22.5


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Something else!

#### Description

Our size-limit CI currently checks the `docs/dist/_astro/` output for total JS & CSS size, but this makes it tricky for us to add things like #470 as one-off components can breach our budget. As we only really want to ensure a small bundle _baseline_ size, it makes more sense to test against our example projects than docs.

This PR switches across to testing the basics example — unlocked just in time by https://github.com/withastro/astro/pull/7983

(I think this PR will like fail in CI because it tries to run the same script on the PR branch and on `main`, but the required script isn’t on `main` yet.)

For the record a comparison of a recent run for docs on `main` currently and the new results running against the basics example:

|  | docs | basics |
|---|---|---|
| `/index.html` | 13.49 kB | 9.59 kB |
| `/_astro/*.js` | 16.94 kB | 16.23 kB |
| `/_astro/*.css` | 8.75 kB | 8.56 kB |

As expected, the basics is smaller, but only slightly apart from the home page which has less content and no language switcher markup.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
