### PR TITLE
i18n(fr): update `manual-setup` & `frontmatter` page titles

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -87,7 +87,7 @@ export default defineConfig({
 								de: 'Manuelle Einrichtung',
 								es: 'Configuración Manual',
 								ja: '手動セットアップ',
-								// fr: 'Manual Setup',
+								fr: 'Installation manuelle',
 								// it: 'Manual Setup',
 								zh: '手动配置',
 								'pt-BR': 'Instalação Manual',

--- a/docs/src/content/docs/fr/reference/frontmatter.md
+++ b/docs/src/content/docs/fr/reference/frontmatter.md
@@ -1,5 +1,5 @@
 ---
-title: Frontmatter Reference
+title: Référence du frontmatter
 description: Une vue d'ensemble des champs du frontmatter par défaut pris en charge par Starlight.
 ---
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

I noticed that 2 page titles in the French docs site were not translated so this PR fixes that.