### PR TITLE
Restore original tighter line-height on `<LinkCard>` titles

### DIFF
--- a/.changeset/eighty-cats-float.md
+++ b/.changeset/eighty-cats-float.md
@@ -1,0 +1,13 @@
+---
+'@astrojs/starlight': minor
+---
+
+Tightens `line-height` on `<LinkCard>` titles to fix regression from original design
+
+If you want to preserve the previous `line-height`, you can add the following custom CSS to your site:
+
+```css
+.sl-link-card a {
+  line-height: 1.6;
+}
+```

--- a/packages/starlight/user-components/LinkCard.astro
+++ b/packages/starlight/user-components/LinkCard.astro
@@ -10,7 +10,7 @@ interface Props extends Omit<HTMLAttributes<'a'>, 'title'> {
 const { title, description, ...attributes } = Astro.props;
 ---
 
-<div>
+<div class="sl-link-card">
 	<span class="sl-flex stack">
 		<a {...attributes}>
 			<span class="title" set:html={title} />
@@ -21,7 +21,7 @@ const { title, description, ...attributes } = Astro.props;
 </div>
 
 <style>
-	div {
+	.sl-link-card {
 		display: grid;
 		grid-template-columns: 1fr auto;
 		gap: 0.5rem;
@@ -65,12 +65,12 @@ const { title, description, ...attributes } = Astro.props;
 	}
 
 	/* Hover state */
-	div:hover {
+	.sl-link-card:hover {
 		background: var(--sl-color-gray-7, var(--sl-color-gray-6));
 		border-color: var(--sl-color-gray-2);
 	}
 
-	div:hover .icon {
+	.sl-link-card:hover .icon {
 		color: var(--sl-color-white);
 	}
 </style>

--- a/packages/starlight/user-components/LinkCard.astro
+++ b/packages/starlight/user-components/LinkCard.astro
@@ -34,6 +34,7 @@ const { title, description, ...attributes } = Astro.props;
 
 	a {
 		text-decoration: none;
+		line-height: var(--sl-line-height-headings);
 	}
 
 	/* a11y fix for https://github.com/withastro/starlight/issues/487 */
@@ -52,7 +53,6 @@ const { title, description, ...attributes } = Astro.props;
 		color: var(--sl-color-white);
 		font-weight: 600;
 		font-size: var(--sl-text-lg);
-		line-height: var(--sl-line-height-headings);
 	}
 
 	.description {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- We noticed in https://github.com/withastro/starlight/pull/1357#issuecomment-1900323888 that we accidentally made the line height of `<LinkCard>` titles wider in #488. This PR restores the original tighter design.

An example of the change: 

| Before | After |
|---|---|
| <img width="755" alt="Three link cards with titles that wrap across two lines" src="https://github.com/withastro/starlight/assets/357379/587b11db-d301-403e-aa73-dd36d7b5b5c7"> | <img width="756" alt="The same three link cards with titles that now have narrower line height" src="https://github.com/withastro/starlight/assets/357379/a047bf9a-af3c-4542-951f-a7482ff0e70d"> |

Docs pages with link cards:

- https://starlight-git-chris-link-card-titles-astrodotbuild.vercel.app/showcase/#plugins
- https://starlight-git-chris-link-card-titles-astrodotbuild.vercel.app/guides/components/#link-cards