### PR TITLE
fix: remove link to incompatible plugin

### DIFF
--- a/docs/src/content/docs/de/showcase.mdx
+++ b/docs/src/content/docs/de/showcase.mdx
@@ -31,11 +31,6 @@ Diese Community-Tools, Plugins und Integrationen arbeiten mit Starlight zusammen
 		description="Füge deinen Dokumentseiten ein Benutzer-Feedback-System hinzu."
 	/>
 	<LinkCard
-		href="https://github.com/HiDeoo/starlight-blog"
-		title="starlight-blog"
-		description="Erweitere deine Dokumentationsseite mit einen Blog."
-	/>
-	<LinkCard
 		href="https://github.com/HiDeoo/starlight-links-validator"
 		title="starlight-links-validator"
 		description="Überprüfe deine Starlight-Seiten auf fehlerhafte Links."

--- a/docs/src/content/docs/es/showcase.mdx
+++ b/docs/src/content/docs/es/showcase.mdx
@@ -31,11 +31,6 @@ Estas herramientas de la comunidad, plugins e integraciones funcionan junto a St
 		description="Agrega un sistema de opinión de usuarios a tus páginas de documentación."
 	/>
 	<LinkCard
-		href="https://github.com/HiDeoo/starlight-blog"
-		title="starlight-blog"
-		description="Agrega un blog a tu sitio de documentación."
-	/>
-	<LinkCard
 		href="https://github.com/HiDeoo/starlight-links-validator"
 		title="starlight-links-validator"
 		description="Verifica en tus páginas de Starlight si hay enlaces rotos."

--- a/docs/src/content/docs/hi/showcase.mdx
+++ b/docs/src/content/docs/hi/showcase.mdx
@@ -31,11 +31,6 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 		description="अपने दस्तावेज़ पृष्ठों पर एक उपयोगकर्ता प्रतिक्रिया प्रणाली जोड़ें।"
 	/>
 	<LinkCard
-		href="https://github.com/HiDeoo/starlight-blog"
-		title="starlight-blog"
-		description="अपनी दस्तावेज़ीकरण साइट पर एक ब्लॉग जोड़ें."
-	/>
-	<LinkCard
 		href="https://github.com/HiDeoo/starlight-links-validator"
 		title="starlight-links-validator"
 		description="अपने Starlight पृष्ठों में टूटे हुए लिंक की जाँच करें।"

--- a/docs/src/content/docs/id/showcase.mdx
+++ b/docs/src/content/docs/id/showcase.mdx
@@ -31,11 +31,6 @@ _Tools_, _plugins_, dan integrasi dari komunitas ini bekerja bersama Starlight u
 		description="Tambahkan sistem user feedback ke halaman dokumentasi Anda."
 	/>
 	<LinkCard
-		href="https://github.com/HiDeoo/starlight-blog"
-		title="starlight-blog"
-		description="Tambahkan blog ke halaman dokumentasi Anda."
-	/>
-	<LinkCard
 		href="https://github.com/HiDeoo/starlight-links-validator"
 		title="starlight-links-validator"
 		description="Cek link yang rusak di website Starlight Anda."

--- a/docs/src/content/docs/it/showcase.mdx
+++ b/docs/src/content/docs/it/showcase.mdx
@@ -31,11 +31,6 @@ Questi strumenti della community, plug-in e integrazioni lavorano insieme a Star
 		description="Aggiungi un sistema di feedback degli utenti alle tue pagine di documenti."
 	/>
 	<LinkCard
-		href="https://github.com/HiDeoo/starlight-blog"
-		title="starlight-blog"
-		description="Aggiungi un blog al tuo sito di documentazione."
-	/>
-	<LinkCard
 		href="https://github.com/HiDeoo/starlight-links-validator"
 		title="starlight-links-validator"
 		description="Verifica la presenza di collegamenti interrotti nelle tue pagine Starlight."

--- a/docs/src/content/docs/ja/showcase.mdx
+++ b/docs/src/content/docs/ja/showcase.mdx
@@ -30,11 +30,6 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 		description="サイトにユーザーフィードバックシステムを追加します。"
 	/>
 	<LinkCard
-		href="https://github.com/HiDeoo/starlight-blog"
-		title="starlight-blog"
-		description="ドキュメントサイトにブログを追加します。"
-	/>
-	<LinkCard
 		href="https://github.com/HiDeoo/starlight-links-validator"
 		title="starlight-links-validator"
 		description="Starlightページに壊れたリンクがないか確認します。"

