### PR TITLE
Ensure showcase image aspect ratios

### DIFF
--- a/docs/src/components/showcase-card.astro
+++ b/docs/src/components/showcase-card.astro
@@ -52,4 +52,9 @@ const src = (await thumbnail()).default;
 	.image {
 		border-bottom: 1px solid var(--sl-color-gray-5);
 	}
+
+	.image img {
+		aspect-ratio: 16 / 9;
+		object-fit: cover;
+	}
 </style>


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

Following #619, there are different aspect ratios for the images in the showcases. All the previous images were `800 × 450` and the last one is `1200 × 630` which is not `16 / 9`:

<img width="736" alt="SCR-20230901-qghg" src="https://github.com/withastro/starlight/assets/494699/ded2d3a8-d56a-4815-b8f7-27ccf8af1224">

This PR adds CSS rules to make the images always `16 / 9`:

<img width="739" alt="SCR-20230901-qgun" src="https://github.com/withastro/starlight/assets/494699/8967b3ec-3ee8-4bfe-a8c2-e8633d4206e2">

Another approach could be enforcing specific image sizes / aspect ratios for the showcase images.