### PR TITLE
Add first-time contributor action

### DIFF
--- a/.github/workflows/welcome-bot.yml
+++ b/.github/workflows/welcome-bot.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   welcome:
-    name: Welcome First Time Contributors
+    name: Welcome First-Time Contributors
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -18,13 +18,15 @@ jobs:
         with:
           repo-token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
           pr-message: |
-            Hello! Thank you for opening your **first PR** to Starlight! 🎉
+            Hello! Thank you for opening your **first PR** to Starlight! ✨
+
             Here’s what will happen next:
+
             1. Our GitHub bots will run to check your changes.
                If they spot any issues you will see some error messages on this PR.
                Don’t hesitate to ask any questions if you’re not sure what these mean!
 
-            2. In a few minutes, you’ll be able to see a preview of your changes on Vercel 🥳
+            2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🤩
 
             3. One or more of our maintainers will take a look and may ask you to make changes.
                We try to be responsive, but don’t worry if this takes a few days.

--- a/.github/workflows/welcome-bot.yml
+++ b/.github/workflows/welcome-bot.yml
@@ -1,0 +1,30 @@
+name: WelcomeBot
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  welcome:
+    name: Welcome First Time Contributors
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
+          pr-message: |
+            Hello! Thank you for opening your **first PR** to Starlight! 🎉
+            Here’s what will happen next:
+            1. Our GitHub bots will run to check your changes.
+               If they spot any issues you will see some error messages on this PR.
+               Don’t hesitate to ask any questions if you’re not sure what these mean!
+
+            2. In a few minutes, you’ll be able to see a preview of your changes on Vercel 🥳
+
+            3. One or more of our maintainers will take a look and may ask you to make changes.
+               We try to be responsive, but don’t worry if this takes a few days.


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Something else!

#### Description

Following https://github.com/withastro/docs/pull/4966, this pull request adds the same GitHub Actions workflow to the Starlight repository.

Compared to the Astro Docs repository, I made the following changes to the message:

```diff
- Hello! Thank you for opening your **first PR** to Astro’s Docs! 🎉
+ Hello! Thank you for opening your **first PR** to Starlight! 🎉
```

```diff
- If they spot any broken links you will see some error messages on this PR.
+ If they spot any issues you will see some error messages on this PR.
```

```diff
- 2. In a few minutes, you’ll be able to see a preview of your changes on Netlify 🥳
+ 2. In a few minutes, you’ll be able to see a preview of your changes on Vercel 🥳
```

(in preparation of #795)