### PR TITLE
i18n(fr): add expressive code french translations

### DIFF
--- a/.changeset/neat-hats-change.md
+++ b/.changeset/neat-hats-change.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Adds French translations for Expressive Code UI

--- a/packages/starlight/translations/fr.json
+++ b/packages/starlight/translations/fr.json
@@ -22,5 +22,8 @@
   "aside.note": "Note",
   "aside.tip": "Astuce",
   "aside.caution": "Attention",
-  "aside.danger": "Danger"
+  "aside.danger": "Danger",
+  "expressiveCode.copyButtonCopied": "Copié !",
+  "expressiveCode.copyButtonTooltip": "Copier dans le presse-papiers",
+  "expressiveCode.terminalWindowFallbackTitle": "Fenêtre de terminal"
 }


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to Starlight code

#### Description

Following this [comment](https://github.com/withastro/starlight/pull/1280#issuecomment-1859189848), this PR adds French translations for EC.

<img width="205" alt="SCR-20231218-kvdx" src="https://github.com/withastro/starlight/assets/494699/c46a6aa6-1bf5-4d45-a89b-e0317cb4c4f5">

<img width="139" alt="SCR-20231218-kvnm" src="https://github.com/withastro/starlight/assets/494699/29bce964-a240-45e5-b7b9-c84118f8621b">

<img width="317" alt="SCR-20231218-kwey" src="https://github.com/withastro/starlight/assets/494699/73e98a08-74d2-41a8-b85b-bd2a2e348778">
