### PR TITLE
i18n(fr): translate some frame titles

### DIFF
--- a/docs/src/content/docs/fr/guides/components.mdx
+++ b/docs/src/content/docs/fr/guides/components.mdx
@@ -16,7 +16,7 @@ Ces balises ressemblent à des balises HTML mais commencent par une lettre majus
 
 ```mdx
 ---
-# src/content/docs/example.mdx
+# src/content/docs/exemple.mdx
 title: Bienvenue dans ma documentation
 ---
 
@@ -40,7 +40,7 @@ Si ces styles entrent en conflit avec l'apparence de votre composant, définisse
 
 ```astro 'class="not-content"'
 ---
-// src/components/Example.astro
+// src/components/Exemple.astro
 ---
 
 <div class="not-content">
@@ -61,7 +61,7 @@ Vous pouvez afficher une interface à onglets en utilisant les composants `<Tabs
 Chaque `<TabItem>` doit avoir un `label` à afficher aux utilisateurs.
 
 ```mdx
-# src/content/docs/example.mdx
+# src/content/docs/exemple.mdx
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
@@ -88,7 +88,7 @@ Enveloppez plusieurs cartes dans le composant `<CardGrid>` pour afficher les car
 Une `<Card>` nécessite un `title` et peut optionellement inclure un attribut `icon` fixé au nom de [l'une des icônes intégrées de Starlight](#toutes-les-icônes).
 
 ```mdx
-# src/content/docs/example.mdx
+# src/content/docs/exemple.mdx
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
 
@@ -142,7 +142,7 @@ Une `<LinkCard>` nécessite les attributs `title` et [`href`](https://developer.
 Regroupez plusieurs composants `<LinkCard>` dans `<CardGrid>` pour afficher les cartes côte à côte lorsqu'il y a suffisamment d'espace.
 
 ```mdx
-# src/content/docs/example.mdx
+# src/content/docs/exemple.mdx
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
@@ -189,7 +189,7 @@ Starlight fournit un ensemble d'icônes courantes que vous pouvez afficher dans 
 Chaque `<Icon>` nécessite un [`name`](#toutes-les-icônes) et peut optionellement inclure un attribut `label`, `size` et `color`.
 
 ```mdx
-# src/content/docs/example.mdx
+# src/content/docs/exemple.mdx
 
 import { Icon } from '@astrojs/starlight/components';
 

--- a/docs/src/content/docs/fr/guides/customization.mdx
+++ b/docs/src/content/docs/fr/guides/customization.mdx
@@ -128,7 +128,7 @@ Par défaut, les titres `<h2>` et `<h3>` sont inclus dans la table des matières
 
 ```md {4-6}
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 title: Page avec seulement les H2s dans la table des matières
 tableOfContents:
   minHeadingLevel: 2
@@ -162,7 +162,7 @@ Désactivez la table des matières complètement en définissant l’option `tab
 
 ```md {4}
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 title: Page sans table des matières
 tableOfContents: false
 ---

--- a/docs/src/content/docs/fr/guides/sidebar.mdx
+++ b/docs/src/content/docs/fr/guides/sidebar.mdx
@@ -203,7 +203,7 @@ Les options du frontmatter pour la barre latérale vous permettent de définir u
 
 ```md "sidebar:"
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 title: Ma page
 sidebar:
   # Définit une étiquette personnalisée pour le lien dans la barre latérale

--- a/docs/src/content/docs/fr/reference/frontmatter.md
+++ b/docs/src/content/docs/fr/reference/frontmatter.md
@@ -7,7 +7,7 @@ Vous pouvez personnaliser des pages Markdown et MDX individuelles dans Starlight
 
 ```md {3-4}
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 title: A propos de ce projet
 description: En savoir plus sur le projet sur lequel je travaille.
 ---
@@ -43,7 +43,7 @@ Vous pouvez ajouter des balises supplémentaires au champ `<head>` de votre page
 
 ```md
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 title: A propos de nous
 head:
   # Utiliser une balise <title> personnalisée
@@ -61,7 +61,7 @@ Personnalisez les niveaux d'en-tête à inclure ou mettez `false` pour cacher la
 
 ```md
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 title: Pagee avec seulement des H2s dans la table des matières
 tableOfContents:
   minHeadingLevel: 2
@@ -71,7 +71,7 @@ tableOfContents:
 
 ```md
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 title: Page sans table des matières
 tableOfContents: false
 ---
@@ -96,7 +96,7 @@ Par exemple, cette configuration montre quelques options communes, y compris le 
 
 ```md
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 title: Ma page d'accueil
 template: splash
 hero:
@@ -120,7 +120,7 @@ Vous pouvez afficher différentes versions de l'image de premier plan en mode cl
 
 ```md
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 hero:
   image:
     alt: Un logo scintillant aux couleurs vives
@@ -175,7 +175,7 @@ Par exemple, cette page affiche une bannière comprenant un lien vers `example.c
 
 ```md
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 title: Page avec une bannière
 banner:
   content: |
@@ -192,7 +192,7 @@ Remplace la [configuration globale `lastUpdated`](/fr/reference/configuration/#l
 
 ```md
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 title: Page avec une date de dernière mise à jour personnalisée
 lastUpdated: 2022-08-09
 ---
@@ -206,7 +206,7 @@ Remplace la [configuration globale `pagination`](/fr/reference/configuration/#pa
 
 ```md
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 # Masquer le lien de la page précédente
 prev: false
 ---
@@ -214,7 +214,7 @@ prev: false
 
 ```md
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 # Remplacer le texte du lien de la page
 prev: Poursuivre the tutorial
 ---
@@ -222,7 +222,7 @@ prev: Poursuivre the tutorial
 
 ```md
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 # Remplacer le lien et le texte de la page
 prev:
   link: /unrelated-page/
@@ -238,7 +238,7 @@ La même chose que [`prev`](#prev) mais pour le lien de la page suivante.
 
 ```md
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 # Masquer le lien de la page suivante
 next: false
 ---
@@ -253,7 +253,7 @@ Définit si cette page doit être incluse dans l'index de recherche de [Pagefind
 
 ```md
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 # Exclut cette page de l'index de recherche
 pagefind: false
 ---
@@ -286,7 +286,7 @@ Définir l'étiquette de cette page dans la barre latérale lorsqu'elle est affi
 
 ```md
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 title: About this project
 sidebar:
   label: About
@@ -302,7 +302,7 @@ Les numéros inférieurs sont affichés plus haut dans le groupe de liens.
 
 ```md
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 title: Page à afficher en premier
 sidebar:
   order: 1
@@ -318,7 +318,7 @@ Empêche cette page d'être incluse dans un groupe de liens généré automatiqu
 
 ```md
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 title: Page à masquer de la barre latérale générée automatiquement
 sidebar:
   hidden: true
@@ -335,7 +335,7 @@ Passez éventuellement un [objet `BadgeConfig`](/fr/reference/configuration/#bad
 
 ```md
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 title: Page avec un badge
 sidebar:
   # Utilise la variante par défaut correspondant à la couleur d'accentuation de votre site
@@ -345,7 +345,7 @@ sidebar:
 
 ```md
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 title: Page avec un badge
 sidebar:
   badge:
@@ -362,7 +362,7 @@ Attributs HTML à ajouter au lien de la page dans la barre latérale lorsqu'il e
 
 ```md
 ---
-# src/content/docs/example.md
+# src/content/docs/exemple.md
 title: Page s'ouvrant dans un nouvel onglet
 sidebar:
   # Ouvre la page dans un nouvel onglet


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

This pull request is a follow-up to [this comment](https://github.com/withastro/starlight/pull/1114#pullrequestreview-1746836085) and translates various frame titles to French, e.g. `example.md` -> `exemple.md`.

There are still some frame titles that are not translated:

- `font-face.css`
- `custom.css`
- `EmailLink.astro`
- `Title.astro`
- `ConditionalFooter.astro`
- `Custom.astro`

If this makes sense to translate some of them like `example` or `my-test-file` in a documentation context, I explicitly left those out for multiple reasons:

- It's usually not recommended to have file names in french in the industry and even forbidden sometimes
- Some are very specific to a concept which could be hard to translate, e.g. `font-face.css`
- Some I just didn't know how to translate, e.g. `custom.css` -> `personnalisé.css`? This makes no sense especially with the `é` which is usually not recommended in file names