### PR TITLE
Remove sharp image processor config

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -154,5 +154,4 @@ export default defineConfig({
 			lastUpdated: true,
 		}),
 	],
-	image: { service: { entrypoint: 'astro/assets/services/sharp' } },
 });

--- a/examples/basics/astro.config.mjs
+++ b/examples/basics/astro.config.mjs
@@ -24,7 +24,4 @@ export default defineConfig({
 			],
 		}),
 	],
-
-	// Process images with sharp: https://docs.astro.build/en/guides/assets/#using-sharp
-	image: { service: { entrypoint: 'astro/assets/services/sharp' } },
 });

--- a/examples/tailwind/astro.config.mjs
+++ b/examples/tailwind/astro.config.mjs
@@ -27,10 +27,4 @@ export default defineConfig({
 		}),
 		tailwind({ applyBaseStyles: false }),
 	],
-	// Process images with sharp: https://docs.astro.build/en/guides/assets/#using-sharp
-	image: {
-		service: {
-			entrypoint: 'astro/assets/services/sharp',
-		},
-	},
 });


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Updates to templates

#### Description

Removed sharp image processor from templates/examples. Sharp is the default image processor for Astro since v3.
