### PR TITLE
i18n(fr): update `reference/configuration.md`

### DIFF
--- a/docs/src/content/docs/fr/reference/configuration.md
+++ b/docs/src/content/docs/fr/reference/configuration.md
@@ -83,7 +83,7 @@ Avec cette configuration, une page `/introduction` aurait un lien d'édition poi
 
 ### `sidebar`
 
-**type:** [`SidebarItem[]`](#sidebarittem)
+**type:** [`SidebarItem[]`](#sidebaritem)
 
 Configure les éléments de navigation de la barre latérale de votre site.
 
@@ -187,9 +187,13 @@ type SidebarItem = {
   | {
       link: string;
       badge?: string | BadgeConfig;
+      attrs?: Record<string, string | number | boolean | undefined>;
     }
-  | { items: SidebarItem[] }
-  | { autogenerate: { directory: string } }
+  | { items: SidebarItem[]; collapsed?: boolean }
+  | {
+      autogenerate: { directory: string; collapsed?: boolean };
+      collapsed?: boolean;
+    }
 );
 ```
 
@@ -304,7 +308,7 @@ La locale par défaut sera utilisée pour fournir un contenu de remplacement lor
 
 ### `social`
 
-**type:** `Partial<Record<'bitbucket' | 'codeberg' | 'codePen' | 'discord' | 'github' | 'gitlab' | 'gitter' | 'instagram' | 'linkedin' | 'mastodon' | 'microsoftTeams' | 'rss' | 'stackOverflow' | 'telegram' | 'threads' | 'twitch' | 'twitter' | 'x.com' | 'youtube', string>>`
+**type:** `Partial<Record<'bitbucket' | 'codeberg' | 'codePen' | 'discord' | 'email' | 'facebook' | 'github' | 'gitlab' | 'gitter' | 'instagram' | 'linkedin' | 'mastodon' | 'microsoftTeams' | 'rss' | 'stackOverflow' | 'telegram' | 'threads' | 'twitch' | 'twitter' | 'x.com' | 'youtube', string>>`
 
 Détails optionnels sur les comptes de médias sociaux pour ce site. L'ajout de l'un d'entre eux les affichera sous forme de liens iconiques dans l'en-tête du site.
 
@@ -424,3 +428,29 @@ starlight({
   ],
 });
 ```
+
+### `titleDelimiter`
+
+**type:** `string`  
+**default:** `'|'`
+
+Définit le délimiteur entre le titre de la page et le titre du site dans la balise `<title>` de la page, qui s'affiche dans les onglets du navigateur.
+
+Par défaut, chaque page a une balise `<title>` contenant `Titre de la page | Titre du site`.
+Par example, cette page a pour titre « Référence de configuration » et ce site a pour titre « Starlight », donc la balise `<title>` de cette page contient « Référence de configuration | Starlight ».
+
+### `components`
+
+**type:** `Record<string, string>`
+
+Fournit les chemins vers les composants pour redéfinir les implémentations par défaut de Starlight.
+
+```js
+starlight({
+  components: {
+    SocialLinks: './src/components/MySocialLinks.astro',
+  },
+});
+```
+
+Consultez la [référence des redéfinitions](/fr/reference/overrides/) pour plus de détails sur tous les composants que vous pouvez redéfinir.


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

This pull request updates the french translation of the `reference/configuration.md` file with the changes of #447, #709, #774 and #815.

Regarding the translation of `override` in french, there are multiple possibilities:

- `remplacer` which would be the most accurate translation for the common `replace` verb.
- `surcharger` which would be the most accurate translation for `overload` in the context of programming, e.g. Java method overloading.
- `redéfinir` which would be the most accurate translation for `override` in the context of programming, e.g. Java method overriding.

Considering the definitions of `overloading` and `overriding` in the context of programming, I went with `redéfinir` (verb) and `redéfinition` (noun) for the translation of `override` in the context of Starlight components.