### PR TITLE
chore: fix type errors

### DIFF
--- a/.changeset/afraid-horses-compare.md
+++ b/.changeset/afraid-horses-compare.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+chore: fix type errors in Starlight internals

--- a/docs-i18n-tracker/build.ts
+++ b/docs-i18n-tracker/build.ts
@@ -6,7 +6,7 @@ const translationStatusBuilder = new TranslationStatusBuilder({
 	htmlOutputFilePath: './dist/index.html',
 	sourceLanguage: 'en',
 	targetLanguages: Object.values(locales)
-		.reduce((acc, { lang }) => (lang !== 'en' ? [lang, ...acc] : acc), [])
+		.reduce((acc, { lang }) => (lang !== 'en' ? [lang, ...acc] : acc), new Array<string>())
 		.sort(),
 	languageLabels: Object.values(locales)
 		.filter((loc) => loc.lang !== 'en')

--- a/docs-i18n-tracker/lib/github-get.mjs
+++ b/docs-i18n-tracker/lib/github-get.mjs
@@ -9,6 +9,7 @@ import pRetry, { AbortError } from 'p-retry';
 export async function githubGet({ url, githubToken = undefined }) {
 	return await pRetry(
 		async () => {
+			/** @type {Record<string, string>} */
 			const headers = {
 				Accept: 'application/vnd.github.v3+json',
 			};

--- a/docs-i18n-tracker/lib/output.mjs
+++ b/docs-i18n-tracker/lib/output.mjs
@@ -30,6 +30,7 @@ export function error(message, ...params) {
 /**
  * Dedents the given markdown and replaces single newlines with spaces,
  * while leaving new paragraphs intact.
+ * @param {[string | TemplateStringsArray, ...any[]]} markdown
  */
 export function dedentMd(...markdown) {
 	return dedent(...markdown).replace(/(\S)\n(?!\n)/g, '$1 ');
@@ -56,7 +57,7 @@ export function formatCount(count, template) {
 	const wrapWithCount = (text) => {
 		// If no count was given, we're outputting a single issue in annotations,
 		// so omit count and capitalize the first letter of the issue type description
-		if (count === undefined) return text[0].toUpperCase() + text.slice(1);
+		if (count === undefined) return text[0]?.toUpperCase() + text.slice(1);
 
 		// Otherwise, prefix the issue type description with count
 		return `${count} ${text}`;
@@ -65,7 +66,7 @@ export function formatCount(count, template) {
 	const usePlural = count !== undefined && count !== 1;
 	const templateParts = template.split('|');
 	const usedTemplate = templateParts.length === 2 ? templateParts[usePlural ? 1 : 0] : template;
-	return wrapWithCount(usedTemplate.replace(/\(s\)/g, usePlural ? 's' : ''));
+	return wrapWithCount(usedTemplate?.replace(/\(s\)/g, usePlural ? 's' : '') ?? '');
 }
 
 export default {

--- a/docs/src/components/theme-designer.astro
+++ b/docs/src/components/theme-designer.astro
@@ -1,7 +1,7 @@
 ---
 import { TabItem, Tabs } from '@astrojs/starlight/components';
-import ColorEditor, { Props as EditorProps } from './theme-designer/color-editor.astro';
-import Presets, { Props as PresetsProps } from './theme-designer/presets.astro';
+import ColorEditor, { type Props as EditorProps } from './theme-designer/color-editor.astro';
+import Presets, { type Props as PresetsProps } from './theme-designer/presets.astro';
 import Preview from './theme-designer/preview.astro';
 
 interface Props {

--- a/packages/starlight/__tests__/i18n/translations.test.ts
+++ b/packages/starlight/__tests__/i18n/translations.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import translations from '../../translations';
 import { useTranslations } from '../../utils/translations';
 

--- a/packages/starlight/__tests__/remark-rehype/asides.test.ts
+++ b/packages/starlight/__tests__/remark-rehype/asides.test.ts
@@ -118,9 +118,7 @@ describe('translated labels in French', () => {
 :::${type}
 Some text
 :::
-`,
-			{ fileURL: new URL('./_src/content/docs/fr/index.md', import.meta.url) }
-		);
+`);
 		expect(res.code).includes(`aria-label="${label}"`);
 		expect(res.code).includes(`</svg>${label}</p>`);
 	});

--- a/packages/starlight/__tests__/remark-rehype/asides.test.ts
+++ b/packages/starlight/__tests__/remark-rehype/asides.test.ts
@@ -118,7 +118,10 @@ describe('translated labels in French', () => {
 :::${type}
 Some text
 :::
-`);
+`,
+// @ts-expect-error fileURL is part of MarkdownProcessor's options
+{ fileURL: new URL('./_src/content/docs/fr/index.md', import.meta.url) }
+);
 		expect(res.code).includes(`aria-label="${label}"`);
 		expect(res.code).includes(`</svg>${label}</p>`);
 	});

--- a/packages/starlight/components.ts
+++ b/packages/starlight/components.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 export { default as Card } from './user-components/Card.astro';
 export { default as CardGrid } from './user-components/CardGrid.astro';
 export { default as Icon } from './user-components/Icon.astro';

--- a/packages/starlight/components.ts
+++ b/packages/starlight/components.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 export { default as Card } from './user-components/Card.astro';
 export { default as CardGrid } from './user-components/CardGrid.astro';
 export { default as Icon } from './user-components/Icon.astro';

--- a/packages/starlight/utils/createTranslationSystem.ts
+++ b/packages/starlight/utils/createTranslationSystem.ts
@@ -72,12 +72,12 @@ function buildDictionary(
 	base: (typeof builtinTranslations)[string],
 	...dictionaries: (i18nSchemaOutput | undefined)[]
 ) {
-	const dictionary = { ...base };
+	const dictionary: typeof base = { ...base };
 	// Iterate over alternate dictionaries to avoid overwriting preceding values with `undefined`.
 	for (const dict of dictionaries) {
 		for (const key in dict) {
-			const value = dict[key as keyof typeof dict];
-			if (value) dictionary[key as keyof typeof dict] = value;
+			const value = dict[key];
+			if (value) dictionary[key as keyof typeof dictionary] = value;
 		}
 	}
 	return dictionary;

--- a/packages/starlight/utils/createTranslationSystem.ts
+++ b/packages/starlight/utils/createTranslationSystem.ts
@@ -72,7 +72,7 @@ function buildDictionary(
 	base: (typeof builtinTranslations)[string],
 	...dictionaries: (i18nSchemaOutput | undefined)[]
 ) {
-	const dictionary: typeof base = { ...base };
+	const dictionary = { ...base };
 	// Iterate over alternate dictionaries to avoid overwriting preceding values with `undefined`.
 	for (const dict of dictionaries) {
 		for (const key in dict) {

--- a/packages/starlight/utils/translations.ts
+++ b/packages/starlight/utils/translations.ts
@@ -8,6 +8,7 @@ let userTranslations: Record<string, i18nSchemaOutput> = {};
 try {
 	// Load the user’s i18n collection and ignore the error if it doesn’t exist.
 	userTranslations = Object.fromEntries(
+		// @ts-expect-error
 		(await getCollection('i18n')).map(({ id, data }) => [id, data] as const)
 	);
 } catch {}

--- a/packages/starlight/utils/translations.ts
+++ b/packages/starlight/utils/translations.ts
@@ -8,7 +8,8 @@ let userTranslations: Record<string, i18nSchemaOutput> = {};
 try {
 	// Load the user’s i18n collection and ignore the error if it doesn’t exist.
 	userTranslations = Object.fromEntries(
-		// @ts-expect-error
+		// @ts-ignore — may be an error in projects without an i18n collection
+
 		(await getCollection('i18n')).map(({ id, data }) => [id, data] as const)
 	);
 } catch {}

--- a/packages/tailwind/__tests__/tailwind.test.ts
+++ b/packages/tailwind/__tests__/tailwind.test.ts
@@ -1,4 +1,4 @@
-import tailwindcss, { Config } from 'tailwindcss';
+import tailwindcss, { type Config } from 'tailwindcss';
 import colors from 'tailwindcss/colors';
 import postcss from 'postcss';
 import { test, expect, describe, vi } from 'vitest';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "astro/tsconfigs/strictest",
   "exclude": ["**/dist/**", "**/__coverage__/**"],
   "compilerOptions": {
+    "jsx": "preserve",
     "allowJs": true,
     "checkJs": true
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "astro/tsconfigs/strictest",
+  "exclude": ["**/dist/**", "**/__coverage__/**"],
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true


### PR DESCRIPTION
#### Description
- Adds type info or pragmas in a bunch of places that fail with `tsc`.
