### PR TITLE
showcase: Add docs.ghostfam.com

### DIFF
--- a/docs/src/components/showcase-sites.astro
+++ b/docs/src/components/showcase-sites.astro
@@ -4,6 +4,11 @@ import FluidGrid from './fluid-grid.astro';
 ---
 
 <FluidGrid>
+	<Card
+		title="TanaFlows Docs"
+		href="https://docs.ghostfam.com/"
+		thumbnail="docs.ghostfam.com.png"
+	/>
 	<Card title="Athena OS" href="https://athenaos.org" thumbnail="www.athenaos.org.png" />
 	<Card
 		title="PubIndexAPI Docs"


### PR DESCRIPTION
Adding a new showcase, this is the documentation of TanaFlows theme docs from ghostfam.com, a ghost theme docs.
Available at https://docs.ghostfam.com/