### PR TITLE
feat: add secondary variant to View on Github link

### DIFF
--- a/docs/src/content/docs/de/index.mdx
+++ b/docs/src/content/docs/de/index.mdx
@@ -23,6 +23,7 @@ hero:
       link: /de/getting-started/
     - text: Auf GitHub
       icon: external
+      variant: secondary
       link: https://github.com/withastro/starlight
 ---
 

--- a/docs/src/content/docs/es/index.mdx
+++ b/docs/src/content/docs/es/index.mdx
@@ -28,6 +28,7 @@ hero:
       link: /es/getting-started/
     - text: Ver en GitHub
       icon: external
+      variant: secondary
       link: https://github.com/withastro/starlight
 ---
 

--- a/docs/src/content/docs/fr/index.mdx
+++ b/docs/src/content/docs/fr/index.mdx
@@ -28,6 +28,7 @@ hero:
       link: /fr/getting-started/
     - text: Voir sur GitHub
       icon: external
+      variant: secondary
       link: https://github.com/withastro/starlight
 ---
 

--- a/docs/src/content/docs/id/index.mdx
+++ b/docs/src/content/docs/id/index.mdx
@@ -23,6 +23,7 @@ hero:
       link: /id/getting-started/
     - text: Lihat di GitHub
       icon: external
+      variant: secondary
       link: https://github.com/withastro/starlight
 ---
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -28,6 +28,7 @@ hero:
       link: /getting-started/
     - text: View on GitHub
       icon: external
+      variant: secondary
       link: https://github.com/withastro/starlight
 ---
 

--- a/docs/src/content/docs/it/index.mdx
+++ b/docs/src/content/docs/it/index.mdx
@@ -28,6 +28,7 @@ hero:
       link: /it/getting-started/
     - text: Vedi su GitHub
       icon: external
+      variant: secondary
       link: https://github.com/withastro/starlight
 ---
 

--- a/docs/src/content/docs/ja/index.mdx
+++ b/docs/src/content/docs/ja/index.mdx
@@ -23,6 +23,7 @@ hero:
       link: /ja/getting-started/
     - text: GitHubで見る
       icon: external
+      variant: secondary
       link: https://github.com/withastro/starlight
 ---
 

--- a/docs/src/content/docs/ko/index.mdx
+++ b/docs/src/content/docs/ko/index.mdx
@@ -28,6 +28,7 @@ hero:
       link: /ko/getting-started/
     - text: GitHub에서 보기
       icon: external
+      variant: secondary
       link: https://github.com/withastro/starlight
 ---
 

--- a/docs/src/content/docs/pt-br/index.mdx
+++ b/docs/src/content/docs/pt-br/index.mdx
@@ -28,6 +28,7 @@ hero:
       link: /pt-br/getting-started/
     - text: Veja no GitHub
       icon: external
+      variant: secondary
       link: https://github.com/withastro/starlight
 ---
 

--- a/docs/src/content/docs/ru/index.mdx
+++ b/docs/src/content/docs/ru/index.mdx
@@ -28,6 +28,7 @@ hero:
       link: /ru/getting-started/
     - text: Открыть в GitHub
       icon: external
+      variant: secondary
       link: https://github.com/withastro/starlight
 ---
 

--- a/docs/src/content/docs/tr/index.mdx
+++ b/docs/src/content/docs/tr/index.mdx
@@ -28,6 +28,7 @@ hero:
       link: getting-started
     - text: Github'da Görüntüle
       icon: external
+      variant: secondary
       link: https://github.com/withastro/starlight
 ---
 

--- a/docs/src/content/docs/zh-cn/index.mdx
+++ b/docs/src/content/docs/zh-cn/index.mdx
@@ -28,6 +28,7 @@ hero:
       link: /zh-cn/getting-started/
     - text: 在 GitHub 上查看
       icon: external
+      variant: secondary
       link: https://github.com/withastro/starlight
 ---
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
add variant secondary to "View on Github" link on docs page

#### Description
Before:
![image](https://github.com/withastro/starlight/assets/20491952/61dacefe-f115-4af9-9cd0-8833c2036e9f)

![Screenshot 2023-10-26 at 5 35 08 PM](https://github.com/withastro/starlight/assets/20491952/4a51dfbf-e197-466c-b324-a5aa7a65e0e4)

After:
![Screenshot 2023-10-26 at 5 37 53 PM](https://github.com/withastro/starlight/assets/20491952/bb26a85c-8bbb-4acd-9448-e882ad031772)
![image](https://github.com/withastro/starlight/assets/20491952/e56f7b71-3ec2-4d04-a1c9-d8ba7ed5cb5b)

This gives consistency compared to Get Started button

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://github.com/withastro/docs/blob/main/.github/hacktoberfest.md for more details. -->
Participating in Hacktoberfest
<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
