### PR TITLE
Fixes for Astro v3

### DIFF
--- a/packages/starlight/components/LastUpdated.astro
+++ b/packages/starlight/components/LastUpdated.astro
@@ -28,7 +28,7 @@ try {
 {
 	date && (
 		<p>
-			{t('page.lastUpdated')}
+			{t('page.lastUpdated')}{' '}
 			<time datetime={date.toISOString()}>
 				{date.toLocaleDateString(lang, { dateStyle: 'medium' })}
 			</time>

--- a/packages/starlight/components/SidebarSublist.astro
+++ b/packages/starlight/components/SidebarSublist.astro
@@ -21,10 +21,13 @@ interface Props {
 					>
 						<span>{entry.label}</span>
 						{entry.badge && (
-							<Badge
-								text={entry.badge.text}
-								variant={entry.isCurrent ? 'outline' : entry.badge.variant}
-							/>
+							<>
+								{' '}
+								<Badge
+									text={entry.badge.text}
+									variant={entry.isCurrent ? 'outline' : entry.badge.variant}
+								/>
+							</>
 						)}
 					</a>
 				) : (


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- Astro v3 sets `compressHTML` to `true` by default.
- Due to https://github.com/withastro/compiler/issues/852 there were a couple of places meaningful whitespace got collapsed in Starlight’s layouts.
- This PR fixes though with some explicit whitespace to preserve previous behaviour.
- No changeset as this change is basically just part of #615.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
