### PR TITLE
Improve inline code and code block support in RTL languages

### DIFF
--- a/.changeset/long-parrots-give.md
+++ b/.changeset/long-parrots-give.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Improve inline code and code block support in RTL languages

--- a/packages/starlight/__tests__/remark-rehype/code-rtl-support.test.ts
+++ b/packages/starlight/__tests__/remark-rehype/code-rtl-support.test.ts
@@ -1,0 +1,25 @@
+import { rehype } from 'rehype';
+import { expect, test } from 'vitest';
+import { rehypeRtlCodeSupport } from '../../integrations/code-rtl-support';
+
+const processor = rehype().data('settings', { fragment: true }).use(rehypeRtlCodeSupport());
+
+test('applies `dir="auto"` to inline code', async () => {
+	const input = `<p>Some text with <code>inline code</code>.</p>`;
+	const output = String(await processor.process(input));
+	expect(output).not.toEqual(input);
+	expect(output).includes('dir="auto"');
+	expect(output).toMatchInlineSnapshot(
+		'"<p>Some text with <code dir=\\"auto\\">inline code</code>.</p>"'
+	);
+});
+
+test('applies `dir="ltr"` to code blocks', async () => {
+	const input = `<p>Some text in a paragraph:</p><pre><code>console.log('test')</code></pre>`;
+	const output = String(await processor.process(input));
+	expect(output).not.toEqual(input);
+	expect(output).includes('dir="ltr"');
+	expect(output).toMatchInlineSnapshot(
+		'"<p>Some text in a paragraph:</p><pre dir=\\"ltr\\"><code>console.log(\'test\')</code></pre>"'
+	);
+});

--- a/packages/starlight/__tests__/remark-rehype/vitest.config.ts
+++ b/packages/starlight/__tests__/remark-rehype/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineVitestConfig } from '../test-config';
+
+export default defineVitestConfig({ title: 'Remark-Rehype' });

--- a/packages/starlight/index.ts
+++ b/packages/starlight/index.ts
@@ -8,6 +8,7 @@ import { starlightSitemap } from './integrations/sitemap';
 import { vitePluginStarlightUserConfig } from './integrations/virtual-user-config';
 import { errorMap } from './utils/error-map';
 import { StarlightConfigSchema, StarlightUserConfig } from './utils/user-config';
+import { rehypeRtlCodeSupport } from './integrations/code-rtl-support';
 
 export default function StarlightIntegration(opts: StarlightUserConfig): AstroIntegration[] {
 	const parsedConfig = StarlightConfigSchema.safeParse(opts, { errorMap });
@@ -39,6 +40,7 @@ export default function StarlightIntegration(opts: StarlightUserConfig): AstroIn
 					},
 					markdown: {
 						remarkPlugins: [...starlightAsides()],
+						rehypePlugins: [rehypeRtlCodeSupport()],
 						shikiConfig:
 							// Configure Shiki theme if the user is using the default github-dark theme.
 							config.markdown.shikiConfig.theme !== 'github-dark' ? {} : { theme: 'css-variables' },

--- a/packages/starlight/integrations/code-rtl-support.ts
+++ b/packages/starlight/integrations/code-rtl-support.ts
@@ -1,0 +1,31 @@
+import type { Root } from 'hastscript/lib/core';
+import { CONTINUE, SKIP, visit } from 'unist-util-visit';
+
+/**
+ * rehype plugin that adds `dir` attributes to `<code>` and `<pre>`
+ * elements that don’t already have them.
+ *
+ * `<code>` will become `<code dir="auto">`
+ * `<pre>` will become `<pre dir="ltr">`
+ *
+ * `<code>` _inside_ `<pre>` is skipped, so respects the `ltr` on its parent.
+ *
+ * Reasoning:
+ * - `<pre>` is usually a code block and code should be LTR even in an RTL document
+ * - `<code>` is often LTR, but could also be RTL. `dir="auto"` ensures the bidirectional
+ *   algorithm treats the contents of `<code>` in isolation and gives its best guess.
+ */
+export function rehypeRtlCodeSupport() {
+	return () => (root: Root) => {
+		visit(root, 'element', (el) => {
+			if (el.tagName === 'pre' || el.tagName === 'code') {
+				el.properties = el.properties || {};
+				if (!('dir' in el.properties)) {
+					el.properties.dir = { pre: 'ltr', code: 'auto' }[el.tagName];
+				}
+				return SKIP;
+			}
+			return CONTINUE;
+		});
+	};
+}

--- a/packages/starlight/integrations/code-rtl-support.ts
+++ b/packages/starlight/integrations/code-rtl-support.ts
@@ -19,7 +19,7 @@ export function rehypeRtlCodeSupport() {
 	return () => (root: Root) => {
 		visit(root, 'element', (el) => {
 			if (el.tagName === 'pre' || el.tagName === 'code') {
-				el.properties = el.properties || {};
+				el.properties ||= {};
 				if (!('dir' in el.properties)) {
 					el.properties.dir = { pre: 'ltr', code: 'auto' }[el.tagName];
 				}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

This PR applies a rehype plugin to Starlight Markdown and MDX content to improve appearance in RTL languages.

- Code blocks have `dir="ltr"` added to the `<pre>` tag.
- Inline code has `dir="auto"` added to the `<code>` tag.
- For code blocks this may be an interim solution until we migrate to Expressive Code.
- Research CodePen while working out the best set-up: https://codepen.io/delucis/pen/vYvBmKx

We don’t currently have an RTL language in our docs site to test with, so I added some Arabic content locally to test these changes.

| Before | After |
|---|---|
| <img width="758" alt="RTL Starlight page where code content is misaligned to the right" src="https://github.com/withastro/starlight/assets/357379/75db45c5-21b4-42e8-aae3-18bba999d353"> | <img width="746" alt="RTL Starlight page where code content is correctly aligned to the left" src="https://github.com/withastro/starlight/assets/357379/dac65acb-7d1a-42bb-8325-d2f95c4bd5d2"> |

Note that in the second image, the code blocks are left-aligned even though page content is right-aligned and that the inline code reads correctly as `@astrojs/*` instead of `*/astrojs@`.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
