### PR TITLE
i18n(fr): fix typo in configuration.mdx

### DIFF
--- a/docs/src/content/docs/fr/reference/configuration.mdx
+++ b/docs/src/content/docs/fr/reference/configuration.mdx
@@ -94,7 +94,7 @@ Chaque élément doit comporter un `label` et l'une des propriétés suivantes :
 
 - `items` — un tableau contenant plus de liens et des sous-groupes.
 
-- `autogenerate` — un objet indiquant un répertoire de vos docs dpeuis lequel générer automatiquement un groupe de liens.
+- `autogenerate` — un objet indiquant un répertoire de vos docs depuis lequel générer automatiquement un groupe de liens.
 
 ```js
 starlight({


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Fix a little typo in french translation in the configuration.mdx file.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
