### PR TITLE
Fix sidebar guide a11y and type issue

### DIFF
--- a/docs/src/components/sidebar-preview.astro
+++ b/docs/src/components/sidebar-preview.astro
@@ -1,6 +1,5 @@
 ---
-import type { AutoSidebarGroup, SidebarItem } from '@astrojs/starlight/utils/user-config';
-
+import type { AutoSidebarGroup, SidebarItem } from '../../../packages/starlight/utils/user-config';
 import SidebarSublist from '../../../packages/starlight/components/SidebarSublist.astro';
 import type { SidebarEntry } from '../../../packages/starlight/utils/navigation';
 
@@ -36,7 +35,7 @@ function makeEntries(items: SidebarConfig): SidebarEntry[] {
 }
 ---
 
-<div class="sidebar-preview not-content" id="starlight__sidebar">
+<div class="sidebar-preview not-content">
 	<SidebarSublist sublist={makeEntries(config)} />
 </div>
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

This PR fixes 2 issues with the newly added sidebar guide:

- Remove the ID in the `sidebar-preview` component to avoid duplicated IDs and we don't need it here anyway.
- Fix a type issue in the `sidebar-preview` component (I assume the import was auto-generated by VSC when the project was still using Astro v2 and somehow fine but now it's not as expected as they are not exported types and was not catch as we do not run `astro check`).

Edit: I tested locally before pushing but pa11y also properly run on the sidebar guide in this PR:

> \> http://localhost:4321/guides/sidebar/ - 0 errors

This PR does not investigate why `pa11y` was not run in the sidebar guide PR, I'll do that in a separate PR.