### PR TITLE
Add links to default components in the JSDoc of component customization configuration

### DIFF
--- a/packages/starlight/schemas/components.ts
+++ b/packages/starlight/schemas/components.ts
@@ -12,6 +12,8 @@ export function ComponentConfigSchema() {
 			 * Includes important tags including `<title>`, and `<meta charset="utf-8">`.
 			 *
 			 * Override this component as a last resort. Prefer the `head` option Starlight config if possible.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/Head.astro Head}
 			 */
 			Head: z.string().default('@astrojs/starlight/components/Head.astro'),
 
@@ -19,6 +21,8 @@ export function ComponentConfigSchema() {
 			 * Component rendered inside `<head>` that sets up dark/light theme support.
 			 * The default implementation includes an inline script and a `<template>` used by the
 			 * script in `ThemeSelect.astro`.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/ThemeProvider.astro ThemeProvider}
 			 */
 			ThemeProvider: z.string().default('@astrojs/starlight/components/ThemeProvider.astro'),
 
@@ -30,6 +34,8 @@ export function ComponentConfigSchema() {
 			 * Component rendered as the first element inside `<body>` which links to the main page
 			 * content for accessibility. The default implementation is hidden until a user focuses it
 			 * by tabbing with their keyboard.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/SkipLink.astro SkipLink}
 			 */
 			SkipLink: z.string().default('@astrojs/starlight/components/SkipLink.astro'),
 
@@ -43,11 +49,15 @@ export function ComponentConfigSchema() {
 			 * `header` and `sidebar` named slots along with a default slot for the main content.
 			 * It also renders `<MobileMenuToggle />` to support toggling the sidebar navigation
 			 * on small (mobile) viewports.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/PageFrame.astro PageFrame}
 			 */
 			PageFrame: z.string().default('@astrojs/starlight/components/PageFrame.astro'),
 			/**
 			 * Component rendered inside `<PageFrame>` that is responsible for toggling the
 			 * sidebar navigation on small (mobile) viewports.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/MobileMenuToggle.astro MobileMenuToggle}
 			 */
 			MobileMenuToggle: z.string().default('@astrojs/starlight/components/MobileMenuToggle.astro'),
 
@@ -55,6 +65,8 @@ export function ComponentConfigSchema() {
 			 * Layout component wrapped around the main content column and right sidebar (table of contents).
 			 * The default implementation handles the switch between a single-column, small-viewport layout
 			 * and a two-column, larger-viewport layout.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/TwoColumnContent.astro TwoColumnContent}
 			 */
 			TwoColumnContent: z.string().default('@astrojs/starlight/components/TwoColumnContent.astro'),
 
@@ -66,29 +78,41 @@ export function ComponentConfigSchema() {
 			 * Header component displayed at the top of every page.
 			 * The default implementation displays `<SiteTitle />`, `<Search />`, `<SocialIcons />`,
 			 * `<ThemeSelect />`, and `<LanguageSelect />`.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/Header.astro Header}
 			 */
 			Header: z.string().default('@astrojs/starlight/components/Header.astro'),
 			/**
 			 * Component rendered at the start of the site header to render the site title.
 			 * The default implementation includes logic for rendering logos defined in Starlight config.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/SiteTitle.astro SiteTitle}
 			 */
 			SiteTitle: z.string().default('@astrojs/starlight/components/SiteTitle.astro'),
 			/**
 			 * Component used to render Starlight’s search UI. The default implementation includes the
 			 * button in the header and the code for displaying a search modal when it is clicked.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/Search.astro Search}
 			 */
 			Search: z.string().default('@astrojs/starlight/components/Search.astro'),
 			/**
 			 * Component rendered in the site header including social icon links. The default
 			 * implementation uses the `social` option in Starlight config to render icons and links.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/SocialIcons.astro SocialIcons}
 			 */
 			SocialIcons: z.string().default('@astrojs/starlight/components/SocialIcons.astro'),
 			/**
 			 * Component rendered in the site header that allows users to select their preferred color scheme.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/ThemeSelect.astro ThemeSelect}
 			 */
 			ThemeSelect: z.string().default('@astrojs/starlight/components/ThemeSelect.astro'),
 			/**
 			 * Component rendered in the site header that allows users to switch to a different language.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/LanguageSelect.astro LanguageSelect}
 			 */
 			LanguageSelect: z.string().default('@astrojs/starlight/components/LanguageSelect.astro'),
 
@@ -101,11 +125,15 @@ export function ComponentConfigSchema() {
 			 * The default implementation displays as a sidebar on wide enough viewports and inside a
 			 * drop-down menu on small (mobile) viewports. It also renders `<MobileMenuFooter />` to
 			 * show additional items inside the mobile menu.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/Sidebar.astro Sidebar}
 			 */
 			Sidebar: z.string().default('@astrojs/starlight/components/Sidebar.astro'),
 			/**
 			 * Component rendered at the bottom of the mobile drop-down menu.
 			 * The default implementation renders `<ThemeSelect />` and `<LanguageSelect />`.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/MobileMenuFooter.astro MobileMenuFooter}
 			 */
 			MobileMenuFooter: z.string().default('@astrojs/starlight/components/MobileMenuFooter.astro'),
 
