### PR TITLE
fix : font not rendered properly on firefox #1419

### DIFF
--- a/packages/starlight/style/props.css
+++ b/packages/starlight/style/props.css
@@ -87,8 +87,8 @@
 		'Segoe UI Symbol', 'Noto Color Emoji';
 	--sl-font-system-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
 		'Courier New', monospace;
-	--__sl-font: var(--sl-font, ''), var(--sl-font-system);
-	--__sl-font-mono: var(--sl-font-mono, ''), var(--sl-font-system-mono);
+	--__sl-font: var(--sl-font-system);
+	--__sl-font-mono: var(--sl-font-system-mono);
 
 	/** Key layout values */
 	--sl-nav-height: 3.5rem;


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #1419 <!-- Add an issue number if this PR will close it. -->
- What does this PR change? Give us a brief description.
this PR fixes an error using the css variable for font-family which caused it not to render properly on firefox
- Did you change something visual? A before/after screenshot can be helpful.
Before:
![astro starlight](https://github.com/withastro/starlight/assets/22223193/ccb53d8d-fb68-43b1-8aa9-eae52f3b16bf)
After:
![image](https://github.com/withastro/starlight/assets/22223193/970992a6-483c-40fd-8d9d-351e51cca778)

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
