### PR TITLE
Small search modal improvements

### DIFF
--- a/.changeset/great-tomatoes-tie.md
+++ b/.changeset/great-tomatoes-tie.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Use Starlight font custom property in Pagefind modal

--- a/.changeset/lemon-cameras-tell.md
+++ b/.changeset/lemon-cameras-tell.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fix RTL styling in Pagefind modal

--- a/packages/starlight/components/Search.astro
+++ b/packages/starlight/components/Search.astro
@@ -205,6 +205,7 @@ const pagefindTranslations = {
 	#starlight__search {
 		--pagefind-ui-primary: var(--sl-color-accent-light);
 		--pagefind-ui-text: var(--sl-color-gray-2);
+		--pagefind-ui-font: var(--__sl-font);
 		--pagefind-ui-background: var(--sl-color-black);
 		--pagefind-ui-border: var(--sl-color-gray-5);
 		--pagefind-ui-border-width: 1px;

--- a/packages/starlight/components/Search.astro
+++ b/packages/starlight/components/Search.astro
@@ -391,6 +391,12 @@ const pagefindTranslations = {
 		mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' viewBox='0 0 16 16'%3E%3Cpath d='M8 0v12m6 0H8'/%3E%3C/svg%3E");
 	}
 
+	/* Flip page and tree icons around the vertical axis when in an RTL layout. */
+	[dir='rtl'] .pagefind-ui__result-title::before,
+	[dir='rtl'] .pagefind-ui__result-nested::before {
+		transform: matrix(-1, 0, 0, 1, 0, 0);
+	}
+
 	#starlight__search .pagefind-ui__result-link::after {
 		content: '';
 		position: absolute;


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- Use Starlight’s font variable inside the Pagefind modal for a consistent experience (will also respect user-configured `--sl-font` if set).
- Fixes the new styles used for subheadings to flip the iconography in RTL pages:
   <img width="99" alt="Search result UI showing some styling that highlights the relationship between a page title and page subheadings. This UI is now flipped to read from right to left as expected." src="https://github.com/withastro/starlight/assets/357379/9d6214ae-3ad2-40ac-8959-5fd82d4fb21a">


<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
