### PR TITLE
i18n(pt-BR): Update `reference/plugins`

### DIFF
--- a/docs/src/content/docs/pt-br/reference/plugins.md
+++ b/docs/src/content/docs/pt-br/reference/plugins.md
@@ -8,7 +8,7 @@ tableOfContents:
 Os plugins do Starlight podem personalizar a configuração, UI, e comportamento, além de serem fáceis de compartilhar e reutilizar.
 Essa página de referência documenta a API que os plugins tem acesso.
 
-Aprenda mais sobre como usar um plugin do Starlight na [Referência da Configuração](/pt-br/reference/configuration/#plugins).
+Aprenda mais sobre como usar um plugin do Starlight na [Referência da Configuração](/pt-br/reference/configuration/#plugins) ou visite o [mostruário de plugins](/pt-br/showcase/#plugins) para ver uma lista de plugins disponíveis.
 
 ## Referência rápida da API
 


### PR DESCRIPTION
#### Description

- Update the Portuguese translation of the plugins reference.
- The new link is broken as it points to a section added on #1342, once that gets merges the link here will be valid