### PR TITLE
Fix translation status page

### DIFF
--- a/docs-i18n-tracker/build.ts
+++ b/docs-i18n-tracker/build.ts
@@ -5,9 +5,8 @@ const translationStatusBuilder = new TranslationStatusBuilder({
 	pageSourceDir: '../docs/src/content/docs',
 	htmlOutputFilePath: './dist/index.html',
 	sourceLanguage: 'en',
-	targetLanguages: Object.keys(locales)
-		.filter((lang) => lang !== 'en')
-		.sort(),
+	targetLanguages: Object.values(locales)
+		.reduce((acc, { lang }) => lang !== "en" ? [lang, ...acc] : acc, []),
 	languageLabels: Object.values(locales)
 		.filter((loc) => loc.lang !== 'en')
 		.reduce((acc, curr) => ({ [curr.lang]: curr.label, ...acc }), {}),

--- a/docs-i18n-tracker/build.ts
+++ b/docs-i18n-tracker/build.ts
@@ -6,7 +6,8 @@ const translationStatusBuilder = new TranslationStatusBuilder({
 	htmlOutputFilePath: './dist/index.html',
 	sourceLanguage: 'en',
 	targetLanguages: Object.values(locales)
-		.reduce((acc, { lang }) => lang !== "en" ? [lang, ...acc] : acc, []),
+		.reduce((acc, { lang }) => lang !== "en" ? [lang, ...acc] : acc, [])
+		.sort(),
 	languageLabels: Object.values(locales)
 		.filter((loc) => loc.lang !== 'en')
 		.reduce((acc, curr) => ({ [curr.lang]: curr.label, ...acc }), {}),

--- a/docs-i18n-tracker/lib/translation-status/builder.ts
+++ b/docs-i18n-tracker/lib/translation-status/builder.ts
@@ -123,7 +123,6 @@ export class TranslationStatusBuilder {
 			[this.sourceLanguage]: {},
 		};
 		this.targetLanguages.forEach((lang) => (pages[lang.toLowerCase()] = {}));
-		
 		// Enumerate all markdown pages with supported languages in pageSourceDir,
 		// retrieve their page data and update them
 		const pagePaths = await glob(`**/*.{md,mdx}`, {

--- a/docs-i18n-tracker/lib/translation-status/builder.ts
+++ b/docs-i18n-tracker/lib/translation-status/builder.ts
@@ -122,8 +122,8 @@ export class TranslationStatusBuilder {
 		const pages: PageIndex = {
 			[this.sourceLanguage]: {},
 		};
-		this.targetLanguages.forEach((lang) => (pages[lang] = {}));
-
+		this.targetLanguages.forEach((lang) => (pages[lang.toLowerCase()] = {}));
+		
 		// Enumerate all markdown pages with supported languages in pageSourceDir,
 		// retrieve their page data and update them
 		const pagePaths = await glob(`**/*.{md,mdx}`, {
@@ -132,7 +132,7 @@ export class TranslationStatusBuilder {
 		const updatedPages = await Promise.all(
 			pagePaths.sort().map(async (pagePath) => {
 				const pathParts = pagePath.split('/');
-				const isLanguageSubpathIncluded = this.targetLanguages.includes(pathParts[0]!);
+				const isLanguageSubpathIncluded = this.targetLanguages.map(el=>el.toLowerCase()).includes(pathParts[0]!);
 
 				// If the first path of a file does not belong to a language, it will be by default a page of the original language set.
 				const lang = isLanguageSubpathIncluded ? pathParts[0] : this.sourceLanguage;
@@ -218,7 +218,7 @@ export class TranslationStatusBuilder {
 			};
 
 			this.targetLanguages.forEach((lang) => {
-				const i18nPage = pages[lang]![subpath]!;
+				const i18nPage = pages[lang.toLowerCase()]![subpath]!;
 				content.translations[lang] = {
 					page: i18nPage,
 					isMissing: !i18nPage,


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

- Changes to Starlight code

## Before: 
![image](https://github.com/withastro/starlight/assets/78129249/c886da80-900b-458f-8a4b-5846bea46cc4)

## After:
![image](https://github.com/withastro/starlight/assets/78129249/1b447f8c-0baa-4222-931d-86417ecc5753)

#### Description

- What does this PR change? Give us a brief description.

The page tracking error has been resolved. This error occurs when there is a case sensitivity issue in the `pt-br` translations folder and a change in capitalization in the language string, as can be seen in the Astro configuration file under the `locales` variable:

```js
export const locales = {
    root: { label: 'English', lang: 'en' },
    de: { label: 'Deutsch', lang: 'de' },
    es: { label: 'Español', lang: 'es' },
    ja: { label: '日本語', lang: 'ja' },
    fr: { label: 'Français', lang: 'fr' },
    it: { label: 'Italiano', lang: 'it' },
    zh: { label: '简体中文', lang: 'zh' },
    'pt-br': { label: 'Português do Brasil', lang: 'pt-BR' },
};
```

Another solution could be to change the `locales['pt-br'][lang]` field to `pt-BR`, or rename the `pt-br` folder to `pt-BR`. These would also be simpler and valid solutions to this issue. However, in this solution, I haven't made any changes to other files in case it's preferred to keep them that way or to avoid causing any problems in other files.
