### PR TITLE
Break long inline <code> elements across lines

### DIFF
--- a/.changeset/gorgeous-wasps-report.md
+++ b/.changeset/gorgeous-wasps-report.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Break inline `<code>` across lines to avoid overflow

--- a/packages/starlight/style/reset.css
+++ b/packages/starlight/style/reset.css
@@ -38,7 +38,8 @@ h2,
 h3,
 h4,
 h5,
-h6 {
+h6,
+code {
 	overflow-wrap: break-word;
 }
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- @Mrahmani71 noticed that long inline code was causing layout to overflow, for example:
   <img width="368" alt="Customizing Starlight docs page with long URLs breaking the layout" src="https://github.com/withastro/starlight/assets/357379/d086ea8b-1c3d-4dba-bf73-788bad7181fb">
- This PR fixes that by adding `code` to the list of elements targeted by our CSS rule that sets `overflow-wrap: break-word`.


<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
