### PR TITLE
Add Deploy to Vercel buttons to starter project READMEs

### DIFF
--- a/examples/basics/README.md
+++ b/examples/basics/README.md
@@ -8,6 +8,7 @@ npm create astro@latest -- --template starlight
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/starlight/tree/main/examples/basics)
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/starlight/tree/main/examples/basics)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fwithastro%2Fstarlight%2Ftree%2Fmain%2Fexamples%2Fbasics&project-name=my-starlight-docs&repository-name=my-starlight-docs)
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 

--- a/examples/tailwind/README.md
+++ b/examples/tailwind/README.md
@@ -8,6 +8,8 @@ npm create astro@latest -- --template starlight/tailwind
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/starlight/tree/main/examples/tailwind)
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/starlight/tree/main/examples/tailwind)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fwithastro%2Fstarlight%2Ftree%2Fmain%2Fexamples%2Ftailwind&project-name=my-starlight-docs&repository-name=my-starlight-docs)
+
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Suggested by @sarah11918 
- Adds a Vercel quick deploy button to the starter project READMEs alongside the open in StackBlitz/CodeSandbox buttons
- Wanted to do the same for Netlify but their equivalent doesn’t support deploying just a subdirectory — it would fork the whole Starlight repo
- Rendered READMEs now look like:
    <img width="447" alt="three buttons reading “Open in StackBlitz”, “Edit in CodeSandbox” and “Deploy”" src="https://github.com/withastro/starlight/assets/357379/d8cc3711-2c7f-40c2-aae3-b6cb244f7eca">


<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
