### PR TITLE
docs: fix formatting related build issue

### DIFF
--- a/docs/src/content/docs/id/guides/site-search.mdx
+++ b/docs/src/content/docs/id/guides/site-search.mdx
@@ -50,65 +50,59 @@ Teks ini akan disembunyikan dari pencarian.
 
 Jika Anda memiliki akses ke [Algolia’s DocSearch program](https://docsearch.algolia.com/) dan ingin menggunakannya sebagai gantinya Pagefind, Anda dapat menggunakan plugin DocSearch Starlight resmi.
 
-1.  Install `@astrojs/starlight-docsearch`:
+1. Install `@astrojs/starlight-docsearch`:
 
-    <Tabs>
+   <Tabs>
 
-        		<TabItem label="npm">
+   <TabItem label="npm">
 
-        				   ```sh
+   ```sh
+   npm install @astrojs/starlight-docsearch
+   ```
 
-    npm install @astrojs/starlight-docsearch
+   </TabItem>
 
-    ````
+   <TabItem label="pnpm">
 
-    			</TabItem>
+   ```sh
+   pnpm install @astrojs/starlight-docsearch
+   ```
 
-    <TabItem label="pnpm">
+   </TabItem>
 
-          ```sh
-    pnpm install @astrojs/starlight-docsearch
-    ````
+   <TabItem label="Yarn">
 
-        		</TabItem>
+   ```sh
+   yarn add @astrojs/starlight-docsearch
+   ```
 
-    <TabItem label="Yarn">
+   </TabItem>
 
-          ```sh
+   </Tabs>
 
-    yarn add @astrojs/starlight-docsearch
+2. Tambahkan DocSearch ke konfigurasi [`plugins`](/id/reference/configuration/#plugins) Starlight Anda di `astro.config.mjs` dan taruh `appId`, `apiKey`, and `indexName` Algolia Anda:
 
-    ```
+   ```js ins={4,10-16}
+   // astro.config.mjs
+   import { defineConfig } from 'astro/config';
+   import starlight from '@astrojs/starlight';
+   import starlightDocSearch from '@astrojs/starlight-docsearch';
 
-    			</TabItem>
-
-    				</Tabs>
-
-    ```
-
-2.  Tambahkan DocSearch ke konfigurasi [`plugins`](/id/reference/configuration/#plugins) Starlight Anda di `astro.config.mjs` dan taruh `appId`, `apiKey`, and `indexName` Algolia Anda:
-
-    ```js ins={4,10-16}
-    // astro.config.mjs
-    import { defineConfig } from 'astro/config';
-    import starlight from '@astrojs/starlight';
-    import starlightDocSearch from '@astrojs/starlight-docsearch';
-
-    export default defineConfig({
-    	integrations: [
-    		starlight({
-    			title: 'Situs dengan DocSearch',
-    			plugins: [
-    				starlightDocSearch({
-    					appId: 'ID_APLIKASI_ANDA',
-    					apiKey: 'KUNCI_API_ANDA',
-    					indexName: 'NAMA_INDEX_ANDA',
-    				}),
-    			],
-    		}),
-    	],
-    });
-    ```
+   export default defineConfig({
+   	integrations: [
+   		starlight({
+   			title: 'Situs dengan DocSearch',
+   			plugins: [
+   				starlightDocSearch({
+   					appId: 'ID_APLIKASI_ANDA',
+   					apiKey: 'KUNCI_API_ANDA',
+   					indexName: 'NAMA_INDEX_ANDA',
+   				}),
+   			],
+   		}),
+   	],
+   });
+   ```
 
 Dengan konfigurasi yang diperbarui ini, bilah pencarian di situs Anda sekarang akan membuka modal Algolia sebagai gantinya modal pencarian bawaan.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

This PR fixes a build issue with the docs following the merge of #1250. If I get this right, I think this is what happened:

- #1250 was building fine in the PR
- #1250 was rendering fine in the PR
- After merging #1250, the live docs are rendering fine
- After CI applied formatting, it somehow formatted the file in way that broke the build

My assumption was that if some Markdown was rendering fine, applying Prettier would never break it but I guess this is a wrong assumption?