### PR TITLE
Prevent scroll on `body` when search is open

### DIFF
--- a/.changeset/soft-steaks-kick.md
+++ b/.changeset/soft-steaks-kick.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+feat: prevent scroll on body when search is open

--- a/packages/starlight/components/Search.astro
+++ b/packages/starlight/components/Search.astro
@@ -87,6 +87,12 @@ const pagefindTranslations = {
 			openBtn.addEventListener('click', openModal);
 			openBtn.disabled = false;
 			closeBtn.addEventListener('click', closeModal);
+			window.addEventListener('keypress', (e) => {
+				if (e.key === 'Escape' && dialog.open) {
+					e.preventDefault();
+					closeModal();
+				}
+			});
 
 			// Listen for `/` and `cmd + k` keyboard shortcuts.
 			window.addEventListener('keydown', (e) => {

--- a/packages/starlight/components/Search.astro
+++ b/packages/starlight/components/Search.astro
@@ -87,7 +87,7 @@ const pagefindTranslations = {
 			openBtn.addEventListener('click', openModal);
 			openBtn.disabled = false;
 			closeBtn.addEventListener('click', closeModal);
-			window.addEventListener('keypress', (e) => {
+			window.addEventListener('keydown', (e) => {
 				if (e.key === 'Escape' && dialog.open) {
 					e.preventDefault();
 					closeModal();

--- a/packages/starlight/components/Search.astro
+++ b/packages/starlight/components/Search.astro
@@ -72,6 +72,7 @@ const pagefindTranslations = {
 
 			const openModal = (event?: MouseEvent) => {
 				dialog.showModal();
+				document.body.toggleAttribute('data-search-modal-open', true);
 				this.querySelector('input')?.focus();
 				event?.stopPropagation();
 				window.addEventListener('click', onClick);
@@ -79,6 +80,7 @@ const pagefindTranslations = {
 
 			const closeModal = () => {
 				dialog.close();
+				document.body.toggleAttribute('data-search-modal-open', false);
 				window.removeEventListener('click', onClick);
 			};
 
@@ -230,6 +232,10 @@ const pagefindTranslations = {
 </style>
 
 <style is:global>
+	[data-search-modal-open] {
+		overflow: hidden;
+	}
+
 	#starlight__search {
 		--sl-search-result-spacing: calc(1.25rem * var(--pagefind-ui-scale));
 		--sl-search-result-pad-inline-start: calc(3.75rem * var(--pagefind-ui-scale));

--- a/packages/starlight/components/Search.astro
+++ b/packages/starlight/components/Search.astro
@@ -80,18 +80,16 @@ const pagefindTranslations = {
 
 			const closeModal = () => {
 				dialog.close();
-				document.body.toggleAttribute('data-search-modal-open', false);
 				window.removeEventListener('click', onClick);
 			};
 
 			openBtn.addEventListener('click', openModal);
 			openBtn.disabled = false;
 			closeBtn.addEventListener('click', closeModal);
-			window.addEventListener('keydown', (e) => {
-				if (e.key === 'Escape' && dialog.open) {
-					e.preventDefault();
-					closeModal();
-				}
+
+			dialog.addEventListener('close', () => {
+				closeModal();
+				document.body.toggleAttribute('data-search-modal-open', false);
 			});
 
 			// Listen for `/` and `cmd + k` keyboard shortcuts.

--- a/packages/starlight/components/Search.astro
+++ b/packages/starlight/components/Search.astro
@@ -88,7 +88,6 @@ const pagefindTranslations = {
 			closeBtn.addEventListener('click', closeModal);
 
 			dialog.addEventListener('close', () => {
-				closeModal();
 				document.body.toggleAttribute('data-search-modal-open', false);
 			});
 

--- a/packages/starlight/components/Search.astro
+++ b/packages/starlight/components/Search.astro
@@ -78,10 +78,7 @@ const pagefindTranslations = {
 				window.addEventListener('click', onClick);
 			};
 
-			const closeModal = () => {
-				dialog.close();
-				window.removeEventListener('click', onClick);
-			};
+			const closeModal = () => dialog.close();
 
 			openBtn.addEventListener('click', openModal);
 			openBtn.disabled = false;
@@ -89,6 +86,7 @@ const pagefindTranslations = {
 
 			dialog.addEventListener('close', () => {
 				document.body.toggleAttribute('data-search-modal-open', false);
+				window.removeEventListener('click', onClick);
 			});
 
 			// Listen for `/` and `cmd + k` keyboard shortcuts.


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to Starlight code

#### Description

This PR resolves the scroll on `body` when the search is open.

From my tests, it works fine even on mobile, with the menu open.