### PR TITLE
build: bump pnpm to 8.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prettier-plugin-astro": "^0.11.0",
     "size-limit": "^8.2.4"
   },
-  "packageManager": "pnpm@8.2.0",
+  "packageManager": "pnpm@8.7.4",
   "size-limit": [
     {
       "name": "/index.html",


### PR DESCRIPTION
#### What kind of changes does this PR include?

- https://github.com/pnpm/pnpm/issues/6424

#### Description

![docs : npm exec pnpm i_01](https://github.com/withastro/starlight/assets/54838975/fe2a8014-f213-4c8c-849c-7a51a46ac854)

Bumped pnpm version in `packageManager` to fix `ERR_UNKNOWN_THIS` in node v20. (the issue is fixed in pnpm@8.3.1)