### PR TITLE
Use looser version for main Starlight peer in Tailwind plugin

### DIFF
--- a/.changeset/tidy-timers-sparkle.md
+++ b/.changeset/tidy-timers-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight-tailwind': patch
+---
+
+Loosen `@astrojs/starlight` peer dependency range to allow higher minor versions.

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -28,7 +28,7 @@
     "vitest": "^0.33.0"
   },
   "peerDependencies": {
-    "@astrojs/starlight": "^0.7.0",
+    "@astrojs/starlight": ">=0.7.0",
     "@astrojs/tailwind": "^4.0.0",
     "tailwindcss": "^3.3.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -193,7 +197,7 @@ importers:
   packages/tailwind:
     dependencies:
       '@astrojs/starlight':
-        specifier: ^0.7.0
+        specifier: '>=0.7.0'
         version: link:../starlight
       '@astrojs/tailwind':
         specifier: ^4.0.0
@@ -7009,7 +7013,3 @@ packages:
 
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

- Something else!

#### Description

- Loosens the `@astrojs/starlight` peer dependency range in the Tailwind plugin to allow higher minor versions.
- We noticed in #498 that a minor Starlight bump would trigger a **major** Tailwind plugin bump currently. Releasing the Tailwind plugin as 1.0.0 was unintentional to be honest, but this change should mean we can avoid bumping the Tailwind plugin just because we release a new Starlight minor version.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
