### PR TITLE
fix: switched h2 to span in sidebar

### DIFF
--- a/.changeset/dull-mails-fold.md
+++ b/.changeset/dull-mails-fold.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+transform sidebar headings into content span elements

--- a/.changeset/dull-mails-fold.md
+++ b/.changeset/dull-mails-fold.md
@@ -2,4 +2,4 @@
 '@astrojs/starlight': patch
 ---
 
-transform sidebar headings into content span elements
+Use `<span>` instead of `<h2>` in sidebar group headings

--- a/packages/starlight/components/SidebarSublist.astro
+++ b/packages/starlight/components/SidebarSublist.astro
@@ -35,7 +35,7 @@ interface Props {
 						open={flattenSidebar(entry.entries).some((i) => i.isCurrent) || !entry.collapsed}
 					>
 						<summary>
-							<h2 class="large">{entry.label}</h2>
+							<span class="large">{entry.label}</span>
 							<Icon name="right-caret" class="caret" size="1.25rem" />
 						</summary>
 						<Astro.self sublist={entry.entries} nested />


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

<!-- Delete any that don’t apply -->

- Changes to Starlight code


#### Description

- Closes #  https://github.com/withastro/starlight/issues/808

- What does this PR change? Give us a brief description.
switches the h2 to a span element. 


<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://github.com/withastro/docs/blob/main/.github/hacktoberfest.md for more details. -->

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
