### PR TITLE
Ignore search keyboard shortcuts for elements with contents that are editable

### DIFF
--- a/.changeset/red-camels-beam.md
+++ b/.changeset/red-camels-beam.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Ignore search keyboard shortcuts for elements with contents that are editable

--- a/packages/starlight/components/Search.astro
+++ b/packages/starlight/components/Search.astro
@@ -89,8 +89,9 @@ const pagefindTranslations = {
 			// Listen for `/` and `cmd + k` keyboard shortcuts.
 			window.addEventListener('keydown', (e) => {
 				const isInput =
-					document.activeElement &&
-					['input', 'select', 'textarea'].includes(document.activeElement.tagName.toLowerCase());
+					document.activeElement instanceof HTMLElement &&
+					(['input', 'select', 'textarea'].includes(document.activeElement.tagName.toLowerCase()) ||
+						document.activeElement.isContentEditable);
 				if (e.metaKey === true && e.key === 'k') {
 					dialog.open ? closeModal() : openModal();
 					e.preventDefault();


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to Starlight code

#### Description

While reading and preparing a reply for #1062, I realized that we do not ignore search keyboard shortcuts for elements with contents that are editable. This PR fixes that by checking the [`isContentEditable` property](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/isContentEditable) of the element.

_Edit: turns out this was [the issue in #1062](https://github.com/withastro/starlight/discussions/1062#discussioncomment-7546788) so this should close it at the same time._