### PR TITLE
Make `lastUpdated` position consistent

### DIFF
--- a/.changeset/smooth-ladybugs-yell.md
+++ b/.changeset/smooth-ladybugs-yell.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fix `lastUpdated` date position to be consistent

--- a/packages/starlight/components/Footer.astro
+++ b/packages/starlight/components/Footer.astro
@@ -48,4 +48,7 @@ const prevNextLinks = getPrevNextLinks(sidebar, config.pagination, {
 		font-size: var(--sl-text-sm);
 		color: var(--sl-color-gray-3);
 	}
+	.meta > :global(p:only-child) {
+		margin-inline-start: auto;
+	}
 </style>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

Closes #417 

Before the "Last Edit Date" would be leading-aligned if there was no edit url set. This caused an inconsistency on the wide layouts:

<img width="785" alt="Screenshot 2023-08-11 at 09 56 20" src="https://github.com/withastro/starlight/assets/15347255/401a87c7-6ebc-4beb-a0f6-09e12fc8c6e0">

Now it will always be trailing-edge aligned if it's the only child:

<img width="770" alt="Screenshot 2023-08-11 at 09 56 26" src="https://github.com/withastro/starlight/assets/15347255/70af1660-b9b3-48d0-a4df-147a01cd7196">

There's no change in behaviour for if the editUrl is present. 

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
