### PR TITLE
Add Rspress to Website Carbon Calculator

### DIFF
--- a/docs/src/content/docs/environmental-impact.md
+++ b/docs/src/content/docs/environmental-impact.md
@@ -100,6 +100,7 @@ These tests with the [Website Carbon Calculator][wcc] compare similar pages buil
 | [docsify][dy-carbon]        | 0.11g              |
 | [Docusaurus][ds-carbon]     | 0.24g              |
 | [Read the Docs][rtd-carbon] | 0.24g              |
+| [Rspress][rp-carbon]        | 0.58g              |
 | [GitBook][gb-carbon]        | 0.71g              |
 
 <small>Data collected on 14 May 2023. Click a link to see up-to-date figures.</small>
@@ -113,6 +114,7 @@ These tests with the [Website Carbon Calculator][wcc] compare similar pages buil
 [dy-carbon]: https://www.websitecarbon.com/website/docsify-js-org/
 [ds-carbon]: https://www.websitecarbon.com/website/docusaurus-io-docs/
 [rtd-carbon]: https://www.websitecarbon.com/website/docs-readthedocs-io-en-stable-index-html/
+[rp-carbon]: https://www.websitecarbon.com/website/rspress-dev-guide-start-introduction-html/
 [gb-carbon]: https://www.websitecarbon.com/website/docs-gitbook-com/
 
 ## More resources

--- a/docs/src/content/docs/es/environmental-impact.md
+++ b/docs/src/content/docs/es/environmental-impact.md
@@ -84,6 +84,7 @@ Estas pruebas con el [Calculadora de Carbono de Sitios Web][wcc] comparan págin
 | [docsify][dy-carbon]        | 0.11g                      |
 | [Docusaurus][ds-carbon]     | 0.24g                      |
 | [Read the Docs][rtd-carbon] | 0.24g                      |
+| [Rspress][rp-carbon]        | 0.58g                      |
 | [GitBook][gb-carbon]        | 0.71g                      |
 
 <small>Datos recopilados el 14 de mayo de 2023. Haz clic en un enlace para ver cifras actualizadas.</small>
@@ -97,6 +98,7 @@ Estas pruebas con el [Calculadora de Carbono de Sitios Web][wcc] comparan págin
 [dy-carbon]: https://www.websitecarbon.com/website/docsify-js-org/
 [ds-carbon]: https://www.websitecarbon.com/website/docusaurus-io-docs/
 [rtd-carbon]: https://www.websitecarbon.com/website/docs-readthedocs-io-en-stable-index-html/
+[rp-carbon]: https://www.websitecarbon.com/website/rspress-dev-guide-start-introduction-html/
 [gb-carbon]: https://www.websitecarbon.com/website/docs-gitbook-com/
 
 ## Más recursos

--- a/docs/src/content/docs/fr/environmental-impact.md
+++ b/docs/src/content/docs/fr/environmental-impact.md
@@ -100,6 +100,7 @@ Ces tests avec le [Website Carbon Calculator][wcc] comparent des pages similaire
 | [docsify][dy-carbon]        | 0.11g                |
 | [Docusaurus][ds-carbon]     | 0.24g                |
 | [Read the Docs][rtd-carbon] | 0.24g                |
+| [Rspress][rp-carbon]        | 0.58g                |
 | [GitBook][gb-carbon]        | 0.71g                |
 
 <small>Données collectées le 14 mai 2023. Cliquez sur un lien pour voir les chiffres actualisés.</small>
@@ -113,6 +114,7 @@ Ces tests avec le [Website Carbon Calculator][wcc] comparent des pages similaire
 [dy-carbon]: https://www.websitecarbon.com/website/docsify-js-org/
 [ds-carbon]: https://www.websitecarbon.com/website/docusaurus-io-docs/
 [rtd-carbon]: https://www.websitecarbon.com/website/docs-readthedocs-io-en-stable-index-html/
+[rp-carbon]: https://www.websitecarbon.com/website/rspress-dev-guide-start-introduction-html/
 [gb-carbon]: https://www.websitecarbon.com/website/docs-gitbook-com/
 
 ## Plus de ressources

--- a/docs/src/content/docs/id/environmental-impact.md
+++ b/docs/src/content/docs/id/environmental-impact.md
@@ -95,6 +95,7 @@ Tertarik bagaimana perbandingannya dengan _framework_ dokumentasi lainnya? Tes i
 | [docsify][dy-carbon]        | 0.11g                     |
 | [Docusaurus][ds-carbon]     | 0.24g                     |
 | [Read the Docs][rtd-carbon] | 0.24g                     |
+| [Rspress][rp-carbon]        | 0.58g                     |
 | [GitBook][gb-carbon]        | 0.71g                     |
 
 <small>Data dikumpulkan pada 14 Mei 2023. Klik link untuk melihat angka terkini.</small>
@@ -108,6 +109,7 @@ Tertarik bagaimana perbandingannya dengan _framework_ dokumentasi lainnya? Tes i
 [dy-carbon]: https://www.websitecarbon.com/website/docsify-js-org/
 [ds-carbon]: https://www.websitecarbon.com/website/docusaurus-io-docs/
 [rtd-carbon]: https://www.websitecarbon.com/website/docs-readthedocs-io-en-stable-index-html/
