### PR TITLE
i18n(ru): Fix typo in `i18n.untranslatedContent`

### DIFF
--- a/.changeset/mighty-bugs-punch.md
+++ b/.changeset/mighty-bugs-punch.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fix typo in Russian untranslated content notice

--- a/packages/starlight/translations/ru.json
+++ b/packages/starlight/translations/ru.json
@@ -13,7 +13,7 @@
   "sidebarNav.accessibleLabel": "Основное",
   "tableOfContents.onThisPage": "На этой странице",
   "tableOfContents.overview": "Обзор",
-  "i18n.untranslatedContent": "Этот содержимое пока не доступно на вашем языке.",
+  "i18n.untranslatedContent": "Это содержимое пока не доступно на вашем языке.",
   "page.editLink": "Редактировать страницу",
   "page.lastUpdated": "Последнее обновление:",
   "page.previousLink": "Предыдущая",


### PR DESCRIPTION
#### Description
This PR fixes small typo in `packages/starlight/translations/ru.json`  file.