### PR TITLE
i18n(fr) update `guides/authoring-content.md`

### DIFF
--- a/docs/src/content/docs/fr/guides/authoring-content.md
+++ b/docs/src/content/docs/fr/guides/authoring-content.md
@@ -206,3 +206,7 @@ Les longs blocs de code d'une seule ligne ne doivent pas être enveloppés. Ils 
 ## Autres fonctionnalités courantes de Markdown
 
 Starlight prend en charge toutes les autres syntaxes de rédaction Markdown, telles que les listes et les tableaux. Voir [Markdown Cheat Sheet from The Markdown Guide](https://www.markdownguide.org/cheat-sheet/) pour un aperçu rapide de tous les éléments de la syntaxe Markdown.
+
+## Configuration avancée de Markdown et MDX
+
+Starlight utilise le moteur de rendu Markdown et MDX d'Astro basé sur remark et rehype. Vous pouvez ajouter la prise en charge de syntaxe et comportement personnalisés en ajoutant `remarkPlugins` ou `rehypePlugins` dans votre fichier de configuration Astro. Pour en savoir plus, consultez [« Configuration de Markdown et MDX »](https://docs.astro.build/fr/guides/markdown-content/#configuration-de-markdown-et-mdx) dans la documentation d'Astro.


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

This PR updates the french version of the `guides/authoring-content.md` page with the changes from #938.