### PR TITLE
Fix target languages in tracker

### DIFF
--- a/docs-i18n-tracker/build.ts
+++ b/docs-i18n-tracker/build.ts
@@ -5,8 +5,7 @@ const translationStatusBuilder = new TranslationStatusBuilder({
 	pageSourceDir: '../docs/src/content/docs',
 	htmlOutputFilePath: './dist/index.html',
 	sourceLanguage: 'en',
-	targetLanguages: Object.values(locales)
-		.map((el) => el.lang)
+	targetLanguages: Object.keys(locales)
 		.filter((lang) => lang !== 'en')
 		.sort(),
 	languageLabels: Object.values(locales)


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Something else!

#### Description

- What does this PR change? Changes the tracker to use the language keys, fixing the filter determining which directories should be marked as language directories.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
