### PR TITLE
feat: alternative syntax for custom aside titles

### DIFF
--- a/.changeset/polite-cougars-move.md
+++ b/.changeset/polite-cougars-move.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Added alternative syntax for custom aside titles.

--- a/docs/src/content/docs/guides/authoring-content.md
+++ b/docs/src/content/docs/guides/authoring-content.md
@@ -123,12 +123,25 @@ npm create astro@latest -- --template starlight
 
 You can specify a custom title for the aside in square brackets following the aside type, e.g. `:::tip[Did you know?]`.
 
-:::tip[Did you know?]
+:::tip{title="Did you know?"}
 Astro helps you build faster websites with [“Islands Architecture”](https://docs.astro.build/en/concepts/islands/).
 :::
 
 ```md
 :::tip[Did you know?]
+Astro helps you build faster websites with [“Islands Architecture”](https://docs.astro.build/en/concepts/islands/).
+:::
+```
+
+You can also use [attribute syntax][attribute] using `title` attribute to avoid [syntax][conflict-1] [conflicts][conflict-2] with markdown link syntax.
+
+[conflict-1]: https://github.com/microsoft/vscode-markdown-languageservice/issues/7
+[conflict-2]: https://github.com/microsoft/vscode-markdown-languageservice/issues/14
+[attribute]: https://talk.commonmark.org/t/generic-directives-plugins-syntax/444
+
+
+```md
+:::tip{title="Did you know?"}
 Astro helps you build faster websites with [“Islands Architecture”](https://docs.astro.build/en/concepts/islands/).
 :::
 ```

--- a/docs/src/content/docs/ko/guides/authoring-content.md
+++ b/docs/src/content/docs/ko/guides/authoring-content.md
@@ -124,7 +124,7 @@ npm create astro@latest -- --template starlight
 
 주석 타입 다음에 대괄호를 사용해 주석의 제목을 지정할 수 있습니다. `:::tip[알고 계셨나요?]`
 
-:::tip[알고 계셨나요?]
+:::tip{title="알고 계셨나요?"}
 
 Astro는 ["Islands Architecture"](https://docs.astro.build/ko/concepts/islands/)를 사용하여 더 빠른 웹사이트를 구축할 수 있도록 도와줍니다.
 :::
@@ -132,6 +132,18 @@ Astro는 ["Islands Architecture"](https://docs.astro.build/ko/concepts/islands/)
 ```md
 :::tip[알고 계셨나요?]
 Astro는 ["Islands Architecture"](https://docs.astro.build/ko/concepts/islands/)를 사용하여 더 빠른 웹사이트를 구축할 수 있도록 도와줍니다.
+:::
+```
+
+대괄호가 마크다운의 링크 문법과 [충돌을][충돌-1] [일으킨다면][충돌-2] [`title` 속성][속성]을 지정하는 문법을 대신 쓸 수도 있습니다.
+
+[충돌-1]: https://github.com/microsoft/vscode-markdown-languageservice/issues/7
+[충돌-2]: https://github.com/microsoft/vscode-markdown-languageservice/issues/14
+[속성]: https://talk.commonmark.org/t/generic-directives-plugins-syntax/444
+
+```md
+:::tip{title="알고 계셨나요?"}
+Astro helps you build faster websites with [“Islands Architecture”](https://docs.astro.build/en/concepts/islands/).
 :::
 ```
 

--- a/packages/starlight/integrations/asides.ts
+++ b/packages/starlight/integrations/asides.ts
@@ -39,6 +39,14 @@ function s(el: string, attrs: Properties = {}, children: any[] = []): P {
  * :::
  * ```
  *
+ * Or this alternative syntax
+ *
+ * ```
+ * :::tip{title="Did you know?"}
+ * Astro helps you build faster websites with “Islands Architecture”.
+ * :::
+ * ```
+ *
  * will produce this output
  *
  * ```astro
@@ -97,7 +105,11 @@ function remarkAsides(): Plugin<[], Root> {
 
 	const transformer: Transformer<Root> = (tree) => {
 		visit(tree, (node, index, parent) => {
-			if (!parent || index === null || node.type !== 'containerDirective') {
+			if (
+				!parent ||
+				index === null ||
+				(node.type !== 'textDirective' && node.type !== 'containerDirective')
+			) {
 				return;
 			}
 			const variant = node.name;
@@ -107,7 +119,8 @@ function remarkAsides(): Plugin<[], Root> {
 			// its children, but we want to pass it as the title prop to <Aside>, so
 			// we iterate over the children, find a directive label, store it for the
 			// title prop, and remove the paragraph from children.
-			let title = defaultTitles[variant];
+			let title = node.attributes?.title || defaultTitles[variant];
+
 			remove(node, (child): boolean | void => {
 				if (child.data?.directiveLabel) {
 					if (


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content
- Changes to Starlight code

#### Description


![image](https://github.com/withastro/starlight/assets/54838975/71bb46d9-10fa-4fb5-a5af-54e1a6a5a9d3)

[original discussion](https://discord.com/channels/830184174198718474/1070481941863878697/1150709007103840286)

markdown tools might parse markdown directive labels as links incorrectly.

- https://github.com/microsoft/vscode-markdown-languageservice/issues/14 
- https://github.com/microsoft/vscode-markdown-languageservice/issues/7


![image](https://github.com/withastro/starlight/assets/54838975/b38f84b3-edd3-47c1-801f-b171cef1ae36)

added alternative syntax that uses `title` attribute instead, e.g `:::tip{title="Did you know?"}`

```
:::tip{title="Did you know?"}
Astro helps you build faster websites with [“Islands Architecture”](https://docs.astro.build/en/concepts/islands/).
:::

```
