### PR TITLE
Make minimal repro required in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/---01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/---01-bug-report.yml
@@ -58,6 +58,8 @@ body:
       label: Link to Minimal Reproducible Example
       description: 'Use [astro.new](https://astro.new) to create a minimal reproduction of the problem. **A minimal reproduction is required** so that others can help debug your issue. If a report is vague (e.g. just a generic error message) and has no reproduction, it may be auto-closed. Not sure how to create a minimal example? [Read our guide](https://docs.astro.build/en/guides/troubleshooting/#creating-minimal-reproductions)'
       placeholder: 'https://stackblitz.com/abcd1234'
+    validations:
+      required: true
   - type: checkboxes
     id: will-pr
     attributes:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Something else!

#### Description

- Marks the minimal reproduction field as required in Starlight’s bug report issue template.

- I initially left this as optional, because I didn’t want to create too many barriers to a bug report, but I’m realising this may not have been smart as issues come in that include lengthy set-up descriptions but no repro, requiring lots of effort just to triage and start debugging.