### PR TITLE
[Chore] Update Docs For subpath

### DIFF
--- a/docs/src/content/docs/manual-setup.mdx
+++ b/docs/src/content/docs/manual-setup.mdx
@@ -102,26 +102,17 @@ If you have an existing Astro project, you can use Starlight to quickly add a do
 
 ### Use Starlight at a subpath
 
-To add all Starlight pages at a subpath, place all your docs content inside a subdirectory of `src/content/docs/`.
+To add all Starlight pages at a subpath, you could relay on top of Astro.js configurations. `base` and `assetPrefix`
 
-For example, if Starlight pages should all start with `/guides/`, add your content in the `src/content/docs/guides/` directory:
+**Base [astro docs](https://docs.astro.build/en/reference/configuration-reference/#base)**
+As the documentation suggests, this will allow you to add basically a `basePath` on your Astro + Startlight project.
 
-import FileTree from '../../components/file-tree.astro';
+**AssetPrefix [astro docs](https://docs.astro.build/en/reference/configuration-reference/#buildassetsprefix)**
+In case your subpath also be the root of your project (in case of micro-frontends or github pages), this property allow you to add a prefix in front of your assets, helping you delivery your astro assets!
 
-<FileTree>
-
-- src/
-  - content/
-    - docs/
-      - **guides/**
-        - guide.md
-        - index.md
-  - pages/
-- astro.config.mjs
-
-</FileTree>
-
-In the future, we plan to support this use case better to avoid the need for the extra nested directory in `src/content/docs/`.
+:::caution
+If you are using Startlight in a subpath, but your assets are being uploaded in the `/`, you don't need to set `assetPrefix`!
+:::
 
 ### Use Starlight with SSR
 

--- a/docs/src/content/docs/manual-setup.mdx
+++ b/docs/src/content/docs/manual-setup.mdx
@@ -102,17 +102,34 @@ If you have an existing Astro project, you can use Starlight to quickly add a do
 
 ### Use Starlight at a subpath
 
-To add all Starlight pages at a subpath, you could relay on top of Astro.js configurations. `base` and `assetPrefix`
+To add all Starlight pages at a subpath, you could relay on top of Astro.js configurations. `base` and `assetsPrefix`
 
 **Base [astro docs](https://docs.astro.build/en/reference/configuration-reference/#base)**
 As the documentation suggests, this will allow you to add basically a `basePath` on your Astro + Startlight project.
 
-**AssetPrefix [astro docs](https://docs.astro.build/en/reference/configuration-reference/#buildassetsprefix)**
+**AssetsPrefix [astro docs](https://docs.astro.build/en/reference/configuration-reference/#buildassetsprefix)**
 In case your subpath also be the root of your project (in case of micro-frontends or github pages), this property allow you to add a prefix in front of your assets, helping you delivery your astro assets!
 
 :::caution
-If you are using Startlight in a subpath, but your assets are being uploaded in the `/`, you don't need to set `assetPrefix`!
+If you are using Startlight in a subpath, but your assets are being uploaded in the `/`, you don't need to set `assetsPrefix`!
 :::
+
+**Samples**
+```typescript
+## Github Sample
+export default defineConfig({
+  base: "/myrepo",
+  build: {
+    assetsPrefix: "/myrepo",
+  },
+});
+
+## SubPages with assets in /
+export default defineConfig({
+  base: "/myrepo"
+});
+
+```
 
 ### Use Starlight with SSR
 


### PR DESCRIPTION
> Expected to use it in hacktoberfest! 

#### What kind of changes does this PR include?
The PR explains a smart way to lead with a subpath without a new directory-level

**Problems:** When using a subpath people may expect `/lang/subpath` which did not happen in this case.

#### Description
Related with:
Discord Talks: 

### ToDo
This is a smart/fast way to introduce the subpath, we keep need to make some changes to support lang before the subpath!
