### PR TITLE
docs: fix `disable404Route` description

### DIFF
--- a/docs/src/content/docs/ko/reference/configuration.mdx
+++ b/docs/src/content/docs/ko/reference/configuration.mdx
@@ -522,7 +522,7 @@ starlight({
 **타입:** `boolean`  
 **기본값:** `false`
 
-Starlight의 기본 [404 페이지](https://docs.astro.build/ko/core-concepts/astro-pages/#사용자-정의-404-오류-페이지) 삽입을 비활성화합니다. 프로젝트에서 사용자 정의 `src/pages/404.astro` 경로를 사용하려면 이 옵션을 `false`로 설정하세요.
+Starlight의 기본 [404 페이지](https://docs.astro.build/ko/core-concepts/astro-pages/#사용자-정의-404-오류-페이지) 삽입을 비활성화합니다. 프로젝트에서 사용자 정의 `src/pages/404.astro` 경로를 사용하려면 이 옵션을 `true`로 설정하세요.
 
 ### `components`
 

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -519,7 +519,7 @@ For example, this page is titled “Configuration Reference” and this site is 
 **type:** `boolean`  
 **default:** `false`
 
-Disables injecting Starlight's default [404 page](https://docs.astro.build/en/core-concepts/astro-pages/#custom-404-error-page). To use a custom `src/pages/404.astro` route in your project, set this option to `false`.
+Disables injecting Starlight's default [404 page](https://docs.astro.build/en/core-concepts/astro-pages/#custom-404-error-page). To use a custom `src/pages/404.astro` route in your project, set this option to `true`.
 
 ### `components`
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

After reading this sentence a few times for reviews, I just realized that the description example is inverted.

Edit: also noticed by @liruifengv in https://github.com/withastro/starlight/pull/1430#discussion_r1469123108