### PR TITLE
fix(docs-i18n-tracker): update `expressive-code` import

### DIFF
--- a/.changeset/tidy-mails-brake.md
+++ b/.changeset/tidy-mails-brake.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Internal: fix import issue with expressive-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: pnpm/action-setup@v2
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,18 @@ jobs:
       - name: Build docs site
         working-directory: ./docs
         run: pnpm build
+
+  docs-i18n-tracker-smoke:
+    name: Docs i18n tracker builds
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+      - run: pnpm i
+      - name: Build docs i18n tracker
+        working-directory: ./docs-i18n-tracker
+        run: pnpm build

--- a/packages/starlight/index.ts
+++ b/packages/starlight/index.ts
@@ -4,7 +4,7 @@ import { spawn } from 'node:child_process';
 import { dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { starlightAsides } from './integrations/asides';
-import { starlightExpressiveCode } from './integrations/expressive-code';
+import { starlightExpressiveCode } from './integrations/expressive-code/index';
 import { starlightSitemap } from './integrations/sitemap';
 import { vitePluginStarlightUserConfig } from './integrations/virtual-user-config';
 import { errorMap } from './utils/error-map';


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Something else!

#### Description

This PR fix an import issue causing the docs-i18n-tracker to fail. (https://github.com/withastro/starlight/pull/1025 contains more details)

This also adds a new step to the CI workflow to build the docs-i18n-tracker to avoid this issue in the future as it's fairly easy to miss.

