### PR TITLE
Add `starlight-openapi` to showcase

### DIFF
--- a/docs/src/content/docs/showcase.mdx
+++ b/docs/src/content/docs/showcase.mdx
@@ -113,4 +113,9 @@ These community tools, plugins, and integrations work alongside Starlight to ext
 		title="starlight-typedoc"
 		description="Generate Starlight pages from TypeScript using TypeDoc."
 	/>
+	<LinkCard
+		href="https://github.com/HiDeoo/starlight-openapi"
+		title="starlight-openapi"
+		description="Create documentation pages from OpenAPI/Swagger specifications."
+	/>
 </CardGrid>


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

A bit of a shameless plug but this PR adds [`starlight-openapi`](https://github.com/HiDeoo/starlight-openapi) to the showcase list.