### PR TITLE
i18n(fr): reference labels consistency

### DIFF
--- a/docs/src/content/docs/fr/reference/configuration.md
+++ b/docs/src/content/docs/fr/reference/configuration.md
@@ -25,19 +25,19 @@ Vous pouvez passer les options suivantes à l'intégration `starlight`.
 
 ### `title` (obligatoire)
 
-**type:** `string`
+**Type :** `string`
 
 Définissez le titre de votre site web. Il sera utilisé dans les métadonnées et dans le titre de l'onglet du navigateur.
 
 ### `description`
 
-**type:** `string`
+**Type :** `string`
 
 Définissez la description de votre site web. Utilisée dans les métadonnées partagées avec les moteurs de recherche dans la balise `<meta name="description">` si `description` n'est pas définie dans le frontmatter d'une page.
 
 ### `logo`
 
-**type:** [`LogoConfig`](#logoconfig)
+**Type :** [`LogoConfig`](#logoconfig)
 
 Définit une image de logo à afficher dans la barre de navigation à côté ou à la place du titre du site. Vous pouvez soit définir une seule propriété `src`, soit définir des sources d'images séparées pour `light` et `dark`.
 
@@ -60,14 +60,14 @@ type LogoConfig = { alt?: string; replacesTitle?: boolean } & (
 
 ### `tableOfContents`
 
-**type:** `false | { minHeadingLevel?: number; maxHeadingLevel?: number; }`  
-**default:** `{ minHeadingLevel: 2; maxHeadingLevel: 3; }`
+**Type :** `false | { minHeadingLevel?: number; maxHeadingLevel?: number; }`  
+**Par défaut :** `{ minHeadingLevel: 2; maxHeadingLevel: 3; }`
 
 Configurez la table des matières affichée à droite de chaque page. Par défaut, les titres `<h2>` et `<h3>` seront inclus dans cette table des matières.
 
 ### `editLink`
 
-**type:** `{ baseUrl: string }`
+**Type :** `{ baseUrl: string }`
 
 Permet d'activer les liens "Modifier cette page" en définissant l'URL de base qu'ils doivent utiliser. Le lien final sera `editLink.baseUrl` + le chemin de la page actuelle. Par exemple, pour permettre l'édition de pages dans le repo `withastro/starlight` sur GitHub :
 
@@ -83,7 +83,7 @@ Avec cette configuration, une page `/introduction` aurait un lien d'édition poi
 
 ### `sidebar`
 
-**type:** [`SidebarItem[]`](#sidebaritem)
+**Type :** [`SidebarItem[]`](#sidebaritem)
 
 Configure les éléments de navigation de la barre latérale de votre site.
 
@@ -208,7 +208,7 @@ interface BadgeConfig {
 
 ### `locales`
 
-**type:** <code>{ \[dir: string\]: [LocaleConfig](#localeconfig) }</code>
+**Type :** <code>{ \[dir: string\]: [LocaleConfig](#localeconfig) }</code>
 
 [Configurez l'internationalisation (i18n)](/fr/guides/i18n/) de votre site en définissant les `locales` supportées.
 
@@ -260,19 +260,19 @@ Vous pouvez définir les options suivantes pour chaque locale :
 
 ##### `label` (obligatoire)
 
-**type:** `string`
+**Type :** `string`
 
 L'étiquette de cette langue à afficher aux utilisateurs, par exemple dans le sélecteur de langue. Le plus souvent, il s'agit du nom de la langue tel qu'un utilisateur de cette langue s'attendrait à le lire, par exemple `"English"`, `"العربية"`, ou `"简体中文"`.
 
 ##### `lang`
 
-**type:** `string`
+**Type :** `string`
 
 L'étiquette d’identification BCP-47 pour cette langue, par exemple `"en"`, `"ar"`, ou `"zh-CN"`. Si elle n'est pas définie, le nom du répertoire de la langue sera utilisé par défaut. Les étiquettes de langue avec des sous-étiquettes régionales (par exemple `"pt-BR"` ou `"en-US"`) utiliseront les traductions de l'interface utilisateur intégrées pour leur langue de base si aucune traduction spécifique à la région n'est trouvée.
 
 ##### `dir`
 
-**type:** `'ltr' | 'rtl'`
+**Type :** `'ltr' | 'rtl'`
 
 Le sens d'écriture de cette langue ; `"ltr"` pour gauche à droite (par défaut) ou `"rtl"` pour droite à gauche.
 
@@ -298,7 +298,7 @@ Par exemple, cela vous permet de servir `/getting-started/` comme une route angl
 
 ### `defaultLocale`
 
-**type:** `string`
+**Type :** `string`
 
 Définit la langue par défaut pour ce site.
 La valeur doit correspondre à l'une des clés de votre objet [`locales`](#locales).
@@ -308,7 +308,7 @@ La locale par défaut sera utilisée pour fournir un contenu de remplacement lor
 
 ### `social`
 
-**type:** `Partial<Record<'bitbucket' | 'codeberg' | 'codePen' | 'discord' | 'email' | 'facebook' | 'github' | 'gitlab' | 'gitter' | 'instagram' | 'linkedin' | 'mastodon' | 'microsoftTeams' | 'rss' | 'stackOverflow' | 'telegram' | 'threads' | 'twitch' | 'twitter' | 'x.com' | 'youtube', string>>`
+**Type :** `Partial<Record<'bitbucket' | 'codeberg' | 'codePen' | 'discord' | 'email' | 'facebook' | 'github' | 'gitlab' | 'gitter' | 'instagram' | 'linkedin' | 'mastodon' | 'microsoftTeams' | 'rss' | 'stackOverflow' | 'telegram' | 'threads' | 'twitch' | 'twitter' | 'x.com' | 'youtube', string>>`
 
 Détails optionnels sur les comptes de médias sociaux pour ce site. L'ajout de l'un d'entre eux les affichera sous forme de liens iconiques dans l'en-tête du site.
 
@@ -332,7 +332,7 @@ starlight({
 
 ### `customCss`
 
-**type:** `string[]`
+**Type :** `string[]`
 
 Fournit des fichiers CSS pour personnaliser l'aspect et la convivialité de votre site Starlight.
 
@@ -346,7 +346,7 @@ starlight({
 
 ### `head`
 
-**type:** [`HeadConfig[]`](#headconfig)
+**Type :** [`HeadConfig[]`](#headconfig)
 
 Ajoute des balises personnalisées au `<head>` de votre site Starlight.
 Cela peut être utile pour ajouter des analyses et d'autres scripts et ressources tiers.
@@ -379,8 +379,8 @@ interface HeadConfig {
 
 ### `lastUpdated`
 
-**type:** `boolean`  
-**default:** `false`
+**Type :** `boolean`  
+**Par défaut :** `false`
 
 Contrôlez si le pied de page affiche la date de la dernière mise à jour de la page.
 
@@ -390,8 +390,8 @@ la date basée sur Git en utilisant [le champ `lastUpdated` du frontmatter](/fr/
 
 ### `pagination`
 
-**type:** `boolean`  
-**default:** `true`
+**Type :** `boolean`  
+**Par défaut :** `true`
 
 Définnissez si le pied de page doit inclure des liens vers les pages précédentes et suivantes.
 
@@ -399,8 +399,8 @@ Une page peut remplacer ce paramètre ou le texte du lien et/ou l'URL en utilisa
 
 ### `favicon`
 
-**type:** `string`  
-**default:** `'/favicon.svg'`
+**Type :** `string`  
+**Par défaut :** `'/favicon.svg'`
 
 Définnissez le chemin de l'icône par défaut pour votre site Web qui doit être situé dans le répertoire `public/` et être un fichier d'icône valide (`.ico`, `.gif`, `.jpg`, `.png` ou `.svg`).
 
@@ -431,8 +431,8 @@ starlight({
 
 ### `titleDelimiter`
 
-**type:** `string`  
-**default:** `'|'`
+**Type :** `string`  
+**Par défaut :** `'|'`
 
 Définit le délimiteur entre le titre de la page et le titre du site dans la balise `<title>` de la page, qui s'affiche dans les onglets du navigateur.
 
@@ -441,7 +441,7 @@ Par example, cette page a pour titre « Référence de configuration » et ce si
 
 ### `components`
 
-**type:** `Record<string, string>`
+**Type :** `Record<string, string>`
 
 Fournit les chemins vers les composants pour redéfinir les implémentations par défaut de Starlight.
 

--- a/docs/src/content/docs/fr/reference/frontmatter.md
+++ b/docs/src/content/docs/fr/reference/frontmatter.md
@@ -18,25 +18,25 @@ Bienvenue sur la page "à propos" !
 
 ### `title` (obligatoire)
 
-**type:** `string`
+**Type :** `string`
 
 Vous devez fournir un titre pour chaque page. Il sera affiché en haut de la page, dans les onglets du navigateur et dans les métadonnées de la page.
 
 ### `description`
 
-**type:** `string`
+**Type :** `string`
 
 La description de la page est utilisée pour les métadonnées de la page et sera reprise par les moteurs de recherche et dans les aperçus des médias sociaux.
 
 ### `editUrl`
 
-**type:** `string | boolean`
+**Type :** `string | boolean`
 
 Remplace la [configuration globale `editLink`](/fr/reference/configuration/#editlink). Mettez `false` pour désactiver le lien "Modifier cette page" pour une page spécifique ou pour fournir une URL alternative où le contenu de cette page est éditable.
 
 ### `head`
 
-**type:** [`HeadConfig[]`](/fr/reference/configuration/#headconfig)
+**Type :** [`HeadConfig[]`](/fr/reference/configuration/#headconfig)
 
 Vous pouvez ajouter des balises supplémentaires au champ `<head>` de votre page en utilisant le champ `head` frontmatter. Cela signifie que vous pouvez ajouter des styles personnalisés, des métadonnées ou d'autres balises à une seule page. Similaire à [l'option globale `head`](/fr/reference/configuration/#head).
 
@@ -52,7 +52,7 @@ head:
 
 ### `tableOfContents`
 
-**type:** `false | { minHeadingLevel?: number; maxHeadingLevel?: number; }`
+**Type :** `false | { minHeadingLevel?: number; maxHeadingLevel?: number; }`
 
 Remplace la [configuration globale `tableOfContents`](/fr/reference/configuration/#tableofcontents).
 Personnalisez les niveaux d'en-tête à inclure ou mettez `false` pour cacher la table des matières sur cette page.
@@ -75,8 +75,8 @@ tableOfContents: false
 
 ### `template`
 
-**type:** `'doc' | 'splash'`  
-**default:** `'doc'`
+**Type :** `'doc' | 'splash'`  
+**Par défaut :** `'doc'`
 
 Définit le modèle de mise en page pour cette page.
 Les pages utilisent la mise en page `'doc'`' par défaut.
@@ -84,7 +84,7 @@ La valeur `'splash''` permet d'utiliser une mise en page plus large, sans barres
 
 ### `hero`
 
-**type:** [`HeroConfig`](#heroconfig)
+**Type :** [`HeroConfig`](#heroconfig)
 
 Ajoute un composant héros en haut de la page. Fonctionne bien avec `template : splash`.
 
@@ -136,7 +136,7 @@ interface HeroConfig {
 
 ### `banner`
 
-**type:** `{ content: string }`
+**Type :** `{ content: string }`
 
 Montrera une bannière d'annonce en haut de cette page.
 
@@ -155,7 +155,7 @@ banner:
 
 ### `lastUpdated`
 
-**type:** `Date | boolean`
+**Type :** `Date | boolean`
 
 Remplace la [configuration globale `lastUpdated`](/fr/reference/configuration/#lastupdated). Si une date est spécifiée, elle doit être un [horodatage YAML](https://yaml.org/type/timestamp.html) valide et remplacera la date stockée dans l'historique Git pour cette page.
 
@@ -168,7 +168,7 @@ lastUpdated: 2022-08-09
 
 ### `prev`
 
-**type:** `boolean | string | { link?: string; label?: string }`
+**Type :** `boolean | string | { link?: string; label?: string }`
 
 Remplace la [configuration globale `pagination`](/fr/reference/configuration/#pagination). Si un string est spécifié, le texte du lien généré sera remplacé et si un objet est spécifié, le lien et le texte seront remplacés.
 
@@ -197,7 +197,7 @@ prev:
 
 ### `next`
 
-**type:** `boolean | string | { link?: string; label?: string }`
+**Type :** `boolean | string | { link?: string; label?: string }`
 
 La même chose que [`prev`](#prev) mais pour le lien de la page suivante.
 
@@ -210,8 +210,8 @@ next: false
 
 ### `pagefind`
 
-**type:** `boolean`  
-**default:** `true`
+**Type :** `boolean`  
+**Par défaut :** `true`
 
 Définit si cette page doit être incluse dans l'index de recherche de [Pagefind](https://pagefind.app/). Définissez la valeur à `false` pour exclure une page des résultats de recherche :
 
@@ -224,7 +224,7 @@ pagefind: false
 
 ### `sidebar`
 
-**type:** [`SidebarConfig`](#sidebarconfig)
+**Type :** [`SidebarConfig`](#sidebarconfig)
 
 Contrôler l'affichage de cette page dans la [barre latérale](/fr/reference/configuration/#sidebar), lors de l'utilisation d'un groupe de liens généré automatiquement.
 
@@ -242,8 +242,8 @@ interface SidebarConfig {
 
 #### `label`
 
-**type:** `string`  
-**default:** the page [`title`](#title-required)
+**Type :** `string`  
+**Par défaut :** the page [`title`](#title-required)
 
 Définir l'étiquette de cette page dans la barre latérale lorsqu'elle est affichée dans un groupe de liens généré automatiquement.
 
@@ -257,7 +257,7 @@ sidebar:
 
 #### `order`
 
-**type:** `number`
+**Type :** `number`
 
 Contrôler l'ordre de cette page lors du tri d'un groupe de liens généré automatiquement.
 Les numéros inférieurs sont affichés plus haut dans le groupe de liens.
@@ -272,8 +272,8 @@ sidebar:
 
 #### `hidden`
 
-**type:** `boolean`  
-**default:** `false`
+**Type :** `boolean`  
+**Par défaut :** `false`
 
 Empêche cette page d'être incluse dans un groupe de liens généré automatiquement.
 
@@ -287,7 +287,7 @@ sidebar:
 
 #### `badge`
 
-**type:** <code>string | <a href="/fr/reference/configuration/#badgeconfig">BadgeConfig</a></code>
+**Type :** <code>string | <a href="/fr/reference/configuration/#badgeconfig">BadgeConfig</a></code>
 
 Ajoute un badge à la page dans la barre latérale lorsqu'elle est affichée dans un groupe de liens généré automatiquement.
 Lors de l'utilisation d'une chaîne de caractères, le badge sera affiché avec une couleur d'accentuation par défaut.
@@ -314,7 +314,7 @@ sidebar:
 
 #### `attrs`
 
-**type:** `Record<string, string | number | boolean | undefined>`
+**Type :** `Record<string, string | number | boolean | undefined>`
 
 Attributs HTML à ajouter au lien de la page dans la barre latérale lorsqu'il est affiché dans un groupe de liens généré automatiquement.
 

--- a/docs/src/content/docs/fr/reference/overrides.md
+++ b/docs/src/content/docs/fr/reference/overrides.md
@@ -33,44 +33,44 @@ Starlight passera les props suivantes à vos composants personnalisés.
 
 #### `dir`
 
-**Type:** `'ltr' | 'rtl'`
+**Type :** `'ltr' | 'rtl'`
 
 Le sens d'écriture de la page.
 
 #### `lang`
 
-**Type:** `string`
+**Type :** `string`
 
 L’étiquette d’identification BCP-47 pour la langue de la page, par exemple `en`, `zh` ou `pt-BR`.
 
 #### `locale`
 
-**Type:** `string | undefined`
+**Type :** `string | undefined`
 
 Le chemin de base utilisé pour servir une langue. `undefined` pour les slugs de la locale racine.
 
 #### `slug`
 
-**Type:** `string`
+**Type :** `string`
 
 Le slug de la page généré à partir du nom du fichier du contenu.
 
 #### `id`
 
-**Type:** `string`
+**Type :** `string`
 
 L'identifiant unique de cette page basé sur le nom du fichier du contenu.
 
 #### `isFallback`
 
-**Type:** `true | undefined`
+**Type :** `true | undefined`
 
 `true` si cette page n'est pas traduite dans la langue actuelle et utilise le contenu de la langue par défaut en tant que repli.
 Utilisé uniquement dans les sites multilingues.
 
 #### `entryMeta`
 
-**Type:** `{ dir: 'ltr' | 'rtl'; lang: string }`
+**Type :** `{ dir: 'ltr' | 'rtl'; lang: string }`
 
 Métadonnées de la locale pour le contenu de la page. Peut être différent des valeurs de locale de premier niveau lorsque la page utilise un contenu de repli.
 
@@ -93,44 +93,44 @@ Pour en savoir plus sur le format de cet objet, consultez la [référence du typ
 
 #### `sidebar`
 
-**Type:** `SidebarEntry[]`
+**Type :** `SidebarEntry[]`
 
 Les entrées de la barre latérale de navigation du site pour cette page.
 
 #### `hasSidebar`
 
-**Type:** `boolean`
+**Type :** `boolean`
 
 Indique si la barre latérale est affichée sur cette page.
 
 #### `pagination`
 
-**Type:** `{ prev?: Link; next?: Link }`
+**Type :** `{ prev?: Link; next?: Link }`
 
 Liens vers la page précédente et suivante dans la barre latérale si celle-ci est activée.
 
 #### `toc`
 
-**Type:** `{ minHeadingLevel: number; maxHeadingLevel: number; items: TocItem[] } | undefined`
+**Type :** `{ minHeadingLevel: number; maxHeadingLevel: number; items: TocItem[] } | undefined`
 
 Table des matières de la page courante si celle-ci est activée.
 
 #### `headings`
 
-**Type:** `{ depth: number; slug: string; text: string }[]`
+**Type :** `{ depth: number; slug: string; text: string }[]`
 
 Un tableau de toutes les en-têtes Markdown extraites de la page courante.
 Utilisez [`toc`](#toc) à la place si vous souhaitez construire une table des matières qui respecte les options de configuration de Starlight.
 
 #### `lastUpdated`
 
-**Type:** `Date | undefined`
+**Type :** `Date | undefined`
 
 Un objet JavaScript de type `Date` représentant la date de dernière mise à jour de cette page si cette fonctionnalité est activée.
 
 #### `editUrl`
 
-**Type:** `URL | undefined`
+**Type :** `URL | undefined`
 
 Un objet `URL` de l'adresse où cette page peut être modifiée si cette fonctionnalité est activée.
 
@@ -145,7 +145,7 @@ Ils ne doivent inclure que des [éléments autorisés à l'intérieur de `<head>
 
 #### `Head`
 
-**Composant par défaut:** [`Head.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Head.astro)
+**Composant par défaut :** [`Head.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Head.astro)
 
 Composant utilisé à l'intérieur de l'élément `<head>` de chaque page.
 Inclut des balises importantes comme `<title>` et `<meta charset="utf-8">`.
@@ -155,7 +155,7 @@ Préférez l'option [`head`](/fr/reference/configuration#head) de la configurati
 
 #### `ThemeProvider`
 
-**Composant par défaut:** [`ThemeProvider.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/ThemeProvider.astro)
+**Composant par défaut :** [`ThemeProvider.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/ThemeProvider.astro)
 
 Composant utilisé à l'intérieur de l'élément `<head>` qui configure la prise en charge du thème sombre/clair.
 L'implémentation par défaut inclut un script en ligne et un élément `<template>` utilisé par le script situé dans [`<ThemeSelect />`](#themeselect).
@@ -166,7 +166,7 @@ L'implémentation par défaut inclut un script en ligne et un élément `<templa
 
 #### `SkipLink`
 
-**Composant par défaut:** [`SkipLink.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/SkipLink.astro)
+**Composant par défaut :** [`SkipLink.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/SkipLink.astro)
 
 Composant utilisé comme premier élément à l'intérieur du `<body>` qui relie au contenu principal de la page pour des raisons d'accessibilité.
 L'implémentation par défaut est masquée jusqu'à ce qu'il reçoive le focus d'un utilisateur utilisant la navigation au clavier.
@@ -181,7 +181,7 @@ Lorsque cela est possible, préférez redéfinir un composant de plus bas niveau
 
 #### `PageFrame`
 
-**Composant par défaut:** [`PageFrame.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/PageFrame.astro)
+**Composant par défaut :** [`PageFrame.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/PageFrame.astro)
 
 Composant de mise en page contenant la plupart du contenu de la page.
 L'implémentation par défaut configure la mise en page de l'en-tête, de la barre latérale et du contenu principal et inclut des emplacements (slots) nommés `header` et `sidebar` en plus de l'emplacement par défaut pour le contenu principal.
@@ -189,13 +189,13 @@ Il affiche également [`<MobileMenuToggle />`](#mobilemenutoggle) qui prend en c
 
 #### `MobileMenuToggle`
 
-**Composant par défaut:** [`MobileMenuToggle.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/MobileMenuToggle.astro)
+**Composant par défaut :** [`MobileMenuToggle.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/MobileMenuToggle.astro)
 
 Composant utilisé à l'intérieur de [`<PageFrame>`](#pageframe) qui est responsable de l'affichage de la barre latérale de navigation sur petits écrans (mobiles).
 
 #### `TwoColumnContent`
 
-**Composant par défaut:** [`TwoColumnContent.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/TwoColumnContent.astro)
+**Composant par défaut :** [`TwoColumnContent.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/TwoColumnContent.astro)
 
 Composant de mise en page enveloppant le contenu principal de la page et la barre latérale de droite (table des matières).
 L'implémentation par défaut prend en charge le changement entre une mise en page à une seule colonne pour petits écrans et une mise en page à deux colonnes pour écrans plus larges.
@@ -208,41 +208,41 @@ Ces composants affichent la barre de navigation supérieure de Starlight.
 
 #### `Header`
 
-**Composant par défaut:** [`Header.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Header.astro)
+**Composant par défaut :** [`Header.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Header.astro)
 
 Composant d'en-tête affiché en haut de chaque page.
 L'implémentation par défaut affiche [`<SiteTitle />`](#sitetitle), [`<Search />`](#search), [`<SocialIcons />`](#socialicons), [`<ThemeSelect />`](#themeselect) et [`<LanguageSelect />`](#languageselect).
 
 #### `SiteTitle`
 
-**Composant par défaut:** [`SiteTitle.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/SiteTitle.astro)
+**Composant par défaut :** [`SiteTitle.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/SiteTitle.astro)
 
 Composant utilisé au début de l'en-tête du site pour afficher le titre du site.
 L'implémentation par défaut inclut la logique pour afficher les logos définis dans la configuration de Starlight.
 
 #### `Search`
 
-**Composant par défaut:** [`Search.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Search.astro)
+**Composant par défaut :** [`Search.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Search.astro)
 
 Composant utilisé pour afficher l'interface de recherche de Starlight.
 L'implémentation par défaut inclut le bouton dans l'en-tête et le code pour afficher une fenêtre modale de recherche lorsqu'il est cliqué et charger [l'interface utilisateur de Pagefind](https://pagefind.app/).
 
 #### `SocialIcons`
 
-**Composant par défaut:** [`SocialIcons.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/SocialIcons.astro)
+**Composant par défaut :** [`SocialIcons.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/SocialIcons.astro)
 
 Composant utilisé dans l'en-tête du site qui inclut des liens avec des icônes vers différents médias sociaux.
 L'implémentation par défaut utilise l'option [`social`](/fr/reference/configuration#social) de la configuration de Starlight pour afficher les icônes et les liens.
 
 #### `ThemeSelect`
 
-**Composant par défaut:** [`ThemeSelect.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/ThemeSelect.astro)
+**Composant par défaut :** [`ThemeSelect.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/ThemeSelect.astro)
 
 Composant utilisé dans l'en-tête du site qui permet aux utilisateurs de sélectionner leur thème de couleur préféré.
 
 #### `LanguageSelect`
 
-**Composant par défaut:** [`LanguageSelect.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/LanguageSelect.astro)
+**Composant par défaut :** [`LanguageSelect.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/LanguageSelect.astro)
 
 Component utilisé dans l'en-tête du site qui permet aux utilisateurs de changer de langue.
 
@@ -255,7 +255,7 @@ Sur des écrans peu larges, elle est masquée derrière un menu déroulant.
 
 #### `Sidebar`
 
-**Composant par défaut:** [`Sidebar.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Sidebar.astro)
+**Composant par défaut :** [`Sidebar.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Sidebar.astro)
 
 Composant utilisé avant le contenu de la page qui contient la navigation globale.
 L'implémentation par défaut est affichée comme une barre latérale sur des écrans suffisamment larges et à l'intérieur d'un menu déroulant sur des écrans plus petits (mobiles).
@@ -263,7 +263,7 @@ Il utilise aussi [`<MobileMenuFooter />`](#mobilemenufooter) pour afficher des �
 
 #### `MobileMenuFooter`
 
-**Composant par défaut:** [`MobileMenuFooter.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/MobileMenuFooter.astro)
+**Composant par défaut :** [`MobileMenuFooter.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/MobileMenuFooter.astro)
 
 Composant utilisé à la fin du menu déroulant mobile.
 L'implémentation par défaut affiche [`<ThemeSelect />`](#themeselect) et [`<LanguageSelect />`](#languageselect).
@@ -277,20 +277,20 @@ Sur des écrans peu larges, elle est remplacée par un menu déroulant adhérant
 
 #### `PageSidebar`
 
-**Composant par défaut:** [`PageSidebar.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/PageSidebar.astro)
+**Composant par défaut :** [`PageSidebar.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/PageSidebar.astro)
 
 Composant affiché avant le contenu de la page et contenant la table des matières.
 L'implémentation par défaut affiche [`<TableOfContents />`](#tableofcontents) et [`<MobileTableOfContents />`](#mobiletableofcontents).
 
 #### `TableOfContents`
 
-**Composant par défaut:** [`TableOfContents.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/TableOfContents.astro)
+**Composant par défaut :** [`TableOfContents.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/TableOfContents.astro)
 
 Composant qui affiche la table des matières de la page courante sur des écrans suffisamment larges.
 
 #### `MobileTableOfContents`
 
-**Composant par défaut:** [`MobileTableOfContents.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/MobileTableOfContents.astro)
+**Composant par défaut :** [`MobileTableOfContents.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/MobileTableOfContents.astro)
 
 Composant qui affiche la table des matières de la page courante sur des petits écrans (mobiles).
 
@@ -302,20 +302,20 @@ Ces composants sont utilisés dans la colonne principale de contenu de la page.
 
 #### `Banner`
 
-**Composant par défaut:** [`Banner.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Banner.astro)
+**Composant par défaut :** [`Banner.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Banner.astro)
 
 Composant représentant une bannière affichée en haut de chaque page.
 L'implémentation par défaut utilise la valeur du champ [`banner`](/fr/reference/frontmatter#banner) du frontmatter de la page pour décider de l'affichage ou non.
 
 #### `ContentPanel`
 
-**Composant par défaut:** [`ContentPanel.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/ContentPanel.astro)
+**Composant par défaut :** [`ContentPanel.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/ContentPanel.astro)
 
 Composant de mise en page utilisé pour envelopper les section de la colonne principale de contenu.
 
 #### `PageTitle`
 
-**Composant par défaut:** [`PageTitle.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/PageTitle.astro)
+**Composant par défaut :** [`PageTitle.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/PageTitle.astro)
 
 Composant contenant l'élement `<h1>` de la page courante.
 
@@ -323,21 +323,21 @@ Les implémentations personnalisées doivent s'assurer qu'elles définissent `id
 
 #### `FallbackContentNotice`
 
-**Composant par défaut:** [`FallbackContentNotice.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/FallbackContentNotice.astro)
+**Composant par défaut :** [`FallbackContentNotice.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/FallbackContentNotice.astro)
 
 Note affichée aux utilisateurs sur les pages où une traduction pour la langue courante n'est pas disponible.
 Utilisé uniquement sur les sites multilingues.
 
 #### `Hero`
 
-**Composant par défaut:** [`Hero.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Hero.astro)
+**Composant par défaut :** [`Hero.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Hero.astro)
 
 Composant affiché en haut de la page lorsque le champ [`hero`](/fr/reference/frontmatter#hero) est défini dans le frontmatter.
 L'implémentation par défaut affiche un large titre, une accroche et des liens d'appel à l'action à côté d'une image facultative.
 
 #### `MarkdownContent`
 
-**Composant par défaut:** [`MarkdownContent.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/MarkdownContent.astro)
+**Composant par défaut :** [`MarkdownContent.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/MarkdownContent.astro)
 
 Composant affiché autour du contenu principal de chaque page.
 L'implémentation par défaut définit les styles de base à appliquer au contenu Markdown.
@@ -350,25 +350,25 @@ Ces composants sont affichés en bas de la colonne principale de contenu de la p
 
 #### `Footer`
 
-**Composant par défaut:** [`Footer.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Footer.astro)
+**Composant par défaut :** [`Footer.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Footer.astro)
 
 Composant pied de page affiché en bas de chaque page.
 L'implémentation par défaut affiche [`<LastUpdated />`](#lastupdated), [`<Pagination />`](#pagination) et [`<EditLink />`](#editlink).
 
 #### `LastUpdated`
 
-**Composant par défaut:** [`LastUpdated.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/LastUpdated.astro)
+**Composant par défaut :** [`LastUpdated.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/LastUpdated.astro)
 
 Composant utilisé dans le pied de page pour afficher la date de dernière mise à jour de la page.
 
 #### `EditLink`
 
-**Composant par défaut:** [`EditLink.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/EditLink.astro)
+**Composant par défaut :** [`EditLink.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/EditLink.astro)
 
 Composant utilisé dans le pied de page pour afficher un lien vers l'emplacement où la page peut être modifiée.
 
 #### `Pagination`
 
-**Composant par défaut:** [`Pagination.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Pagination.astro)
+**Composant par défaut :** [`Pagination.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Pagination.astro)
 
 Composant utilisé dans le pied de page pour afficher des flèches de navigation entre les pages précédentes/suivantes.


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

This pull request apply some consistency to the reference labels (`type:`, `default:`, etc.) to the french translation of the Starlight docs reference pages:

- Always start with a capital letter
- Use a space before the colon
- Translate `default` to [`par défaut`](https://fr.wiktionary.org/wiki/par_d%C3%A9faut) as this means nothing in french