### PR TITLE
Update note aside color contrast

### DIFF
--- a/packages/starlight/style/props.css
+++ b/packages/starlight/style/props.css
@@ -19,8 +19,8 @@
 	--sl-color-green: hsl(var(--sl-hue-green), 82%, 63%);
 	--sl-color-green-high: hsl(var(--sl-hue-green), 82%, 80%);
 	--sl-hue-blue: 234;
-	--sl-color-blue-low: hsl(var(--sl-hue-blue), 54%, 20%);
-	--sl-color-blue: hsl(var(--sl-hue-blue), 100%, 60%);
+	--sl-color-blue-low: hsl(var(--sl-hue-blue), 45%, 20%);
+	--sl-color-blue: hsl(var(--sl-hue-blue), 70%, 60%);
 	--sl-color-blue-high: hsl(var(--sl-hue-blue), 100%, 87%);
 	--sl-hue-purple: 281;
 	--sl-color-purple-low: hsl(var(--sl-hue-purple), 39%, 22%);


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- What does this PR change? Changes the color contrast of note aside. The current note component had colors which were very difficult on the eyes on dark mode. This update tones it down a little.
- Did you change something visual? Yes

Before:
![image](https://github.com/withastro/starlight/assets/119873044/549c07fd-512d-4859-aa28-8236da6e9782)

After:
![image](https://github.com/withastro/starlight/assets/119873044/52d9ff1c-6bb5-4ff0-8b15-3a69212cb92c)


<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
