### PR TITLE
fix: handle `[data-has-toc]` when calculating main pane width

### DIFF
--- a/.changeset/cold-bikes-knock.md
+++ b/.changeset/cold-bikes-knock.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fix main content column width for pages without a table of contents

--- a/packages/starlight/layout/TwoColumnContent.astro
+++ b/packages/starlight/layout/TwoColumnContent.astro
@@ -46,7 +46,7 @@ interface Props {
 			width: 100%;
 		}
 
-		:global([data-has-sidebar]) .main-pane {
+		:global([data-has-sidebar][data-has-toc]) .main-pane {
 			--sl-content-margin-inline: auto 0;
 
 			order: 1;


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

Closes #691 

This PR limits the calculation of the main pane width when there's a sidebar but also a ToC. Before, this calculation was done as soon as there was a sidebar without taking into account whether a ToC was present.

As a result, the content is centered when there's a sidebar and no ToC, and the horizontal rules are rendered using the full-width.

I suppose that there are other ways to tackle it, so I'm open to suggestions to try if you have other ideas.

I'm not that aware of all features in Starlight, so I've basically tested the rendering with and without ToC for non-regressions but always with a sidebar, so there are maybe other use cases to check.

##### Before

![2023-09-11 21 08 32](https://github.com/withastro/starlight/assets/17381666/08720b24-9105-4fa4-9595-f23360d3fce1)

##### Now

![2023-09-11 21 09 02](https://github.com/withastro/starlight/assets/17381666/bfed0608-e3b1-4c58-94d9-e689b3f4ef5e)

#### Live preview

- https://deploy-preview-708--astro-starlight.netlify.app/getting-started/ (for non-regression testing)

In order to test this PR, IDK there's another way than making a checkout of the branch locally and adding `tableOfContents: false` to `/src/content/docs/getting-started.mdx` for instance.