### PR TITLE
fix: add open new tab to social links

### DIFF
--- a/.changeset/warm-hotels-tie.md
+++ b/.changeset/warm-hotels-tie.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+fix socialicons component

--- a/packages/starlight/components/SocialIcons.astro
+++ b/packages/starlight/components/SocialIcons.astro
@@ -12,7 +12,7 @@ const links = Object.entries(config.social || {}) as [Platform, SocialConfig][];
 	links.length > 0 && (
 		<>
 			{links.map(([platform, { label, url }]) => (
-				<a href={url} rel="me" class="sl-flex">
+				<a href={url} rel="me" class="sl-flex" target="_blank">
 					<span class="sr-only">{label}</span>
 					<Icon name={platform} />
 				</a>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Most websites' social link buttons are expected to open in a new window. (including [Astro Docs](https://astro.build))
However, the social link buttons on the [Starlight website](https://starlight.astro.build/) do not.
Fix this to improve UX.