### PR TITLE
i18n(zh-CN): translate `overrides.md`, `overriding-components.md`

### DIFF
--- a/docs/src/content/docs/zh/guides/overriding-components.md
+++ b/docs/src/content/docs/zh/guides/overriding-components.md
@@ -130,4 +130,4 @@ const isHomepage = Astro.props.slug === '';
 }
 ```
 
-了解更多关于条件渲染的内容，请参阅 [Astro 模板语法指南](https://docs.astro.build/zh-cn/core-concepts/astro-syntax/#%E5%8A%A8%E6%80%81-html)。
+了解更多关于条件渲染的内容，请参阅 [Astro 模板语法指南](https://docs.astro.build/zh-cn/core-concepts/astro-syntax/#动态-html)。

--- a/docs/src/content/docs/zh/guides/overriding-components.md
+++ b/docs/src/content/docs/zh/guides/overriding-components.md
@@ -66,7 +66,7 @@ Starlight 的默认 UI 和配置选项被设计成能灵活地适用于各种内
 ---
 // src/components/EmailLink.astro
 import type { Props } from '@astrojs/starlight/props';
-import Default from '@astrojs/starlight/SocialIcons.astro';
+import Default from '@astrojs/starlight/components/SocialIcons.astro';
 ---
 
 <a href="mailto:houston@example.com">E-mail Me</a>
@@ -114,7 +114,7 @@ const { title } = Astro.props.entry.data;
 ---
 // src/components/ConditionalFooter.astro
 import type { Props } from '@astrojs/starlight/props';
-import Default from '@astrojs/starlight/Footer.astro';
+import Default from '@astrojs/starlight/components/Footer.astro';
 
 const isHomepage = Astro.props.slug === '';
 ---

--- a/docs/src/content/docs/zh/guides/overriding-components.md
+++ b/docs/src/content/docs/zh/guides/overriding-components.md
@@ -1,0 +1,133 @@
+---
+title: 重写组件
+description: 学习如何通过替换 Starlight 的内置组件来给你的文档站点 UI 添加自定义元素。
+sidebar:
+  badge: 新功能
+---
+
+Starlight 的默认 UI 和配置选项被设计成能灵活地适用于各种内容。大部分 Starlight 的默认外观可以通过 [CSS](/zh/guides/css-and-tailwind/) 和 [配置选项](/zh/guides/customization/) 进行自定义。
+
+当你的需求超出了默认提供的功能时，Starlight 支持使用你自己的自定义组件来扩展或重写（完全替换）它的默认组件。
+
+## 什么时候重写
+
+重写 Starlight 的默认组件在以下情况下很有用：
+
+- 你想要修改 Starlight 的一部分 UI 的样式，但是无法通过使用[自定义 CSS](/zh/guides/css-and-tailwind/) 实现。
+- 你想要修改 Starlight 的一部分 UI 的行为。
+- 你想要在 Starlight 的现有 UI 旁边添加一些额外的 UI。
+
+## 如何重写
+
+1. 选择你想要重写的 Starlight 组件。
+   你可以在[重写参考](/zh/reference/overrides/)中找到完整的组件列表。
+
+   本示例将重写 Starlight 页面导航栏中的 [`SocialIcons`](/zh/reference/overrides/#socialicons) 组件。
+
+2. 创建一个 Astro 组件来替换 Starlight 组件。
+   本示例渲染了一个联系方式链接。
+
+   ```astro
+   ---
+   // src/components/EmailLink.astro
+   import type { Props } from '@astrojs/starlight/props';
+   ---
+
+   <a href="mailto:houston@example.com">E-mail Me</a>
+   ```
+
+3. 在 `astro.config.mjs` 的 [`components`](/zh/reference/configuration/#components) 配置选项中告诉 Starlight 使用你的自定义组件：
+
+   ```js {9-12}
+   // astro.config.mjs
+   import { defineConfig } from 'astro/config';
+   import starlight from '@astrojs/starlight';
+
+   export default defineConfig({
+     integrations: [
+       starlight({
+         title: 'My Docs with Overrides',
+         components: {
+           // 重写默认的 `SocialLinks` 组件。
+           SocialIcons: './src/components/EmailLink.astro',
+         },
+       }),
+     ],
+   });
+   ```
+
+## 复用内置组件
+
+你可以像使用自己的组件一样使用 Starlight 的默认 UI 组件：导入并在你自己的自定义组件中渲染它们。这样你就可以在你的设计中保留 Starlight 的基本 UI，同时在它们旁边添加额外的 UI。
+
+下面的示例是一个自定义组件，它渲染了一个电子邮件链接以及默认的 `SocialLinks` 组件：
+
+```astro {4,8}
+---
+// src/components/EmailLink.astro
+import type { Props } from '@astrojs/starlight/props';
+import Default from '@astrojs/starlight/SocialIcons.astro';
+---
+
+<a href="mailto:houston@example.com">E-mail Me</a>
+<Default {...Astro.props}><slot /></Default>
+```
+
+在自定义组件中渲染内置组件时：
+
+- 展开传入 `Astro.props`。这样可以确保它接收到渲染所需的所有数据。
+- 在默认组件内部添加一个 [`<slot />`](https://docs.astro.build/en/core-concepts/astro-components/#slots)。这样，如果组件传入了任何子元素，Astro 就知道在哪里渲染它们。
+
+## 使用页面数据
+
+当重写 Starlight 组件时，你的自定义实现会接收一个标准的 `Astro.props` 对象，其中包含当前页面的所有数据。
+这使得你可以使用这些值来控制你的组件模板的渲染方式。
+
+例如，你可以通过 `Astro.props.entry.data` 读取页面的 frontmatter 数据。在下面的示例中，一个 [`PageTitle`](/zh/reference/overrides/#pagetitle) 的替代组件使用它来显示当前页面的标题：
+
+```astro {5} "{title}"
+---
+// src/components/Title.astro
+import type { Props } from '@astrojs/starlight/props';
+
+const { title } = Astro.props.entry.data;
+---
+
+<h1 id="_top">{title}</h1>
+
+<style>
+  h1 {
+    font-family: 'Comic Sans';
+  }
+</style>
+```
+
+要了解更多关于可用的参数的信息，请参阅[重写参考](/zh/reference/overrides/#%E7%BB%84%E4%BB%B6%E5%8F%82%E6%95%B0)。
+
+### 仅在特定页面上重写
+
+组件重写在所有页面上生效。但是，你可以使用 `Astro.props` 中的值来条件性渲染，决定何时显示你的自定义 UI，何时显示 Starlight 的默认 UI，甚至何时显示完全不同的内容。
+
+在下面的示例中，一个重写 [`Footer`](/zh/reference/overrides/#footer-1) 的组件只在首页上显示“Built with Starlight 🌟”，在其他页面上显示默认的页脚：
+
+```astro
+---
+// src/components/ConditionalFooter.astro
+import type { Props } from '@astrojs/starlight/props';
+import Default from '@astrojs/starlight/Footer.astro';
+
+const isHomepage = Astro.props.slug === '';
+---
+
+{
+  isHomepage ? (
+    <footer>Built with Starlight 🌟</footer>
+  ) : (
+    <Default {...Astro.props}>
+      <slot />
+    </Default>
+  )
+}
+```
+
+了解更多关于条件渲染的内容，请参阅 [Astro 模板语法指南](https://docs.astro.build/zh-cn/core-concepts/astro-syntax/#%E5%8A%A8%E6%80%81-html)。

--- a/docs/src/content/docs/zh/guides/overriding-components.md
+++ b/docs/src/content/docs/zh/guides/overriding-components.md
@@ -48,7 +48,7 @@ Starlight 的默认 UI 和配置选项被设计成能灵活地适用于各种内
        starlight({
          title: 'My Docs with Overrides',
          components: {
-           // 重写默认的 `SocialLinks` 组件。
+           // 重写默认的 `SocialIcons` 组件。
            SocialIcons: './src/components/EmailLink.astro',
          },
        }),
@@ -60,7 +60,7 @@ Starlight 的默认 UI 和配置选项被设计成能灵活地适用于各种内
 
 你可以像使用自己的组件一样使用 Starlight 的默认 UI 组件：导入并在你自己的自定义组件中渲染它们。这样你就可以在你的设计中保留 Starlight 的基本 UI，同时在它们旁边添加额外的 UI。
 
-下面的示例是一个自定义组件，它渲染了一个电子邮件链接以及默认的 `SocialLinks` 组件：
+下面的示例是一个自定义组件，它渲染了一个电子邮件链接以及默认的 `SocialIcons` 组件：
 
 ```astro {4,8}
 ---
