### PR TITLE
[i18nIgnore] docs: revert some translated default UI strings

### DIFF
--- a/docs/src/content/docs/es/guides/i18n.mdx
+++ b/docs/src/content/docs/es/guides/i18n.mdx
@@ -179,61 +179,61 @@ Puedes proprocionar traducciones para idiomas adicionales, o editar nuestras eti
 
 3. Agrega traducciones para las claves que deseas traducir en los archivos JSON. Traduce solo los valores, dejando las claves en inglés (p. ej. `"search.label": "Buscar"`).
 
-Estos son los valores predeterminados en inglés de las cadenas existentes que se incluyen en Starlight:
+   Estos son los valores predeterminados en inglés de las cadenas existentes que se incluyen en Starlight:
 
-```json
-{
-	"skipLink.label": "Skip to content",
-	"search.label": "Search",
-	"search.shortcutLabel": "(Press / to Search)",
-	"search.cancelLabel": "Cancel",
-	"search.devWarning": "Search is only available in production builds. \nTry building and previewing the site to test it out locally.",
-	"themeSelect.accessibleLabel": "Select theme",
-	"themeSelect.dark": "Dark",
-	"themeSelect.light": "Light",
-	"themeSelect.auto": "Auto",
-	"languageSelect.accessibleLabel": "Select language",
-	"menuButton.accessibleLabel": "Menu",
-	"sidebarNav.accessibleLabel": "Main",
-	"tableOfContents.onThisPage": "On this page",
-	"tableOfContents.overview": "Overview",
-	"i18n.untranslatedContent": "This content is not available in your language yet.",
-	"page.editLink": "Edit page",
-	"page.lastUpdated": "Last updated:",
-	"page.previousLink": "Next",
-	"page.nextLink": "Previous",
-	"404.text": "Page not found. Check the URL or try using the search bar."
-}
-```
+   ```json
+   {
+   	"skipLink.label": "Skip to content",
+   	"search.label": "Search",
+   	"search.shortcutLabel": "(Press / to Search)",
+   	"search.cancelLabel": "Cancel",
+   	"search.devWarning": "Search is only available in production builds. \nTry building and previewing the site to test it out locally.",
+   	"themeSelect.accessibleLabel": "Select theme",
+   	"themeSelect.dark": "Dark",
+   	"themeSelect.light": "Light",
+   	"themeSelect.auto": "Auto",
+   	"languageSelect.accessibleLabel": "Select language",
+   	"menuButton.accessibleLabel": "Menu",
+   	"sidebarNav.accessibleLabel": "Main",
+   	"tableOfContents.onThisPage": "On this page",
+   	"tableOfContents.overview": "Overview",
+   	"i18n.untranslatedContent": "This content is not available in your language yet.",
+   	"page.editLink": "Edit page",
+   	"page.lastUpdated": "Last updated:",
+   	"page.previousLink": "Next",
+   	"page.nextLink": "Previous",
+   	"404.text": "Page not found. Check the URL or try using the search bar."
+   }
+   ```
 
-Los bloques de código de Starlight están impulsados por la biblioteca [Expressive Code](https://github.com/expressive-code/expressive-code).
-Puedes establecer traducciones para las cadenas de UI en el mismo archivo JSON utilizando las llaves `expressiveCode`:
+   Los bloques de código de Starlight están impulsados por la biblioteca [Expressive Code](https://github.com/expressive-code/expressive-code).
+   Puedes establecer traducciones para las cadenas de UI en el mismo archivo JSON utilizando las llaves `expressiveCode`:
 
-```json
-{
-	"expressiveCode.copyButtonCopied": "¡Copiado!",
-	"expressiveCode.copyButtonTooltip": "Copiar al portapapeles",
-	"expressiveCode.terminalWindowFallbackTitle": "Ventana de terminal"
-}
-```
+   ```json
+   {
+   	"expressiveCode.copyButtonCopied": "Copied!",
+   	"expressiveCode.copyButtonTooltip": "Copy to clipboard",
+   	"expressiveCode.terminalWindowFallbackTitle": "Terminal window"
+   }
+   ```
 
-El modal de búsqueda de Starlight está impulsado por la biblioteca [Pagefind](https://pagefind.app/).
-Puedes establecer traducciones para la UI de Pagefind en el mismo archivo JSON utilizando claves `pagefind`:
+   El modal de búsqueda de Starlight está impulsado por la biblioteca [Pagefind](https://pagefind.app/).
+   Puedes establecer traducciones para la UI de Pagefind en el mismo archivo JSON utilizando claves `pagefind`:
 
-```json
-{
-	"pagefind.clear_search": "Clear",
-	"pagefind.load_more": "Load more results",
-	"pagefind.search_label": "Search this site",
-	"pagefind.filters_label": "Filters",
-	"pagefind.zero_results": "No results for [SEARCH_TERM]",
-	"pagefind.many_results": "[COUNT] results for [SEARCH_TERM]",
-	"pagefind.one_result": "[COUNT] result for [SEARCH_TERM]",
-	"pagefind.alt_search": "No results for [SEARCH_TERM]. Showing results for [DIFFERENT_TERM] instead",
-	"pagefind.search_suggestion": "No results for [SEARCH_TERM]. Try one of the following searches:",
-	"pagefind.searching": "Searching for [SEARCH_TERM]..."
-}
-```
+   ```json
+   {
+   	"pagefind.clear_search": "Clear",
+   	"pagefind.load_more": "Load more results",
+   	"pagefind.search_label": "Search this site",
+   	"pagefind.filters_label": "Filters",
+   	"pagefind.zero_results": "No results for [SEARCH_TERM]",
+   	"pagefind.many_results": "[COUNT] results for [SEARCH_TERM]",
+   	"pagefind.one_result": "[COUNT] result for [SEARCH_TERM]",
+   	"pagefind.alt_search": "No results for [SEARCH_TERM]. Showing results for [DIFFERENT_TERM] instead",
+   	"pagefind.search_suggestion": "No results for [SEARCH_TERM]. Try one of the following searches:",
+   	"pagefind.searching": "Searching for [SEARCH_TERM]..."
+   }
+   ```
 
 ### Extiende el esquema de traducción
 

--- a/docs/src/content/docs/pt-br/guides/i18n.mdx
+++ b/docs/src/content/docs/pt-br/guides/i18n.mdx
@@ -209,9 +209,9 @@ Você pode fornecer traduções para idiomas adicionais que você suporta — ou
 
    ```json
    {
-   	"expressiveCode.copyButtonCopied": "Copiado!",
-   	"expressiveCode.copyButtonTooltip": "Copiar",
-   	"expressiveCode.terminalWindowFallbackTitle": "Janela do Terminal"
+   	"expressiveCode.copyButtonCopied": "Copied!",
+   	"expressiveCode.copyButtonTooltip": "Copy to clipboard",
+   	"expressiveCode.terminalWindowFallbackTitle": "Terminal window"
    }
    ```
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

While looking for something, I noticed that some of the default UI strings were translated in the docs site (I also checked all the other languages and they were fine).

This PR reverts those changes (note that the Spanish change is slightly bigger as it also fixes an indentation issue).