### PR TITLE
fix: prevent text from overflowing prev/next links

### DIFF
--- a/.changeset/tasty-garlics-dress.md
+++ b/.changeset/tasty-garlics-dress.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Prevent text from overflowing pagination items

--- a/packages/starlight/components/Pagination.astro
+++ b/packages/starlight/components/Pagination.astro
@@ -9,7 +9,7 @@ const isRtl = dir === 'rtl';
 const t = useTranslations(locale);
 ---
 
-<div class="pagination-links sl-flex" dir={dir}>
+<div class="pagination-links" dir={dir}>
 	{
 		prev && (
 			<a href={prev.href} rel="prev">
@@ -38,7 +38,8 @@ const t = useTranslations(locale);
 
 <style>
 	.pagination-links {
-		flex-wrap: wrap;
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(18rem, 100%), 1fr));
 		gap: 1rem;
 	}
 
@@ -56,6 +57,7 @@ const t = useTranslations(locale);
 		text-decoration: none;
 		color: var(--sl-color-gray-2);
 		box-shadow: var(--sl-shadow-md);
+		overflow-wrap: anywhere;
 	}
 	[rel='next'] {
 		justify-content: end;
@@ -70,5 +72,9 @@ const t = useTranslations(locale);
 		color: var(--sl-color-white);
 		font-size: var(--sl-text-2xl);
 		line-height: var(--sl-line-height-headings);
+	}
+
+	svg {
+		flex-shrink: 0;
 	}
 </style>


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to Starlight code

#### Before the final merge if/when approved

- [x] Remove https://github.com/withastro/starlight/pull/814/commits/2cd86e9d6c40e2f4ddf6323fee3fd3874a17d65f which gathers the extra long texts added for testing purposes
  - ⚠️ This commit breaks pa11y-ci job temporarily

#### Description

This PR is a follow-up of https://github.com/withastro/starlight/pull/756 where we decided to extract this fix for prev/next links in a separate PR. We agreed at the time that the suggested fix wasn't good enough because relying on media queries and values that don't exist already as media queries in Starlight (see discussion from https://github.com/withastro/starlight/pull/756#discussion_r1337584797).

A possible simple fix would have been to use media containers because what we really want is a specific rendering based on the size of the container but the browsers' support is not yet good enough.

So I had to rely on some advanced features of `display: grid` often used to create complex layouts.

The following code already existed and worked well for the rendering of each pagination item.
```css
a {
  flex-basis: calc(50% - 0.5rem);
  flex-grow: 1;
}
```

Since we are playing with auto layouts and sizes, the icon size can sometimes be reduced (or the icon can "disappear"), so the following allows us to keep the same size for the icon:

```css
svg {
  flex-shrink: 0
}
```

The most complex part is definitely the following:

```css
.pagination-links {
  display: grid;
  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
  grid-gap: 1rem;
}
```

The `grid-template-columns` property defines the columns of the grid. The `repeat(auto-fit, minmax(200px, 1fr))` value means that the grid will automatically create as many columns as it can fit in the available space, with a minimum width of 200px and a maximum width of 1fr (which means the columns will take up equal space).
If I say it differently, the pagination item will take the whole space until there's enough space to render two 200px pagination items on the same row.

The `grid-gap` property sets the gap between the columns.

#### Tested environments

In terms of browsers' support, it seems to be safe to use:
- [`display: grid`](https://caniuse.com/?search=display%3A%20grid)
- [`grid-template-columns`](https://caniuse.com/?search=grid-template-columns)
- [`repeat()`](https://developer.mozilla.org/en-US/docs/Web/CSS/repeat#browser_compatibility)
- [ `minmax()`](https://developer.mozilla.org/en-US/docs/Web/CSS/minmax#browser_compatibility)

So I tested only the oldest combinations of browsers/versions listed in [our compatibility browsers list](https://browsersl.ist/#q=%3E+0.5%25%2C+not+dead%2C+Chrome+%3E%3D+88%2C+Edge+%3E%3D+88%2C+Firefox+%3E%3D+98%2C+Safari+%3E%3D+15.4%2C+iOS+%3E%3D+15.4%2C+not+op_mini+all)):

- Firefox 118.0.1 / macOS 14.1 (my env by default)
- Chrome 88 / Windows 8
- Edge 88 / Windows 8
- iPhone 12 Pro Max / Safari 16
  - ⚠️ I don't have any 15.4 env to test on BrowserStack, before 15.4, the layout is completely broken so untestable
- Firefox 98 / macOS 12.1 