### PR TITLE
Update `localizedUrl()` to handle `.html` routes correctly

### DIFF
--- a/.changeset/hip-otters-deny.md
+++ b/.changeset/hip-otters-deny.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes URLs in language picker for sites with `build.format: 'file'`

--- a/packages/starlight/__tests__/basics/localizedUrl.test.ts
+++ b/packages/starlight/__tests__/basics/localizedUrl.test.ts
@@ -1,7 +1,26 @@
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { localizedUrl } from '../../utils/localizedUrl';
 
-test('it has no effect in a monolingual project', () => {
-	const url = new URL('https://example.com/en/guide/');
-	expect(localizedUrl(url, undefined).href).toBe(url.href);
+describe('with `build.output: "directory"`', () => {
+	test('it has no effect in a monolingual project', () => {
+		const url = new URL('https://example.com/en/guide/');
+		expect(localizedUrl(url, undefined).href).toBe(url.href);
+	});
+
+	test('has no effect on index route in a monolingual project', () => {
+		const url = new URL('https://example.com/');
+		expect(localizedUrl(url, undefined).href).toBe(url.href);
+	});
+});
+
+describe('with `build.output: "file"`', () => {
+	test('it has no effect in a monolingual project', () => {
+		const url = new URL('https://example.com/en/guide.html');
+		expect(localizedUrl(url, undefined).href).toBe(url.href);
+	});
+
+	test('has no effect on index route in a monolingual project', () => {
+		const url = new URL('https://example.com/index.html');
+		expect(localizedUrl(url, undefined).href).toBe(url.href);
+	});
 });

--- a/packages/starlight/__tests__/i18n-root-locale/localizedUrl.test.ts
+++ b/packages/starlight/__tests__/i18n-root-locale/localizedUrl.test.ts
@@ -1,22 +1,76 @@
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { localizedUrl } from '../../utils/localizedUrl';
 
-test('it has no effect if locale matches', () => {
-	const url = new URL('https://example.com/en/guide/');
-	expect(localizedUrl(url, 'en').href).toBe(url.href);
+describe('with `build.output: "directory"`', () => {
+	test('it has no effect if locale matches', () => {
+		const url = new URL('https://example.com/en/guide/');
+		expect(localizedUrl(url, 'en').href).toBe(url.href);
+	});
+
+	test('it has no effect if locale matches for index', () => {
+		const url = new URL('https://example.com/en/');
+		expect(localizedUrl(url, 'en').href).toBe(url.href);
+	});
+
+	test('it changes locale to requested locale', () => {
+		const url = new URL('https://example.com/en/guide/');
+		expect(localizedUrl(url, 'ar').href).toBe('https://example.com/ar/guide/');
+	});
+
+	test('it changes locale to requested locale for index', () => {
+		const url = new URL('https://example.com/en/');
+		expect(localizedUrl(url, 'ar').href).toBe('https://example.com/ar/');
+	});
+
+	test('it can change to root locale', () => {
+		const url = new URL('https://example.com/en/guide/');
+		expect(localizedUrl(url, undefined).href).toBe('https://example.com/guide/');
+	});
+
+	test('it can change from root locale', () => {
+		const url = new URL('https://example.com/guide/');
+		expect(localizedUrl(url, 'en').href).toBe('https://example.com/en/guide/');
+	});
 });
 
-test('it changes locale to requested locale', () => {
-	const url = new URL('https://example.com/en/guide/');
-	expect(localizedUrl(url, 'ar').href).toBe('https://example.com/ar/guide/');
-});
+describe('with `build.output: "file"`', () => {
+	test('it has no effect if locale matches', () => {
+		const url = new URL('https://example.com/en/guide.html');
+		expect(localizedUrl(url, 'en').href).toBe(url.href);
+	});
 
-test('it can change to root locale', () => {
-	const url = new URL('https://example.com/en/guide/');
-	expect(localizedUrl(url, undefined).href).toBe('https://example.com/guide/');
-});
+	test('it has no effect if locale matches for index', () => {
+		const url = new URL('https://example.com/en.html');
+		expect(localizedUrl(url, 'en').href).toBe(url.href);
+	});
 
-test('it can change from root locale', () => {
-	const url = new URL('https://example.com/guide/');
-	expect(localizedUrl(url, 'en').href).toBe('https://example.com/en/guide/');
+	test('it changes locale to requested locale', () => {
+		const url = new URL('https://example.com/en/guide.html');
+		expect(localizedUrl(url, 'ar').href).toBe('https://example.com/ar/guide.html');
+	});
+
+	test('it changes locale to requested locale for index', () => {
+		const url = new URL('https://example.com/en.html');
+		expect(localizedUrl(url, 'ar').href).toBe('https://example.com/ar.html');
+	});
+
+	test('it can change to root locale', () => {
+		const url = new URL('https://example.com/en/guide.html');
+		expect(localizedUrl(url, undefined).href).toBe('https://example.com/guide.html');
+	});
+
+	test('it can change to root locale from index', () => {
+		const url = new URL('https://example.com/en.html');
+		expect(localizedUrl(url, undefined).href).toBe('https://example.com/index.html');
+	});
+
+	test('it can change from root locale', () => {
+		const url = new URL('https://example.com/guide.html');
+		expect(localizedUrl(url, 'en').href).toBe('https://example.com/en/guide.html');
+	});
+
+	test('it can change from root locale from index', () => {
+		const url = new URL('https://example.com/index.html');
+		expect(localizedUrl(url, 'en').href).toBe('https://example.com/en.html');
+	});
 });

--- a/packages/starlight/__tests__/i18n/localizedUrl.test.ts
+++ b/packages/starlight/__tests__/i18n/localizedUrl.test.ts
@@ -1,12 +1,46 @@
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { localizedUrl } from '../../utils/localizedUrl';
 
-test('it has no effect if locale matches', () => {
-	const url = new URL('https://example.com/en/guide/');
-	expect(localizedUrl(url, 'en').href).toBe(url.href);
+describe('with `build.output: "directory"`', () => {
+	test('it has no effect if locale matches', () => {
+		const url = new URL('https://example.com/en/guide/');
+		expect(localizedUrl(url, 'en').href).toBe(url.href);
+	});
+
+	test('it has no effect if locale matches for index', () => {
+		const url = new URL('https://example.com/en/');
+		expect(localizedUrl(url, 'en').href).toBe(url.href);
+	});
+
+	test('it changes locale to requested locale', () => {
+		const url = new URL('https://example.com/en/guide/');
+		expect(localizedUrl(url, 'fr').href).toBe('https://example.com/fr/guide/');
+	});
+
+	test('it changes locale to requested locale for index', () => {
+		const url = new URL('https://example.com/en/');
+		expect(localizedUrl(url, 'fr').href).toBe('https://example.com/fr/');
+	});
 });
 
-test('it changes locale to requested locale', () => {
-	const url = new URL('https://example.com/en/guide/');
-	expect(localizedUrl(url, 'fr').href).toBe('https://example.com/fr/guide/');
+describe('with `build.output: "file"`', () => {
+	test('it has no effect if locale matches', () => {
+		const url = new URL('https://example.com/en/guide.html');
+		expect(localizedUrl(url, 'en').href).toBe(url.href);
+	});
+
+	test('it has no effect if locale matches for index', () => {
+		const url = new URL('https://example.com/en.html');
+		expect(localizedUrl(url, 'en').href).toBe(url.href);
+	});
+
+	test('it changes locale to requested locale', () => {
+		const url = new URL('https://example.com/en/guide.html');
+		expect(localizedUrl(url, 'fr').href).toBe('https://example.com/fr/guide.html');
+	});
+
+	test('it changes locale to requested locale for index', () => {
+		const url = new URL('https://example.com/en.html');
+		expect(localizedUrl(url, 'fr').href).toBe('https://example.com/fr.html');
+	});
 });


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #1423
- Adds test cases for our `localizedUrl()` helper for routes with `.html` extensions
- Fixes the tests
- This fixes URLs in language picker (and a couple other places) for sites with `build.format: 'file'`

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