+[rp-carbon]: https://www.websitecarbon.com/website/rspress-dev-guide-start-introduction-html/
 [gb-carbon]: https://www.websitecarbon.com/website/docs-gitbook-com/
 
 ## Sumber Tambahan

--- a/docs/src/content/docs/it/environmental-impact.md
+++ b/docs/src/content/docs/it/environmental-impact.md
@@ -100,6 +100,7 @@ Questi test eseguiti con [Website Carbon Calculator][wcc] confrontano pagine sim
 | [docsify][dy-carbon]        | 0,11 g         |
 | [Docusaurus][ds-carbon]     | 0,24 g         |
 | [Read the Docs][rtd-carbon] | 0,24 g         |
+| [Rspress][rp-carbon]        | 0,58 g         |
 | [GitBook][gb-carbon]        | 0,71 g         |
 
 <small>Dati collezionati il 14 Maggio 2023. Clicca i link per vedere i dati aggiornati.</small>
@@ -113,6 +114,7 @@ Questi test eseguiti con [Website Carbon Calculator][wcc] confrontano pagine sim
 [dy-carbon]: https://www.websitecarbon.com/website/docsify-js-org/
 [ds-carbon]: https://www.websitecarbon.com/website/docusaurus-io-docs/
 [rtd-carbon]: https://www.websitecarbon.com/website/docs-readthedocs-io-en-stable-index-html/
+[rp-carbon]: https://www.websitecarbon.com/website/rspress-dev-guide-start-introduction-html/
 [gb-carbon]: https://www.websitecarbon.com/website/docs-gitbook-com/
 
 ## Altre risorse

--- a/docs/src/content/docs/ja/environmental-impact.md
+++ b/docs/src/content/docs/ja/environmental-impact.md
@@ -83,6 +83,7 @@ JavaScriptの解析とコンパイルは、ブラウザが実行する最も高�
 | [docsify][dy-carbon]        | 0.11g               |
 | [Docusaurus][ds-carbon]     | 0.24g               |
 | [Read the Docs][rtd-carbon] | 0.24g               |
+| [Rspress][rp-carbon]        | 0.58g               |
 | [GitBook][gb-carbon]        | 0.71g               |
 
 <small>データは2023年5月14日に収集されたものです。リンクをクリックすると、最新の数値が表示されます。</small>
@@ -96,6 +97,7 @@ JavaScriptの解析とコンパイルは、ブラウザが実行する最も高�
 [dy-carbon]: https://www.websitecarbon.com/website/docsify-js-org/
 [ds-carbon]: https://www.websitecarbon.com/website/docusaurus-io-docs/
 [rtd-carbon]: https://www.websitecarbon.com/website/docs-readthedocs-io-en-stable-index-html/
+[rp-carbon]: https://www.websitecarbon.com/website/rspress-dev-guide-start-introduction-html/
 [gb-carbon]: https://www.websitecarbon.com/website/docs-gitbook-com/
 
 ## その他のリソース

--- a/docs/src/content/docs/ko/environmental-impact.md
+++ b/docs/src/content/docs/ko/environmental-impact.md
@@ -101,6 +101,7 @@ JavaScript를 분석하고 컴파일하는 것은 브라우저가 수행해야 �
 | [docsify][dy-carbon]        | 0.11g             |
 | [Docusaurus][ds-carbon]     | 0.24g             |
 | [Read the Docs][rtd-carbon] | 0.24g             |
+| [Rspress][rp-carbon]        | 0.58g             |
 | [GitBook][gb-carbon]        | 0.71g             |
 
 <small>2023년 5월 14일에 수집된 데이터. 최신 수치를 보려면 링크를 클릭하세요.</small>
@@ -114,6 +115,7 @@ JavaScript를 분석하고 컴파일하는 것은 브라우저가 수행해야 �
 [dy-carbon]: https://www.websitecarbon.com/website/docsify-js-org/
 [ds-carbon]: https://www.websitecarbon.com/website/docusaurus-io-docs/
 [rtd-carbon]: https://www.websitecarbon.com/website/docs-readthedocs-io-en-stable-index-html/
+[rp-carbon]: https://www.websitecarbon.com/website/rspress-dev-guide-start-introduction-html/
 [gb-carbon]: https://www.websitecarbon.com/website/docs-gitbook-com/
 
 ## 더 많은 자료

--- a/docs/src/content/docs/pt-br/environmental-impact.md
+++ b/docs/src/content/docs/pt-br/environmental-impact.md
@@ -100,6 +100,7 @@ Esses testes com o [Website Carbon Calculator][wcc] comparam páginas similares 
 | [docsify][dy-carbon]        | 0.11g                    |
 | [Docusaurus][ds-carbon]     | 0.24g                    |
 | [Read the Docs][rtd-carbon] | 0.24g                    |
+| [Rspress][rp-carbon]        | 0.58g                    |
 | [GitBook][gb-carbon]        | 0.71g                    |
 
 <small>Dados coletados em 14 de Maio de 2023. Clique num dos links para ver valores atualizados.</small>
