### PR TITLE
Fix pa11y tests on Windows

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 prefer-workspace-packages=true
 link-workspace-packages=true
+shell-emulator=true

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "version": "0.0.1",
   "scripts": {
-    "test": "start-server-and-test preview http://localhost:4321 pa11y",
+    "test": "start-server-and-test 'pnpm preview' http://localhost:4321 'pnpm pa11y'",
     "pa11y": "pa11y-ci --sitemap 'http://localhost:4321/sitemap-0.xml' --sitemap-find 'https://starlight.astro.build' --sitemap-replace 'http://localhost:4321' --sitemap-exclude '/(de|zh|fr|es|pt-br|it|ko)/.*'",
     "dev": "astro dev",
     "start": "astro dev",


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- Fixes an issue that made it impossible to run accessibility tests on Windows. In the `docs` folder, neither `pnpm test` nor `pnpm pa11y` were working due to OS differences.
- To solve the differences, I enabled the `shell-emulator` flag in `.npmrc` and changed the `test` script to ensure it actually uses `pnpm` instead of its default `npm`.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