--- a/docs/src/content/docs/ko/showcase.mdx
+++ b/docs/src/content/docs/ko/showcase.mdx
@@ -33,11 +33,6 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 		description="문서 페이지에 사용자 피드백 시스템을 추가하세요."
 	/>
 	<LinkCard
-		href="https://github.com/HiDeoo/starlight-blog"
-		title="starlight-blog"
-		description="문서 사이트에 블로그를 추가하세요."
-	/>
-	<LinkCard
 		href="https://github.com/HiDeoo/starlight-links-validator"
 		title="starlight-links-validator"
 		description="Starlight 페이지에 끊어진 링크가 있는지 확인하세요."

--- a/docs/src/content/docs/pt-br/showcase.mdx
+++ b/docs/src/content/docs/pt-br/showcase.mdx
@@ -31,11 +31,6 @@ Essas ferramentas, plugins e integrações da comunidade funcionam ao lado do St
 		description="Adicione um sistema de feedback do usuário ao seu site."
 	/>
 	<LinkCard
-		href="https://github.com/HiDeoo/starlight-blog"
-		title="starlight-blog"
-		description="Adicione um blog ao seu site de documentação."
-	/>
-	<LinkCard
 		href="https://github.com/HiDeoo/starlight-links-validator"
 		title="starlight-links-validator"
 		description="Verifique se há links quebrados em suas páginas Starlight."

--- a/docs/src/content/docs/ru/showcase.mdx
+++ b/docs/src/content/docs/ru/showcase.mdx
@@ -31,11 +31,6 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 		description="Добавьте систему обратной связи на страницы вашей документации."
 	/>
 	<LinkCard
-		href="https://github.com/HiDeoo/starlight-blog"
-		title="starlight-blog"
-		description="Добавьте блог на ваш сайт с документацией."
-	/>
-	<LinkCard
 		href="https://github.com/HiDeoo/starlight-links-validator"
 		title="starlight-links-validator"
 		description="Проверьте наличие неработающих ссылок на ваших страницах Starlight."

--- a/docs/src/content/docs/showcase.mdx
+++ b/docs/src/content/docs/showcase.mdx
@@ -31,11 +31,6 @@ These community tools, plugins, and integrations work alongside Starlight to ext
 		description="Add a user feedback system to your docs pages."
 	/>
 	<LinkCard
-		href="https://github.com/HiDeoo/starlight-blog"
-		title="starlight-blog"
-		description="Add a blog to your documentation site."
-	/>
-	<LinkCard
 		href="https://github.com/HiDeoo/starlight-links-validator"
 		title="starlight-links-validator"
 		description="Check for broken links in your Starlight pages."

--- a/docs/src/content/docs/tr/showcase.mdx
+++ b/docs/src/content/docs/tr/showcase.mdx
@@ -31,11 +31,6 @@ Bu topluluk araçları, eklentileri ve entegrasyonları Starlight ile yan yana i
 		description="Dokümantasyon sayfalarına kullanıcı geribildirim sistemi ekle."
 	/>
 	<LinkCard
-		href="https://github.com/HiDeoo/starlight-blog"
-		title="starlight-blog"
-		description="Dokümantasyon sitene blok ekle."
-	/>
-	<LinkCard
 		href="https://github.com/HiDeoo/starlight-links-validator"
 		title="starlight-links-validator"
 		description="Starlight sayfalarındaki kırık bağlantıları kontrol et."

--- a/docs/src/content/docs/zh-cn/showcase.mdx
+++ b/docs/src/content/docs/zh-cn/showcase.mdx
@@ -30,11 +30,6 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 		description="在文档页面中添加用户反馈系统。"
 	/>
 	<LinkCard
-		href="https://github.com/HiDeoo/starlight-blog"
-		title="starlight-blog"
-		description="添加一个博客到你的文档网站。"
-	/>
-	<LinkCard
 		href="https://github.com/HiDeoo/starlight-links-validator"
 		title="starlight-links-validator"
 		description="在你的 Starlight 页面中检查损坏的链接"


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

As [mentioned](https://github.com/HiDeoo/starlight-blog/issues/19) in the starlight-blog repo, starlight-blog does not work with starlight 0.14 and above. There has been some [work](https://github.com/withastro/starlight/pull/1175) by @HiDeoo to reenable the plugin and I hope that this topic gets more interest and push from the maintainers soon. It seems to be non-trivial though and it looks as it requires decision making from the maintainers of starlight. This is also why I open this PR.

I think it makes sense not to advertise for the plugin for the time being since it creates some really difficult to debug crashes. I tried to move from docusaurus to astro + starlight + starlight-blog and this topic cost me several hours pulling my hair.

The changes should be easy to revert once the plugin has been fixed.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
