### PR TITLE
Fix `test-utils.ts` error

### DIFF
--- a/packages/starlight/__tests__/test-utils.ts
+++ b/packages/starlight/__tests__/test-utils.ts
@@ -17,6 +17,7 @@ const frontmatterSchema = docsSchema()({
 				z.literal('webp'),
 				z.literal('gif'),
 				z.literal('svg'),
+				z.literal('avif'),
 			]),
 		}),
 });


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to Starlight code

#### Description

This PR fixes a type error in `test-utils.ts`:

```
Type 'ZodObject<{ src: ZodString; width: ZodNumber; height: ZodNumber; format: ZodUnion<[ZodLiteral<"png">, ZodLiteral<"jpg">, ZodLiteral<"jpeg">, ZodLiteral<...>, ZodLiteral<...>, ZodLiteral<...>, ZodLiteral<...>]>; }, "strip", ZodTypeAny, { ...; }, { ...; }>' is not assignable to type 'ZodObject<{ src: ZodString; width: ZodNumber; height: ZodNumber; format: ZodUnion<[ZodLiteral<"png">, ZodLiteral<"jpg">, ZodLiteral<"jpeg">, ... 4 more ..., ZodLiteral<...>]>; }, UnknownKeysParam, ZodTypeAny, { ...; }, { ...; }>'.
  The types of '_getCached().shape' are incompatible between these types.
    Type '{ src: z.ZodString; width: z.ZodNumber; height: z.ZodNumber; format: z.ZodUnion<[z.ZodLiteral<"png">, z.ZodLiteral<"jpg">, z.ZodLiteral<"jpeg">, z.ZodLiteral<"tiff">, z.ZodLiteral<...>, z.ZodLiteral<...>, z.ZodLiteral<...>]>; }' is not assignable to type '{ src: ZodString; width: ZodNumber; height: ZodNumber; format: ZodUnion<[ZodLiteral<"png">, ZodLiteral<"jpg">, ZodLiteral<"jpeg">, ... 4 more ..., ZodLiteral<...>]>; }'.ts(2322)
```

Unfortunately, I don't think we can apply a similar fix as #775 as we do not only need the type but the actual value so I think we need to keep it synced manually for now.