### PR TITLE
Specify `entrypoint` in addition to `entryPoint`

### DIFF
--- a/packages/starlight/index.ts
+++ b/packages/starlight/index.ts
@@ -41,11 +41,13 @@ export default function StarlightIntegration({
 
 				injectRoute({
 					pattern: '404',
-					entryPoint: '@astrojs/starlight/404.astro',
+					entrypoint: '@astrojs/starlight/404.astro',
+					entryPoint: '@astrojs/starlight/404.astro', // deprecated in Astro v4
 				});
 				injectRoute({
 					pattern: '[...slug]',
-					entryPoint: '@astrojs/starlight/index.astro',
+					entrypoint: '@astrojs/starlight/404.astro',
+					entryPoint: '@astrojs/starlight/index.astro', // deprecated in Astro v4
 				});
 				// Add built-in integrations only if they are not already added by the user through the
 				// config or by a plugin.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Fixes the warnings logged with Astro v4 as shown in #1236.

Astro v4 deprecated `entryPoint` in favour of `entrypoint`. The migration docs suggest [specifying both](https://docs.astro.build/en/guides/upgrade-to/v4/#what-should-i-do-2) to support older versions of Astro in addition to v4.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
