### PR TITLE
docs: fix `disable404Route` default type

### DIFF
--- a/docs/src/content/docs/ko/reference/configuration.mdx
+++ b/docs/src/content/docs/ko/reference/configuration.mdx
@@ -520,7 +520,7 @@ starlight({
 ### `disable404Route`
 
 **타입:** `boolean`  
-**기본값:** `'false'`
+**기본값:** `false`
 
 Starlight의 기본 [404 페이지](https://docs.astro.build/ko/core-concepts/astro-pages/#사용자-정의-404-오류-페이지) 삽입을 비활성화합니다. 프로젝트에서 사용자 정의 `src/pages/404.astro` 경로를 사용하려면 이 옵션을 `false`로 설정하세요.
 

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -517,7 +517,7 @@ For example, this page is titled “Configuration Reference” and this site is 
 ### `disable404Route`
 
 **type:** `boolean`  
-**default:** `'false'`
+**default:** `false`
 
 Disables injecting Starlight's default [404 page](https://docs.astro.build/en/core-concepts/astro-pages/#custom-404-error-page). To use a custom `src/pages/404.astro` route in your project, set this option to `false`.
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

This PR fixes the default type of the new `disable404Route` in the docs to be a boolean (`false`) instead of a string (`'false'`) which I think was a typo that I noticed while reviewing a translation.

This PR also apply the changes to the `ko/reference/configuration` page which has already been translated. When merged, I'll apply a suggestion to https://github.com/withastro/starlight/pull/1414 too (and any other translation PRs that may appear until then).