### PR TITLE
Added a template for custom pages

### DIFF
--- a/packages/starlight/layout.ts
+++ b/packages/starlight/layout.ts
@@ -1,1 +1,1 @@
-export { default as Template } from "./layout/Template.astro";
+export { default as StarlightTemplate } from "./layout/Template.astro";

--- a/packages/starlight/layout.ts
+++ b/packages/starlight/layout.ts
@@ -1,0 +1,1 @@
+export { default as Template } from "./layout/Template.astro";

--- a/packages/starlight/layout/Page.astro
+++ b/packages/starlight/layout/Page.astro
@@ -19,6 +19,7 @@ import Header from '../components/Header.astro';
 import Hero from '../components/Hero.astro';
 import MarkdownContent from '../components/MarkdownContent.astro';
 import RightSidebar from '../components/RightSidebar.astro';
+import RightSidebarPanel from '../components/RightSidebarPanel.astro';
 import Sidebar from '../components/Sidebar.astro';
 import SkipLink from '../components/SkipLink.astro';
 import ThemeProvider from '../components/ThemeProvider.astro';
@@ -92,7 +93,15 @@ const pagefindEnabled =
 			<Header slot="header" {locale} />
 			{hasSidebar && <Sidebar slot="sidebar" {sidebar} {locale} />}
 			<TwoColumnContent {hasToC}>
-				<RightSidebar slot="right-sidebar" {headings} {locale} {tocConfig} />
+				{
+					Astro.slots.has('right-sidebar') ? (
+						<RightSidebarPanel slot="right-sidebar">
+							<slot name="right-sidebar" />
+						</RightSidebarPanel>
+					) : (
+						<RightSidebar slot="right-sidebar" {headings} {locale} {tocConfig} />
+					)
+				}
 				<main data-pagefind-body={pagefindEnabled} lang={entryMeta.lang} dir={entryMeta.dir}>
 					{/* TODO: Revisit how this logic flows. */}
 					{entry.data.banner && <Banner {...entry.data.banner} />}

--- a/packages/starlight/layout/Template.astro
+++ b/packages/starlight/layout/Template.astro
@@ -1,0 +1,36 @@
+---
+import config from 'virtual:starlight/user-config';
+import Page from './Page.astro';
+import type { StarlightDocsEntry } from '../utils/routing';
+
+interface Props {
+	title: string;
+	template?: 'splash' | 'doc';
+}
+
+const { title, template } = Astro.props;
+const { pathname } = Astro.url;
+
+const { lang = 'en', dir = 'ltr' } = config.defaultLocale || {};
+let locale = config.defaultLocale?.locale;
+if (locale === 'root') locale = undefined;
+
+const entryMeta = { dir, lang, locale };
+
+const entry: StarlightDocsEntry = {
+	slug: pathname,
+	id: pathname as StarlightDocsEntry['id'],
+	body: '',
+	collection: 'docs',
+	data: {
+		title,
+		template: template ?? 'doc',
+		head: [],
+	},
+};
+---
+
+<Page headings={[]} entry={entry} id={entry.id} slug={entry.slug} {...entryMeta} {entryMeta}>
+	<slot slot="right-sidebar" name="right-sidebar" />
+	<slot />
+</Page>

--- a/packages/starlight/package.json
+++ b/packages/starlight/package.json
@@ -28,6 +28,7 @@
     "./components": "./components.ts",
     "./schema": "./schema.ts",
     "./types": "./types.ts",
+    "./layout": "./layout.ts",
     "./index.astro": "./index.astro",
     "./404.astro": "./404.astro"
   },


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code

#### Description

Created an exported layout template so you can create more customised pages in the `src/pages` directory while keeping the starlight page layout and sidebar navigation.

I had a need where I needed to use `[id].astro` style pages to auto generate docs from external sources but wanted to keep the starlight look and feel. If this isn't a feature starlight is looking for then I'm happy to leave this as fork :smile:

**Example:**

```astro
---
// pages/test.astro
import { StarlightTemplate } from "@astrojs/starlight/layout";
---

<StarlightTemplate title="Hello world">
  <p>A custom astro page with all the starlight goodness!</p>

  <div slot="right-sidebar">
    <h2>Custom Sidebar</h2>
    <p>
      Lorem ipsum dolor sit, amet consectetur adipisicing elit. Dolores beatae
      eos, nostrum dolore veniam voluptates eveniet architecto aliquid!
      Distinctio, iure cumque explicabo aspernatur est vitae fuga tempora
      repellat nisi sed.
    </p>
  </div>
</StarlightTemplate>

```

![image](https://github.com/withastro/starlight/assets/18021383/c87cf4b5-1d5c-4464-b4d1-626d044da664)


<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://github.com/withastro/docs/blob/main/.github/hacktoberfest.md for more details. -->

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
