### PR TITLE
Exclude `/id/` pages from pa11y checks

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.1",
   "scripts": {
     "test": "start-server-and-test 'pnpm preview' http://localhost:4321 'pnpm pa11y'",
-    "pa11y": "pa11y-ci --sitemap 'http://localhost:4321/sitemap-0.xml' --sitemap-find 'https://starlight.astro.build' --sitemap-replace 'http://localhost:4321' --sitemap-exclude '/(de|zh|fr|es|pt-br|it|ko)/.*'",
+    "pa11y": "pa11y-ci --sitemap 'http://localhost:4321/sitemap-0.xml' --sitemap-find 'https://starlight.astro.build' --sitemap-replace 'http://localhost:4321' --sitemap-exclude '/(de|zh|fr|es|pt-br|it|id|ko)/.*'",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Something else!

#### Description

- Updates our script that runs pa11y to ignore `/id/` pages
- These checks are relatively slow, so this should knock 20–30 seconds off CI times

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://github.com/withastro/docs/blob/main/.github/hacktoberfest.md for more details. -->

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
