### PR TITLE
Use `Intl.NumberFormat` to display decimals in theme editor

### DIFF
--- a/docs/src/components/theme-designer/value-slider.astro
+++ b/docs/src/components/theme-designer/value-slider.astro
@@ -28,6 +28,7 @@ const value = store[storeKey].get()[type];
 		#output = this.querySelector<HTMLSpanElement>('.value')!;
 		#store = store[this.dataset.store as keyof typeof store];
 		#type = this.dataset.type as 'hue' | 'chroma';
+		#formatter = new Intl.NumberFormat(document.documentElement.lang || 'en');
 
 		constructor() {
 			super();
@@ -35,10 +36,9 @@ const value = store[storeKey].get()[type];
 				this.#store.setKey(this.#type, this.#input.valueAsNumber)
 			);
 			this.#store.subscribe((v) => {
-				const newValue = v[this.#type].toString();
-				this.#input.value = newValue;
-				// HACK: slice excess digits in case of rounding errors.
-				this.#output.innerText = newValue.slice(0, 5);
+				const newValue = v[this.#type];
+				this.#input.value = String(newValue);
+				this.#output.innerText = this.#formatter.format(newValue);
 			});
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes or translations of Starlight docs site content

#### Description

This tweaks the sliders in the color theme editor to display their values using [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat). This ensures the correct decimal place indicator is used for the current language. (All praise Web Standards for making this so simple 🙇)

As an example, here is the Chroma slider for various languages:

| English | Japanese | Spanish | Portuguese |
|---|---|---|---|
| <img width="335" alt="Slider with value of 0.27" src="https://github.com/withastro/starlight/assets/357379/2173efa9-82c9-40b4-8fb8-ab6cc0f09327"> | <img width="324" alt="Slider with value of 0.27" src="https://github.com/withastro/starlight/assets/357379/c3a31c32-855c-4084-842b-979fb25753db"> | <img width="330" alt="Slider with value of 0,27" src="https://github.com/withastro/starlight/assets/357379/492a66bb-3020-4e00-8495-7ba41449fa55"> | <img width="320" alt="Slider with value of 0,27" src="https://github.com/withastro/starlight/assets/357379/ea37f743-99f6-4691-b630-6c92b2a5d51f"> |


<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
