### PR TITLE
Escape argument in examples build script

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 prefer-workspace-packages=true
 link-workspace-packages=true
+shell-emulator=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 prefer-workspace-packages=true
 link-workspace-packages=true
-shell-emulator=true

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "build:examples": "pnpm --filter @example/* build",
+    "build:examples": "pnpm --filter '@example/*' build",
     "size": "size-limit",
     "version": "pnpm changeset version && pnpm i --no-frozen-lockfile",
     "format": "prettier -w --cache --plugin prettier-plugin-astro ."


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Something else!

#### Description

- #743 introduced `shell-emulator=true` in `.npmrc`
- This caused the Size Limit check to fail in #709 because the example build script included `@examples/*` unescaped, which with shell emulation enabled was parsed as a glob and errored when it failed to expand the `*`.
- This PR wraps the `--filter` pattern in `'` to escape it.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
