### PR TITLE
ci: Update first interaction action

### DIFF
--- a/.github/workflows/welcome-bot.yml
+++ b/.github/workflows/welcome-bot.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/first-interaction@v1
+      - uses: zephyrproject-rtos/action-first-interaction@7e6446f8439d8b4399169880c36a3a12b5747699
         with:
           repo-token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
-          pr-message: |
+          pr-opened-message: |
             Hello! Thank you for opening your **first PR** to Starlight! ✨
 
             Here’s what will happen next:


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Something else!

#### Description

This PR changes the GitHub Actions workflow for the first interaction to no longer use [`actions/first-interaction`](https://github.com/actions/first-interaction) still running on Node 14. Instead, it uses a 7 months old fork of the action that has been updated with various changes including:

- run on Node LTS
- switch from review comment to review message
- improved perfomance when checking for first interaction by using the `/search` API
- throttling and retry mechanism 
- support for opened and closed PR events


As per the [recommendation](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) of GitHub regarding third-party actions, the action is pinned to a full length commit SHA.