@@ -108,7 +108,7 @@ const { title } = Astro.props.entry.data;
 
 组件重写在所有页面上生效。但是，你可以使用 `Astro.props` 中的值来条件性渲染，决定何时显示你的自定义 UI，何时显示 Starlight 的默认 UI，甚至何时显示完全不同的内容。
 
-在下面的示例中，一个重写 [`Footer`](/zh/reference/overrides/#footer-1) 的组件只在首页上显示“Built with Starlight 🌟”，在其他页面上显示默认的页脚：
+在下面的示例中，一个重写 [`Footer`](/zh/reference/overrides/#footer) 的组件只在首页上显示“Built with Starlight 🌟”，在其他页面上显示默认的页脚：
 
 ```astro
 ---

--- a/docs/src/content/docs/zh/reference/overrides.md
+++ b/docs/src/content/docs/zh/reference/overrides.md
@@ -89,7 +89,7 @@ entry: {
 }
 ```
 
-在 [Astro 的集合条目类型](https://docs.astro.build/zh-cn/reference/api-reference/#%E9%9B%86%E5%90%88%E6%9D%A1%E7%9B%AE%E7%B1%BB%E5%9E%8B)参考中了解更多关于此对象的信息。
+在 [Astro 的集合条目类型](https://docs.astro.build/zh-cn/reference/api-reference/#集合条目类型)参考中了解更多关于此对象的信息。
 
 #### `sidebar`
 
@@ -141,7 +141,7 @@ entry: {
 ### 头部
 
 这些组件在每个页面的 `<head>` 元素内渲染。
-它们应只包含[允许在 `<head>` 中使用的元素](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/head#%E7%9B%B8%E5%85%B3%E9%93%BE%E6%8E%A5)。
+它们应只包含[允许在 `<head>` 中使用的元素](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/head#相关链接)。
 
 #### `Head`
 
@@ -162,13 +162,13 @@ entry: {
 
 ---
 
-### 可访问性
+### 无障碍
 
 #### `SkipLink`
 
 **默认组件：** [`SkipLink.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/SkipLink.astro)
 
-在 `<body>` 内渲染的第一个元素，它链接到主页面内容以实现可访问性。
+在 `<body>` 内渲染的第一个元素，它链接到主页面内容以实现无障碍访问。
 默认实现默认为隐藏状态，只有在用户使用键盘通过 tab 键聚焦到它时才会显示。
 
 ---
@@ -176,7 +176,7 @@ entry: {
 ### 布局
 
 这些组件负责在不同的断点 (breakpoints) 上布局 Starlight 的组件、管理视图。
-重载这些组件会有很大的复杂性。
+重写这些组件会有很大的复杂性。
 如果可能，请优先重写较低级别的组件。
 
 #### `PageFrame`
@@ -281,8 +281,6 @@ Starlight 的页面侧边栏负责显示当前页面的子标题的目录。
 
 在页面内容之前渲染的包含目录的组件。
 默认实现渲染了 [`<TableOfContents />`](#tableofcontents) 和 [`<MobileTableOfContents />`](#mobiletableofcontents)。
-Component rendered before the main page’s content to display a table of contents.
-The default implementation renders [`<TableOfContents />`](#tableofcontents) and [`<MobileTableOfContents />`](#mobiletableofcontents).
 
 #### `TableOfContents`
 

--- a/docs/src/content/docs/zh/reference/overrides.md
+++ b/docs/src/content/docs/zh/reference/overrides.md
@@ -77,7 +77,7 @@ Starlight 会将以下参数传递给你的自定义组件。
 #### `entry`
 
 当前页面所对应的 Astro 内容集合条目。
-在 `entry.data` 中包含当前页面的 frontmatter 值。
+在 `entry.data` 中包含当前页面的 frontmatter 内容。
 
 ```ts
 entry: {

--- a/docs/src/content/docs/zh/reference/overrides.md
+++ b/docs/src/content/docs/zh/reference/overrides.md
@@ -1,6 +1,6 @@
 ---
 title: 重写参考
-description: Starlight 支持重写的组件以及组件的概述。
+description: Starlight 支持重写的组件以及组件参数的概述。
 tableOfContents:
   maxHeadingLevel: 4
 ---

--- a/docs/src/content/docs/zh/reference/overrides.md
+++ b/docs/src/content/docs/zh/reference/overrides.md
@@ -1,0 +1,376 @@
+---
+title: 重写参考
+description: Starlight 支持重写的组件以及组件的概述。
+tableOfContents:
+  maxHeadingLevel: 4
+---
+
+你可以通过在 Starlight 的 [`components`](/zh/reference/configuration/#components) 配置选项中提供替代组件的路径来替换掉 (即重写) Starlight 的内置组件。
+本页面列出了所有可被重写的组件和它们默认实现的 GitHub 链接。
+
+在 [重写组件指南](/zh/guides/overriding-components/) 中了解更多。
+
+## 组件参数
+
+所有组件都可以使用标准的 `Astro.props` 对象，该对象包含有关当前页面的信息。
+
+从 Starlight 导入 `Props` 类型来为你的自定义组件定义类型：
+
+```astro
+---
+import type { Props } from '@astrojs/starlight/props';
+
+const { hasSidebar } = Astro.props;
+//      ^ type: boolean
+---
+```
+
+这样当使用 `Astro.props` 时就会有自动补全和类型提示。
+
+### 参数
+
+Starlight 会将以下参数传递给你的自定义组件。
+
+#### `dir`
+
+**类型：** `'ltr' | 'rtl'`
+
+当前页面的文本方向。
+
+#### `lang`
+
+**类型：** `string`
+
+当前页面的 BCP-47 语言标签，例如 `en`、`zh` 或 `pt-BR`。
+
+#### `locale`
+
+**类型：** `string | undefined`
+
+当前语言的根路径。对于默认语言来说是 `undefined`。
+
+#### `slug`
+
+**类型：** `string`
+
+从内容文件名生成的页面 slug。
+
+#### `id`
+
+**类型：** `string`
+
+基于内容文件名的页面的唯一 ID。
+
+#### `isFallback`
+
+**类型：** `true | undefined`
+
+如果此页面在当前语言中未翻译，回退到使用默认语言的内容，则为 `true`。
+仅在多语言站点中使用。
+
+#### `entryMeta`
+
+**类型：** `{ dir: 'ltr' | 'rtl'; lang: string }`
+
+页面内容的语言环境元数据 (locale metadata)。当页面使用回退内容时可以与顶级语言环境设置值不同。
+
+#### `entry`
+
+当前页面所对应的 Astro 内容集合条目。
+在 `entry.data` 中包含当前页面的 frontmatter 值。
+
+```ts
+entry: {
+  data: {
+    title: string;
+    description: string | undefined;
+    // 等
+  }
+}
+```
+
+在 [Astro 的集合条目类型](https://docs.astro.build/zh-cn/reference/api-reference/#%E9%9B%86%E5%90%88%E6%9D%A1%E7%9B%AE%E7%B1%BB%E5%9E%8B)参考中了解更多关于此对象的信息。
+
+#### `sidebar`
+
+**类型：** `SidebarEntry[]`
+
+当前页面的侧边栏条目。
+
+#### `hasSidebar`
+
+**类型：** `boolean`
+
+当前页面是否应该显示侧边栏。
+
+#### `pagination`
+
+**类型：** `{ prev?: Link; next?: Link }`
+
+如果启用了，当前页面在侧边栏中的上一页和下一页的链接。
+
+#### `toc`
+
+**类型：** `{ minHeadingLevel: number; maxHeadingLevel: number; items: TocItem[] } | undefined`
+
+如果启用了，当前页面的目录 (table of contents)。
+
+#### `headings`
+
+**类型：** `{ depth: number; slug: string; text: string }[]`
+
+从当前页面提取的所有 Markdown 标题的数组。
+如果你想要构建一个遵循 Starlight 配置选项的目录，请使用 [`toc`](#toc)。
+
+#### `lastUpdated`
+
+**类型：** `Date | undefined`
+
+如果启用了，表示此页面最后更新时间的 JavaScript `Date` 对象。
+
+#### `editUrl`
+
+**类型：** `URL | undefined`
+
+如果启用了，表示可以编辑此页面的地址的 JavaScript `URL` 对象。
+
+---
+
+## 组件
+
+### 头部
+
+这些组件在每个页面的 `<head>` 元素内渲染。
+它们应只包含[允许在 `<head>` 中使用的元素](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/head#%E7%9B%B8%E5%85%B3%E9%93%BE%E6%8E%A5)。
+
+#### `Head`
+
+**默认组件：** [`Head.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Head.astro)
+
+在每个页面的 `<head>` 元素内渲染的组件。
+包含 `<title>` 和 `<meta charset="utf-8">` 等重要标签。
+
+重写此组件应作为最后手段。
+如果可能，请优先使用 Starlight 配置中的 [`head`](/zh/reference/configuration/#head) 选项。
+
+#### `ThemeProvider`
+
+**默认组件：** [`ThemeProvider.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/ThemeProvider.astro)
+
+在 `<head>` 内渲染的用于提供暗色/亮色主题支持的组件。
+默认实现包括一个内联脚本和一个 `<template>`，该脚本在 [`<ThemeSelect />`](#themeselect) 中使用该模板。
+
+---
+
+### 可访问性
+
+#### `SkipLink`
+
+**默认组件：** [`SkipLink.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/SkipLink.astro)
+
+在 `<body>` 内渲染的第一个元素，它链接到主页面内容以实现可访问性。
+默认实现默认为隐藏状态，只有在用户使用键盘通过 tab 键聚焦到它时才会显示。
+
+---
+
+### 布局
+
+这些组件负责在不同的断点 (breakpoints) 上布局 Starlight 的组件、管理视图。
+重载这些组件会有很大的复杂性。
+如果可能，请优先重写较低级别的组件。
+
+#### `PageFrame`
+
+**默认组件：** [`PageFrame.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/PageFrame.astro)
+
+包在绝大部分页面内容外的布局组件。
+默认实现提供了头部—侧边栏—主内容的布局，并包含 `header` 和 `sidebar` 命名插槽以及主内容的默认插槽。
+它还渲染了 [`<MobileMenuToggle />`](#mobilemenutoggle) 以支持在小 (移动) 视口 (viewports) 上切换侧边栏导航。
+
+#### `MobileMenuToggle`
+
+**默认组件：** [`MobileMenuToggle.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/MobileMenuToggle.astro)
+
+在 [`<PageFrame>`](#pageframe) 内渲染的负责在小 (移动) 视口上切换侧边栏导航的组件。
+
+#### `TwoColumnContent`
+
+**默认组件：** [`TwoColumnContent.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/TwoColumnContent.astro)
+
+包在主内容列和右侧栏 (目录) 外的布局组件。
+默认实现实现了在单列、小视口布局和两列、较大视口布局之间的切换。
+
+---
+
+### 导航
+
+这些组件渲染 Starlight 的顶部导航栏。
+
+#### `Header`
+
+**默认组件：** [`Header.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Header.astro)
+
+在每个页面顶部显示的导航栏组件。
+默认实现显示了 [`<SiteTitle />`](#sitetitle)、[`<Search />`](#search)、[`<SocialIcons />`](#socialicons)、[`<ThemeSelect />`](#themeselect) 和 [`<LanguageSelect />`](#languageselect)。
+
+#### `SiteTitle`
+
+**默认组件：** [`SiteTitle.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/SiteTitle.astro)
+
+在导航栏开头渲染的组件，用于渲染站点标题。
+默认实现包含在 Starlight 配置中定义的 logo 的渲染逻辑。
+
+#### `Search`
+
+**默认组件：** [`Search.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Search.astro)
+
+用于渲染 Starlight 搜索 UI 的组件。
+默认实现包含在导航栏中的按钮和在点击时显示搜索模态框以及加载 [Pagefind UI](https://pagefind.app/) 的代码。
+
+#### `SocialIcons`
+
+**默认组件：** [`SocialIcons.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/SocialIcons.astro)
+
+在导航栏中渲染的组件，用于渲染社交图标链接。
+默认实现使用 Starlight 配置中的 [`social`](/zh/reference/configuration/#social) 选项来渲染图标和链接。
+
+#### `ThemeSelect`
+
+**默认组件：** [`ThemeSelect.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/ThemeSelect.astro)
+
+在导航栏中渲染的组件，用于允许用户选择深浅主题偏好。
+
+#### `LanguageSelect`
+
+**默认组件：** [`LanguageSelect.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/LanguageSelect.astro)
+
+在导航栏中渲染的组件，用于允许用户切换到不同的语言。
+
+---
+
+### 全局侧边栏
+
+Starlight 的全局侧边栏包含了主站点导航。
+在较窄的视口上，它会隐藏在下拉菜单中。
+
+#### `Sidebar`
+
+**默认组件：** [`Sidebar.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Sidebar.astro)
+
+在页面内容之前渲染的包含全局导航的组件。
+默认实现在足够宽的视口上显示为侧边栏，在小 (移动) 视口上显示为下拉菜单。
+它还渲染了 [`<MobileMenuFooter />`](#mobilemenufooter) 以在移动菜单中显示额外的项目。
+
+#### `MobileMenuFooter`
+
+**默认组件：** [`MobileMenuFooter.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/MobileMenuFooter.astro)
+
+在移动下拉菜单最底部中渲染的组件。
+默认实现渲染了 [`<ThemeSelect />`](#themeselect) 和 [`<LanguageSelect />`](#languageselect)。
+
+---
+
+### 页面侧边栏
+
+Starlight 的页面侧边栏负责显示当前页面的子标题的目录。
+在较窄的视口上，它会缩为一个固定的下拉菜单。
+
+#### `PageSidebar`
+
+**默认组件：** [`PageSidebar.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/PageSidebar.astro)
+
+在页面内容之前渲染的包含目录的组件。
+默认实现渲染了 [`<TableOfContents />`](#tableofcontents) 和 [`<MobileTableOfContents />`](#mobiletableofcontents)。
+Component rendered before the main page’s content to display a table of contents.
+The default implementation renders [`<TableOfContents />`](#tableofcontents) and [`<MobileTableOfContents />`](#mobiletableofcontents).
+
+#### `TableOfContents`
+
+**默认组件：** [`TableOfContents.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/TableOfContents.astro)
+
+在较宽的视口上渲染当前页面的目录的组件。
+
+#### `MobileTableOfContents`
+
+**默认组件：** [`MobileTableOfContents.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/MobileTableOfContents.astro)
+
+在小 (移动) 视口上渲染当前页面的目录的组件。
+
+---
+
+### 内容
+
+这些组件在页面主内容列中渲染。
+
+#### `Banner`
+
+**默认组件：** [`Banner.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Banner.astro)
+
+横幅 (Banner) 组件在每个页面的顶部渲染。
+默认实现使用页面的 [`banner`](/zh/reference/frontmatter#banner) frontmatter 值来决定是否渲染。
+
+#### `ContentPanel`
+
+**默认组件：** [`ContentPanel.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/ContentPanel.astro)
+
+包在页面主内容列中的段落外的布局组件。
+
+#### `PageTitle`
+
+**默认组件：** [`PageTitle.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/PageTitle.astro)
+
+包含当前页面的 `<h1>` 元素的组件。
+
+自定义实现应确保在 `<h1>` 元素上设置 `id="_top"`，就像默认实现中一样。
+
+#### `FallbackContentNotice`
+
+**默认组件：** [`FallbackContentNotice.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/FallbackContentNotice.astro)
+
+在本页面当前语言没有翻译时显示给用户的通知。
+仅在多语言站点中使用。
+
+#### `Hero`
+
+**默认组件：** [`Hero.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Hero.astro)
+
+当设置了 frontmatter 中的 [`hero`](/zh/reference/frontmatter#hero) 时在页面顶部渲染的组件。
+默认实现显示了一个大标题、标语、动作链接 (call-to-action links) 和可选的图片。
+
+#### `MarkdownContent`
+
+**默认组件：** [`MarkdownContent.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/MarkdownContent.astro)
+
+在页面主内容列中渲染 Markdown 内容的组件。
+默认实现为 Markdown 内容提供了基本的样式。
+
+---
+
+### 页脚
+
+这些组件在页面主内容列的底部渲染。
+
+#### `Footer`
+
+**默认组件：** [`Footer.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Footer.astro)
+
+页脚 (Footer) 组件在每个页面的底部渲染。
+默认实现显示了 [`<LastUpdated />`](#lastupdated)、[`<Pagination />`](#pagination) 和 [`<EditLink />`](#editlink)。
+
+#### `LastUpdated`
+
+**默认组件：** [`LastUpdated.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/LastUpdated.astro)
+
+在页脚中渲染的组件，用于显示最后更新日期。
+
+#### `EditLink`
+
+**默认组件：** [`EditLink.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/EditLink.astro)
+
+在页脚中渲染的组件，用于显示指向页面编辑地址的链接。
+
+#### `Pagination`
+
+**默认组件：** [`Pagination.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Pagination.astro)
+
+在页脚中渲染的组件，用于显示上一页和下一页的导航箭头。

--- a/docs/src/content/docs/zh/reference/overrides.md
+++ b/docs/src/content/docs/zh/reference/overrides.md
@@ -8,7 +8,7 @@ tableOfContents:
 你可以通过在 Starlight 的 [`components`](/zh/reference/configuration/#components) 配置选项中提供替代组件的路径来替换掉 (即重写) Starlight 的内置组件。
 本页面列出了所有可被重写的组件和它们默认实现的 GitHub 链接。
 
-在 [重写组件指南](/zh/guides/overriding-components/) 中了解更多。
+在[重写组件指南](/zh/guides/overriding-components/)中了解更多。
 
 ## 组件参数
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

| File | Source | Links |
| --- | --- | --- |
| `guides/overriding-components.md` | [source@`b893cbd`](https://github.com/withastro/starlight/blob/b893cbd6d0e2ff801084aa17df85576dd5598cd0/docs/src/content/docs/guides/overriding-components.md) | [blame@`main`](https://github.com/withastro/starlight/blame/main/docs/src/content/docs/guides/overriding-components.md) <br> [blame@`b893cbd`](https://github.com/withastro/starlight/blame/b893cbd6d0e2ff801084aa17df85576dd5598cd0/docs/src/content/docs/guides/overriding-components.md) <br> [history](https://github.com/withastro/starlight/commits/main/docs/src/content/docs/guides/overriding-components.md) |
| `reference/overrides.md` | [source@`140e729`](https://github.com/withastro/starlight/blob/140e729a8bf12f805ae0b7e2b5ad959cf68d8e22/docs/src/content/docs/reference/overrides.md) | [blame@`main`](https://github.com/withastro/starlight/blame/main/docs/src/content/docs/reference/overrides.md) <br> [blame@`140e729`](https://github.com/withastro/starlight/blame/140e729a8bf12f805ae0b7e2b5ad959cf68d8e22/docs/src/content/docs/reference/overrides.md) <br> [history](https://github.com/withastro/starlight/commits/main/docs/src/content/docs/reference/overrides.md) |
