### PR TITLE
chore: add `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Apply with:
+# `git config --local blame.ignoreRevsFile .git-blame-ignore-revs`
+
+# [Add Prettier and format files](https://github.com/withastro/starlight/pull/393)
+9b172f5ee09697d80f301e9b70aca1946419ce24


### PR DESCRIPTION
#### What kind of changes does this PR include?

included `.git-blame-ignore-revs` to use https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt

#### Description

when using line blame from VSCode gitlens, i've found a lot of lines from #393, as the PR formatted many files. Adding `.git-blame-ignore-revs` ignores commits mentioned in the file, in [github](https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/) in local via `git config --local blame.ignoreRevsFile .git-blame-ignore-revs`.

| before | after |
|--------|--------|
| [before][before] | [after][after] | 

[before]: https://github.com/withastro/starlight/assets/54838975/80081ba7-91aa-4235-8537-a6ae9d0bc145

[after]: https://github.com/withastro/starlight/assets/54838975/10659b3e-1208-4a2b-b0c0-859a34299336