@@ -113,6 +114,7 @@ Esses testes com o [Website Carbon Calculator][wcc] comparam páginas similares 
 [dy-carbon]: https://www.websitecarbon.com/website/docsify-js-org/
 [ds-carbon]: https://www.websitecarbon.com/website/docusaurus-io-docs/
 [rtd-carbon]: https://www.websitecarbon.com/website/docs-readthedocs-io-en-stable-index-html/
+[rp-carbon]: https://www.websitecarbon.com/website/rspress-dev-guide-start-introduction-html/
 [gb-carbon]: https://www.websitecarbon.com/website/docs-gitbook-com/
 
 ## Mais recursos

--- a/docs/src/content/docs/ru/environmental-impact.md
+++ b/docs/src/content/docs/ru/environmental-impact.md
@@ -109,6 +109,7 @@ Cache-Control: public, max-age=604800, immutable
 | [docsify][dy-carbon]        | 0.11g                        |
 | [Docusaurus][ds-carbon]     | 0.24g                        |
 | [Read the Docs][rtd-carbon] | 0.24g                        |
+| [Rspress][rp-carbon]        | 0.58g                        |
 | [GitBook][gb-carbon]        | 0.71g                        |
 
 <small>Данные собраны 14 мая 2023 года. Чтобы увидеть актуальные цифры, перейдите по ссылке..</small>
@@ -122,6 +123,7 @@ Cache-Control: public, max-age=604800, immutable
 [dy-carbon]: https://www.websitecarbon.com/website/docsify-js-org/
 [ds-carbon]: https://www.websitecarbon.com/website/docusaurus-io-docs/
 [rtd-carbon]: https://www.websitecarbon.com/website/docs-readthedocs-io-en-stable-index-html/
+[rp-carbon]: https://www.websitecarbon.com/website/rspress-dev-guide-start-introduction-html/
 [gb-carbon]: https://www.websitecarbon.com/website/docs-gitbook-com/
 
 ## Дополнительные ресурсы

--- a/docs/src/content/docs/tr/environmental-impact.md
+++ b/docs/src/content/docs/tr/environmental-impact.md
@@ -100,6 +100,7 @@ Diğer dokümantasyon çerçeveleri ile nasıl kıyaslandığını merak ediyor 
 | [docsify][dy-carbon]        | 0.11gr                     |
 | [Docusaurus][ds-carbon]     | 0.24gr                     |
 | [Read the Docs][rtd-carbon] | 0.24gr                     |
+| [Rspress][rp-carbon]        | 0.58gr                     |
 | [GitBook][gb-carbon]        | 0.71gr                     |
 
 <small>14 Mayıs 2023 tarihli veriler. Güncel bilgileri görmek için linke tıkla.</small>
@@ -113,6 +114,7 @@ Diğer dokümantasyon çerçeveleri ile nasıl kıyaslandığını merak ediyor 
 [dy-carbon]: https://www.websitecarbon.com/website/docsify-js-org/
 [ds-carbon]: https://www.websitecarbon.com/website/docusaurus-io-docs/
 [rtd-carbon]: https://www.websitecarbon.com/website/docs-readthedocs-io-en-stable-index-html/
+[rp-carbon]: https://www.websitecarbon.com/website/rspress-dev-guide-start-introduction-html/
 [gb-carbon]: https://www.websitecarbon.com/website/docs-gitbook-com/
 
 ## Diğer Kaynaklar

--- a/docs/src/content/docs/zh-cn/environmental-impact.md
+++ b/docs/src/content/docs/zh-cn/environmental-impact.md
@@ -100,6 +100,7 @@ Cache-Control: public, max-age=604800, immutable
 | [docsify][dy-carbon]        | 0.11g              |
 | [Docusaurus][ds-carbon]     | 0.24g              |
 | [Read the Docs][rtd-carbon] | 0.24g              |
+| [Rspress][rp-carbon]        | 0.58g              |
 | [GitBook][gb-carbon]        | 0.71g              |
 
 <small>数据收集于 2023 年 5 月 14 日。点击链接查看最新数据。</small>
@@ -113,6 +114,7 @@ Cache-Control: public, max-age=604800, immutable
 [dy-carbon]: https://www.websitecarbon.com/website/docsify-js-org/
 [ds-carbon]: https://www.websitecarbon.com/website/docusaurus-io-docs/
 [rtd-carbon]: https://www.websitecarbon.com/website/docs-readthedocs-io-en-stable-index-html/
+[rp-carbon]: https://www.websitecarbon.com/website/rspress-dev-guide-start-introduction-html/
 [gb-carbon]: https://www.websitecarbon.com/website/docs-gitbook-com/
 
 ## 更多资源


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

[Rspress 1.0 released](https://github.com/orgs/web-infra-dev/discussions/5) (Rspack-based static site generator)

- Add Rspress to the Website Carbon Calculator comparisons table

<img width="781" alt="image" src="https://github.com/withastro/starlight/assets/3381481/ee38068b-b2a1-406a-9ae5-badb7e649213">