### PR TITLE
fix: prevent overscroll on mobile toc

### DIFF
--- a/.changeset/shaggy-socks-exercise.md
+++ b/.changeset/shaggy-socks-exercise.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Prevent overscrolling on mobile table of contents by setting 'overscroll-behavior: contain'.

--- a/packages/starlight/components/MobileTableOfContents.astro
+++ b/packages/starlight/components/MobileTableOfContents.astro
@@ -105,6 +105,7 @@ const t = useTranslations(locale);
 		overflow-y: auto;
 		background-color: var(--sl-color-black);
 		box-shadow: var(--sl-shadow-md);
+		overscroll-behavior: contain;
 	}
 </style>
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to Starlight code

#### Description

- Closes #976 
- What does this PR change? 
Prevent overscrolling on mobile table of contents by setting 'overscroll-behavior: contain' as suggested. Although this CSS property is not supported in Safari 15.4-15.7, the visual bug it fixes only impacts a small number of users on those specific versions. 