### PR TITLE
hotfix: Update Showcase site URL (broken link)

### DIFF
--- a/docs/src/content/docs/showcase.mdx
+++ b/docs/src/content/docs/showcase.mdx
@@ -18,7 +18,7 @@ Starlight is already being used in production. These are some of the sites aroun
 <FluidGrid>
 	<Card
 		title="Athena OS"
-		href="https://www.athenaos.org"
+		href="https://athenaos.org"
 		thumbnail="www.athenaos.org.png"
 	/>
 	<Card


### PR DESCRIPTION
Athena OS, linked in the showcase, doesn't resolve with the `www`.

`athenaos.org` works fine, but `www.athenaos.org` does not.

<img width="596" alt="CleanShot 2023-09-01 at 14 15 09@2x" src="https://github.com/withastro/starlight/assets/485747/955d4692-a632-4466-a30d-645fc362296e">