### PR TITLE
Add Starlight types to `defineEcConfig`, export `StarlightExpressiveCodeOptions`

### DIFF
--- a/.changeset/calm-roses-joke.md
+++ b/.changeset/calm-roses-joke.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/starlight': patch
+---
+
+Adds Starlight-specific types to `defineEcConfig` function and exports `StarlightExpressiveCodeOptions`.
+
+This provides Starlight types and IntelliSense support for your Expressive Code configuration options inside an `ec.config.mjs` file. See the [Expressive Code documentation](https://expressive-code.com/key-features/code-component/#using-an-ecconfigmjs-file) for more information.

--- a/packages/starlight/integrations/expressive-code/exports.ts
+++ b/packages/starlight/integrations/expressive-code/exports.ts
@@ -35,4 +35,36 @@
 
 export * from 'astro-expressive-code';
 
+import type { StarlightExpressiveCodeOptions } from './index';
+
+export type { StarlightExpressiveCodeOptions };
+
+/**
+ * A utility function that helps you define an Expressive Code configuration object. It is meant
+ * to be used inside the optional config file `ec.config.mjs` located in the root directory
+ * of your Starlight project, and its return value to be exported as the default export.
+ *
+ * Expressive Code will automatically detect this file and use the exported configuration object
+ * to override its own default settings.
+ *
+ * Using this function is recommended, but not required. It just passes through the given object,
+ * but it also provides type information for your editor's auto-completion and type checking.
+ *
+ * @example
+ * ```js
+ * // ec.config.mjs
+ * import { defineEcConfig } from '@astrojs/starlight/expressive-code'
+ *
+ * export default defineEcConfig({
+ *   themes: ['starlight-dark', 'github-light'],
+ *   styleOverrides: {
+ *     borderRadius: '0.5rem',
+ *   },
+ * })
+ * ```
+ */
+export function defineEcConfig(config: StarlightExpressiveCodeOptions) {
+	return config;
+}
+
 export { getStarlightEcConfigPreprocessor } from './index';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Adds Starlight-specific types to the `defineEcConfig` function and exports `StarlightExpressiveCodeOptions`. Both can be imported from `@astrojs/starlight/expressive-code`.

This provides Starlight types and IntelliSense support for your Expressive Code configuration options inside an `ec.config.mjs` file. See the [Expressive Code documentation](https://expressive-code.com/key-features/code-component/#using-an-ecconfigmjs-file) for more information.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
