### PR TITLE
Expand size-limit workflow to run basic version on forks

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -10,17 +10,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # This basic check runs size-limit for the current branch.
+  # It will fail if the branch pushes the size over the specified budget.
+  size-limit-basic:
+    if: ${{ github.event.pull_request.head.repo.full_name != 'withastro/starlight' }}
+    name: Check build output is within performance budget (forks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+      - run: 'pnpm build:examples'
+      - run: pnpm size
+
+  # This check cannot run in forks, so is only run for PRs from this repo.
+  # It will run size-limit for both `main` and the PR branch and comment in the PR with changes.
   size-limit:
     if: ${{ github.event.pull_request.head.repo.full_name == 'withastro/starlight' }}
     name: Check build output is within performance budget
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup PNPM
-        uses: pnpm/action-setup@v2
-
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
       - name: Run size-limit
         uses: andresz1/size-limit-action@dd31dce7dcc72a041fd3e49abf0502b13fc4ce05
         with:

--- a/package.json
+++ b/package.json
@@ -24,17 +24,17 @@
     {
       "name": "/index.html",
       "path": "examples/basics/dist/index.html",
-      "limit": "14 kB"
+      "limit": "10 kB"
     },
     {
       "name": "/_astro/*.js",
       "path": "examples/basics/dist/_astro/*.js",
-      "limit": "20 kB"
+      "limit": "21 kB"
     },
     {
       "name": "/_astro/*.css",
       "path": "examples/basics/dist/_astro/*.css",
-      "limit": "10 kB"
+      "limit": "14 kB"
     }
   ]
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Runs a simpler version of our `size-limit` check for PRs from forks

   We can’t run the full-blown size-limit action from forks because it needs permission to comment on PRs, which is impossible to permit safely from forks. Instead, we run the basic `size-limit` CLI just for the PR branch. This won’t create a PR comment, but will at least fail for changes that breach the current budget.

- Updates our file-size budgets after bump in size caused by #742 

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