@@ -116,14 +144,20 @@ export function ComponentConfigSchema() {
 			/**
 			 * Component rendered before the main page’s content to display a table of contents.
 			 * The default implementation renders `<TableOfContents />` and `<MobileTableOfContents />`.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/RightSidebar.astro RightSidebar}
 			 */
 			RightSidebar: z.string().default('@astrojs/starlight/components/RightSidebar.astro'),
 			/**
 			 * Component that renders the current page’s table of contents on wider viewports.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/TableOfContents.astro TableOfContents}
 			 */
 			TableOfContents: z.string().default('@astrojs/starlight/components/TableOfContents.astro'),
 			/**
 			 * Component that renders the current page’s table of contents on small (mobile) viewports.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/MobileTableOfContents.astro MobileTableOfContents}
 			 */
 			MobileTableOfContents: z
 				.string()
@@ -136,10 +170,16 @@ export function ComponentConfigSchema() {
 			/**
 			 * Banner component rendered at the top of each page. The default implementation uses the
 			 * page’s `banner` frontmatter value to decide whether or not to render.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/Banner.astro Banner}
 			 */
 			Banner: z.string().default('@astrojs/starlight/components/Banner.astro'),
 
-			/** Layout component used to wrap sections of the main content column. */
+			/**
+			 * Layout component used to wrap sections of the main content column.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/ContentPanel.astro ContentPanel}
+			 */
 			ContentPanel: z.string().default('@astrojs/starlight/components/ContentPanel.astro'),
 
 			/**
@@ -147,12 +187,16 @@ export function ComponentConfigSchema() {
 			 *
 			 * Implementations should ensure they set `id="_top"` on the `<h1>` element as in the default
 			 * implementation.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/PageTitle.astro PageTitle}
 			 */
 			PageTitle: z.string().default('@astrojs/starlight/components/PageTitle.astro'),
 
 			/**
 			 * Notice displayed to users on pages where a translation for the current language is not
 			 * available. Only used on multilingual sites.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/FallbackContentNotice.astro FallbackContentNotice}
 			 */
 			FallbackContentNotice: z
 				.string()
@@ -161,6 +205,8 @@ export function ComponentConfigSchema() {
 			/**
 			 * Component rendered at the top of the page when `hero` is set in frontmatter. The default
 			 * implementation shows a large title, tagline, and call-to-action links alongside an optional image.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/Hero.astro Hero}
 			 */
 			Hero: z.string().default('@astrojs/starlight/components/Hero.astro'),
 
@@ -171,6 +217,8 @@ export function ComponentConfigSchema() {
 			/**
 			 * Component rendered around each page’s main content.
 			 * The default implementation sets up basic styles to apply to Markdown content.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/MarkdownContent.astro MarkdownContent}
 			 */
 			MarkdownContent: z.string().default('@astrojs/starlight/components/MarkdownContent.astro'),
 
@@ -181,18 +229,26 @@ export function ComponentConfigSchema() {
 			/**
 			 * Footer component displayed at the bottom of each documentation page.
 			 * The default implementation displays `<LastUpdated />`, `<Pagination />`, and `<EditLink />`.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/Footer.astro Footer}
 			 */
 			Footer: z.string().default('@astrojs/starlight/components/Footer.astro'),
 			/**
 			 * Component rendered in the page footer to display the last-updated date.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/LastUpdated.astro LastUpdated}
 			 */
 			LastUpdated: z.string().default('@astrojs/starlight/components/LastUpdated.astro'),
 			/**
 			 * Component rendered in the page footer to display navigation arrows between previous/next pages.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/Pagination.astro Pagination}
 			 */
 			Pagination: z.string().default('@astrojs/starlight/components/Pagination.astro'),
 			/**
 			 * Component rendered in the page footer to display a link to where the page can be edited.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/EditLink.astro EditLink}
 			 */
 			EditLink: z.string().default('@astrojs/starlight/components/EditLink.astro'),
 		})


### PR DESCRIPTION
⚠️ This PR is targeting https://github.com/withastro/starlight/pull/709 ⚠️

#### What kind of changes does this PR include?

- Something else!

#### Description

As [discussed](https://discord.com/channels/830184174198718474/1070481941863878697/1158692572806524928) on Discord, this pull request adds links to the default components in the JSDoc comments for the component customization configuration options.

This means that when you hover over the component name in the configuration options, you will see a link to the default component that a user can click on to quickly navigate to the component's original implementation.

<img width="723" alt="SCR-20231003-nwio" src="https://github.com/withastro/starlight/assets/494699/6e9d20e2-5749-4ae2-ab64-953545dbd491">
