### PR TITLE
Improve table of content current item highlight behavior

### DIFF
--- a/.changeset/fair-tips-reply.md
+++ b/.changeset/fair-tips-reply.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Improve table of content current item highlight behavior

--- a/packages/starlight/components/TableOfContents/TableOfContentsList.astro
+++ b/packages/starlight/components/TableOfContents/TableOfContentsList.astro
@@ -14,7 +14,7 @@ const { toc, isMobile = false, depth = 0 } = Astro.props;
 	{
 		toc.map((heading) => (
 			<li>
-				<a href={'#' + heading.slug} aria-current={heading.current && 'true'}>
+				<a href={'#' + heading.slug}>
 					<span>{heading.text}</span>
 				</a>
 				{heading.children.length > 0 && (

--- a/packages/starlight/components/TableOfContents/generateToC.ts
+++ b/packages/starlight/components/TableOfContents/generateToC.ts
@@ -2,7 +2,6 @@ import type { MarkdownHeading } from 'astro';
 
 export interface TocItem extends MarkdownHeading {
 	children: TocItem[];
-	current?: boolean;
 }
 
 function diveChildren(item: TocItem, depth: number): TocItem[] {
@@ -34,7 +33,7 @@ export function generateToC(
 
 	for (const heading of headings) {
 		if (toc.length === 0) {
-			toc.push({ ...heading, children: [], current: true });
+			toc.push({ ...heading, children: [] });
 		} else {
 			const lastItemInToc = toc.at(-1)!;
 			if (heading.depth < lastItemInToc.depth) {


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to Starlight code

#### Description

- Closes #455.

This pull request implements the changes suggested in #455 to avoid a visual jump of the table of content current item highlight on page load when using an anchor link and also avoid showing invalid highlights when JS is disabled.

The linked issue contains a lot more informations and comparison videos but here is a video of the new behavior when using an anchor link:


https://github.com/withastro/starlight/assets/494699/b4c52ef3-d305-42e3-b2c1-1e5b8d45d088

Turns out that on top of removing the `current: true` that was automatically added to the overview, we can also entirely remove this property from the `TocItem` type definition and usage in the `<TableOfContentsList>` component. The `StarlightTOC` component will pick up when loaded and highlight the current item.
