### PR TITLE
docs: move `starlight-typedoc` to the community plugins section

### DIFF
--- a/docs/src/content/docs/showcase.mdx
+++ b/docs/src/content/docs/showcase.mdx
@@ -41,6 +41,11 @@ Extend your site with official plugins supported by the Starlight team and commu
 		title="starlight-links-validator"
 		description="Check for broken links in your Starlight pages."
 	/>
+	<LinkCard
+		href="https://github.com/HiDeoo/starlight-typedoc"
+		title="starlight-typedoc"
+		description="Generate Starlight pages from TypeScript using TypeDoc."
+	/>
 </CardGrid>
 
 ## Community tools and integrations
@@ -59,11 +64,6 @@ These community tools and integrations can be used to add features to your Starl
 		href="https://github.com/HiDeoo/starlight-blog"
 		title="starlight-blog"
 		description="Add a blog to your documentation site."
-	/>
-	<LinkCard
-		href="https://github.com/HiDeoo/starlight-typedoc"
-		title="starlight-typedoc"
-		description="Generate Starlight pages from TypeScript using TypeDoc."
 	/>
 	<LinkCard
 		href="https://github.com/HiDeoo/starlight-openapi"


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

Following the release of [version 0.7.0](<https://github.com/HiDeoo/starlight-typedoc/releases/tag/v0.7.0>) of `starlight-typedoc` which converts it to a Starlight plugin, this PR moves the associated showcase entry to the new community plugins section.