### PR TITLE
Prefetch links on hover by default

### DIFF
--- a/.changeset/sour-guests-tease.md
+++ b/.changeset/sour-guests-tease.md
@@ -1,0 +1,24 @@
+---
+'@astrojs/starlight': minor
+---
+
+Enables link prefetching on hover by default
+
+Astro v4’s [prefetch](https://docs.astro.build/en/guides/prefetch) support is now enabled by default. If `prefetch` is not set in `astro.config.mjs`, Starlight will use `prefetch: { prefetchAll: true, defaultStrategy: 'hover' }` by default.
+
+If you want to preserve previous behaviour, disable link prefetching in `astro.config.mjs`:
+
+```js
+import { defineConfig } from 'astro/config';
+import starlight from '@astrojs/starlight';
+
+export default defineConfig({
+  // Disable link prefetching:
+  prefetch: false,
+
+  integrations: [
+    starlight({
+      // ...
+    }),
+  ],
+});

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     {
       "name": "/_astro/*.js",
       "path": "examples/basics/dist/_astro/*.js",
-      "limit": "21 kB"
+      "limit": "22 kB"
     },
     {
       "name": "/_astro/*.css",

--- a/packages/starlight/index.ts
+++ b/packages/starlight/index.ts
@@ -76,6 +76,8 @@ export default function StarlightIntegration({
 							config.markdown.shikiConfig.theme !== 'github-dark' ? {} : { theme: 'css-variables' },
 					},
 					scopedStyleStrategy: 'where',
+					// If not already conigured, default to prefetching all links on hover.
+					prefetch: config.prefetch ?? { prefetchAll: true },
 				});
 			},
 

--- a/packages/starlight/index.ts
+++ b/packages/starlight/index.ts
@@ -76,7 +76,7 @@ export default function StarlightIntegration({
 							config.markdown.shikiConfig.theme !== 'github-dark' ? {} : { theme: 'css-variables' },
 					},
 					scopedStyleStrategy: 'where',
-					// If not already conigured, default to prefetching all links on hover.
+					// If not already configured, default to prefetching all links on hover.
 					prefetch: config.prefetch ?? { prefetchAll: true },
 				});
 			},


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Enables Astro’s `prefetch.prefetchAll` config option by default for all Starlight users.
- Users can opt out or customise the prefetching strategy using Astro’s [`prefetch` configuration options](https://docs.astro.build/en/guides/prefetch/)

- **Note:** Had to bump our size limit JS budget by 1 kB as this does add roughly 1kB to our JS bundle. I think it should be worth it for the snappier navigation and people will be able to opt out if they need.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
