### PR TITLE
Add a `pagefind` boolean flag to user config

### DIFF
--- a/.changeset/beige-shoes-whisper.md
+++ b/.changeset/beige-shoes-whisper.md
@@ -2,4 +2,4 @@
 '@astrojs/starlight': minor
 ---
 
-Add configuration option to disable Pagefind
+Adds a configuration option to disable site indexing with Pagefind and the default search UI

--- a/.changeset/beige-shoes-whisper.md
+++ b/.changeset/beige-shoes-whisper.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': minor
+---
+
+Add configuration option to disable Pagefind

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -416,7 +416,7 @@ When using custom themes and setting this to `true`, you must provide at least o
 **type:** `boolean`  
 **default:** `true`
 
-Define if Starlight’s default site search provider [Pagefind](https://pagefind.app/) is enabled.
+Define whether Starlight’s default site search provider [Pagefind](https://pagefind.app/) is enabled.
 
 Set to `false` to disable indexing your site with Pagefind.
 This will also hide the default search UI if in use.

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -411,6 +411,16 @@ When `false`, the colors provided by the active syntax highlighting theme are us
 When using custom themes and setting this to `true`, you must provide at least one dark and one light theme to ensure proper color contrast.
 :::
 
+### `pagefind`
+
+**type:** `boolean`  
+**default:** `true`
+
+Define if Starlight’s default site search provider [Pagefind](https://pagefind.app/) is enabled.
+
+Set to `false` to disable indexing your site with Pagefind.
+This will also hide the default search UI if in use.
+
 ### `head`
 
 **type:** [`HeadConfig[]`](#headconfig)

--- a/docs/src/content/docs/reference/overrides.md
+++ b/docs/src/content/docs/reference/overrides.md
@@ -228,6 +228,10 @@ The default implementation includes logic for rendering logos defined in Starlig
 Component used to render Starlight’s search UI.
 The default implementation includes the button in the header and the code for displaying a search modal when it is clicked and loading [Pagefind’s UI](https://pagefind.app/).
 
+When [`pagefind`](/reference/configuration/#pagefind) is disabled, the default search component will not be rendered.
+However, if you override `Search`, your custom component will always be rendered even if the `pagefind` configuration option is `false`.
+This allows you to add UI for alternative search providers when disabling Pagefind.
+
 #### `SocialIcons`
 
 **Default component:** [`SocialIcons.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/SocialIcons.astro)

--- a/packages/starlight/components/Header.astro
+++ b/packages/starlight/components/Header.astro
@@ -1,4 +1,5 @@
 ---
+import config from 'virtual:starlight/user-config';
 import type { Props } from '../props';
 
 import {
@@ -8,6 +9,12 @@ import {
 	SocialIcons,
 	ThemeSelect,
 } from 'virtual:starlight/components';
+
+/**
+ * Render the `Search` component if Pagefind is enabled or the default search component has been overridden.
+ */
+const shouldRenderSearch =
+	config.pagefind || config.components.Search !== '@astrojs/starlight/components/Search.astro';
 ---
 
 <div class="header sl-flex">
@@ -15,7 +22,7 @@ import {
 		<SiteTitle {...Astro.props} />
 	</div>
 	<div class="sl-flex">
-		<Search {...Astro.props} />
+		{shouldRenderSearch && <Search {...Astro.props} />}
 	</div>
 	<div class="sl-hidden md:sl-flex right-group">
 		<div class="sl-flex social-icons">

--- a/packages/starlight/components/Search.astro
+++ b/packages/starlight/components/Search.astro
@@ -3,7 +3,6 @@ import '@pagefind/default-ui/css/ui.css';
 import { useTranslations } from '../utils/translations';
 import Icon from '../user-components/Icon.astro';
 import type { Props } from '../props';
-import config from 'virtual:starlight/user-config';
 
 const t = useTranslations(Astro.props.locale);
 const pagefindTranslations = {
@@ -14,8 +13,6 @@ const pagefindTranslations = {
 };
 ---
 
-{
-	config.pagefind && (
 <site-search data-translations={JSON.stringify(pagefindTranslations)}>
 	<button data-open-modal disabled>
 		{
@@ -48,8 +45,6 @@ const pagefindTranslations = {
 		</div>
 	</dialog>
 </site-search>
-	)
-}
 
 <script>
 	class SiteSearch extends HTMLElement {

--- a/packages/starlight/components/Search.astro
+++ b/packages/starlight/components/Search.astro
@@ -3,6 +3,7 @@ import '@pagefind/default-ui/css/ui.css';
 import { useTranslations } from '../utils/translations';
 import Icon from '../user-components/Icon.astro';
 import type { Props } from '../props';
+import config from 'virtual:starlight/user-config';
 
 const t = useTranslations(Astro.props.locale);
 const pagefindTranslations = {
@@ -13,6 +14,8 @@ const pagefindTranslations = {
 };
 ---
 
+{
+	config.pagefind && (
 <site-search data-translations={JSON.stringify(pagefindTranslations)}>
 	<button data-open-modal disabled>
 		{
@@ -45,6 +48,8 @@ const pagefindTranslations = {
 		</div>
 	</dialog>
 </site-search>
+	)
+}
 
 <script>
 	class SiteSearch extends HTMLElement {

--- a/packages/starlight/index.ts
+++ b/packages/starlight/index.ts
@@ -77,6 +77,7 @@ export default function StarlightIntegration(opts: StarlightUserConfig): AstroIn
 			},
 
 			'astro:build:done': ({ dir }) => {
+				if (!userConfig.pagefind) return;
 				const targetDir = fileURLToPath(dir);
 				const cwd = dirname(fileURLToPath(import.meta.url));
 				const relativeDir = relative(cwd, targetDir);

--- a/packages/starlight/utils/user-config.ts
+++ b/packages/starlight/utils/user-config.ts
@@ -191,7 +191,7 @@ const UserConfigSchema = z.object({
 	expressiveCode: ExpressiveCodeSchema(),
 
 	/**
-	 * Define if Starlight’s default site search provider Pagefind is enabled.
+	 * Define whether Starlight’s default site search provider Pagefind is enabled.
 	 * Set to `false` to disable indexing your site with Pagefind.
 	 * This will also hide the default search UI if in use.
 	 */

--- a/packages/starlight/utils/user-config.ts
+++ b/packages/starlight/utils/user-config.ts
@@ -190,6 +190,13 @@ const UserConfigSchema = z.object({
 	 */
 	expressiveCode: ExpressiveCodeSchema(),
 
+	/**
+	 * Define if Starlight’s default site search provider Pagefind is enabled.
+	 * Set to `false` to disable indexing your site with Pagefind.
+	 * This will also hide the default search UI if in use.
+	 */
+	pagefind: z.boolean().default(true),
+
 	/** Specify paths to components that should override Starlight’s default components */
 	components: ComponentConfigSchema(),
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #952
- Adds a `pagefind` boolean to user config that can be set to `false` to disable Pagefind indexing and skip rendering the default search UI.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
