### PR TITLE
docs: tweak overrides reference `headings` prop wording

### DIFF
--- a/docs/src/content/docs/reference/overrides.md
+++ b/docs/src/content/docs/reference/overrides.md
@@ -120,7 +120,7 @@ Table of contents for this page if enabled.
 **Type:** `{ depth: number; slug: string; text: string }[]`
 
 Array of all Markdown headings extracted from the current page.
-Use [`toc`](#toc) instead if you want to build a table of contents that respects Starlight’s configuration options.
+Use [`toc`](#toc) instead if you want to build a table of contents component that respects Starlight’s configuration options.
 
 #### `lastUpdated`
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

This pull request is a follow up to #861.

It tweaks the wording of the `headings` prop in the overrides reference to emphasize that the documentation is referencing building a custom table of contents _component_ (with Starlight provided route data) and not a table of contents with custom data using the builtin component.