### PR TITLE
Throw error if a user’s project adds MDX or sitemap integrations

### DIFF
--- a/.changeset/brown-olives-share.md
+++ b/.changeset/brown-olives-share.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': minor
+---
+
+Throw an error for duplicate MDX or sitemap integrations

--- a/packages/starlight/index.ts
+++ b/packages/starlight/index.ts
@@ -50,6 +50,19 @@ export default function StarlightIntegration(opts: StarlightUserConfig): AstroIn
 				updateConfig(newConfig);
 			},
 
+			'astro:config:done': ({ config }) => {
+				const integrations = config.integrations.map(({ name }) => name);
+				for (const builtin of ['@astrojs/mdx', '@astrojs/sitemap']) {
+					if (integrations.filter((name) => name === builtin).length > 1) {
+						throw new Error(
+							`Found more than one instance of ${builtin}.\n` +
+								`Starlight includes ${builtin} by default.\n` +
+								'Please remove it from your integrations array in astro.config.mjs'
+						);
+					}
+				}
+			},
+
 			'astro:build:done': ({ dir }) => {
 				const targetDir = fileURLToPath(dir);
 				const cwd = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- Users could potentially run into cryptic errors if they themselves added the MDX or sitemap integrations that come bundled with Starlight.
- This heads that off by throwing a clearer error if we detect it.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
