### PR TITLE
Update `pa11y-ci` sitemap URL

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.1",
   "scripts": {
     "test": "start-server-and-test preview http://localhost:4321 pa11y",
-    "pa11y": "pa11y-ci --sitemap 'http://localhost:4321/sitemap-index.xml' --sitemap-find 'https://starlight.astro.build' --sitemap-replace 'http://localhost:4321' --sitemap-exclude '/(de|zh|fr|es|pt-br|it|ko)/.*'",
+    "pa11y": "pa11y-ci --sitemap 'http://localhost:4321/sitemap-0.xml' --sitemap-find 'https://starlight.astro.build' --sitemap-replace 'http://localhost:4321' --sitemap-exclude '/(de|zh|fr|es|pt-br|it|ko)/.*'",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Something else!

#### Description

This PR updates the sitemap URL used by `pa11y-ci` during tests to no longer use the sitemap index file as the `--sitemap-find` and `--sitemap-replace` options are not used for a sitemap index. This would mean that new pages were not being tested before hitting production.

I tested this locally by adding a new guide - on the left, a run before the change, on the right, a run after the change:

![pa11y](https://github.com/withastro/starlight/assets/494699/19d398f1-1efb-443e-a8bb-178aba4d1735)
