### PR TITLE
Export `StarlightUserConfig` type

### DIFF
--- a/.changeset/tame-squids-yawn.md
+++ b/.changeset/tame-squids-yawn.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Exports the `StarlightUserConfig` TypeScript type representing the user's Starlight configuration received by plugins.

--- a/packages/starlight/types.ts
+++ b/packages/starlight/types.ts
@@ -1,2 +1,5 @@
 export type { StarlightConfig } from './utils/user-config';
-export type { StarlightPlugin } from './utils/plugins';
+export type {
+	StarlightPlugin,
+	StarlightUserConfigWithPlugins as StarlightUserConfig,
+} from './utils/plugins';


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to Starlight code

#### Description

I've been finding myself often writing the following type when working on plugins and having to pass down the received Starlight user config to a function that needs multiple of its properties:

```ts
type StarlightUserConfig = Parameters<StarlightPlugin['hooks']['setup']>['0']['config']
```

This PR exports this type which is already referenced multiple times in the ["Plugins reference" page](https://starlight.astro.build/reference/plugins/) of the docs.