### PR TITLE
Replace copy/pasted `ImageFunction` with imported `SchemaContext`

### DIFF
--- a/.changeset/fair-trains-care.md
+++ b/.changeset/fair-trains-care.md
@@ -2,4 +2,4 @@
 "@astrojs/starlight": patch
 ---
 
-Fix content collection schema compatibility with different Astro versions
+Fix content collection schema compatibility with Astro 3.1 and higher

--- a/.changeset/fair-trains-care.md
+++ b/.changeset/fair-trains-care.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fix content collection schema compatibility with different Astro versions

--- a/packages/starlight/schema.ts
+++ b/packages/starlight/schema.ts
@@ -1,4 +1,5 @@
-import { z, type SchemaContext } from 'astro:content';
+import { z } from 'astro/zod';
+import type { SchemaContext } from 'astro:content';
 import { HeadConfigSchema } from './schemas/head';
 import { PrevNextLinkConfigSchema } from './schemas/prevNextLink';
 import { TableOfContentsSchema } from './schemas/tableOfContents';

--- a/packages/starlight/schema.ts
+++ b/packages/starlight/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'astro/zod';
+import { z, type SchemaContext } from 'astro:content';
 import { HeadConfigSchema } from './schemas/head';
 import { PrevNextLinkConfigSchema } from './schemas/prevNextLink';
 import { TableOfContentsSchema } from './schemas/tableOfContents';
@@ -9,25 +9,8 @@ export { i18nSchema } from './schemas/i18n';
 type IconName = keyof typeof Icons;
 const iconNames = Object.keys(Icons) as [IconName, ...IconName[]];
 
-type ImageFunction = () => z.ZodObject<{
-	src: z.ZodString;
-	width: z.ZodNumber;
-	height: z.ZodNumber;
-	format: z.ZodUnion<
-		[
-			z.ZodLiteral<'png'>,
-			z.ZodLiteral<'jpg'>,
-			z.ZodLiteral<'jpeg'>,
-			z.ZodLiteral<'tiff'>,
-			z.ZodLiteral<'webp'>,
-			z.ZodLiteral<'gif'>,
-			z.ZodLiteral<'svg'>,
-		]
-	>;
-}>;
-
 export function docsSchema() {
-	return ({ image }: { image: ImageFunction }) =>
+	return ({ image }: SchemaContext) =>
 		z.object({
 			/** The title of the current page. Required. */
 			title: z.string(),


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

- Closes #767 
- Updates our frontmatter schema to import the `SchemaContext` type from `astro:content`.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
