### PR TITLE
i18n(de): fix type import

### DIFF
--- a/docs/src/content/docs/de/reference/overrides.md
+++ b/docs/src/content/docs/de/reference/overrides.md
@@ -18,7 +18,7 @@ Um deine eigenen Komponenten zu schreiben, importiere den `Props`-Typ von Starli
 
 ```astro
 ---
-import Typ { Props } from '@astrojs/starlight/props';
+import type { Props } from '@astrojs/starlight/props';
 
 const { hatSeitennavigation } = Astro.props;
 //      ^ Typ: boolean


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

This PR fixes a type import in the `/de/reference/overrides.md` file which seems to also [totally break](https://github.com/withastro/starlight/actions/runs/6652578458/job/18076846039) the `format` job.

I tested locally by running the `pnpm format` command before and after the change (not sure why this error leads to error in other files tho 🤔 )