### PR TITLE
docs: ignore testimonials from search results

### DIFF
--- a/docs/src/components/testimonial-grid.astro
+++ b/docs/src/components/testimonial-grid.astro
@@ -6,7 +6,7 @@ interface Props {
 const { title } = Astro.props;
 ---
 
-<div class="testimonial-wrapper not-content">
+<div class="testimonial-wrapper not-content" data-pagefind-ignore>
 	<h2 class="testimonial-grid-title">{title}</h2>
 	<ul class="testimonial-grid">
 		<slot />


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

This PR is a follow-up to this [Discord message](https://discord.com/channels/830184174198718474/1070481941863878697/1196378884950720512) that got some positive reactions so I decided to go ahead and make a PR for it (happy to close it if it's not wanted for whatever reason).

The idea is to ignore testimonials from search results as searching for "subdomain", "component", or "monorepo" for example can return results redirecting to the top of the homepage which I don't think is very useful from a user perspective.