### PR TITLE
i18n(it): Translated community-content, plugins and showcase

### DIFF
--- a/docs/src/content/docs/it/resources/community-content.mdx
+++ b/docs/src/content/docs/it/resources/community-content.mdx
@@ -1,0 +1,118 @@
+---
+title: Contenuti della community
+description: Scopri guide, articoli e video prodotti dalla community per imparare e costruire con Starlight!
+---
+
+:::tip[Aggiungi il tuo!]
+Hai prodotto contenuti su Starlight?
+Apri una PR aggiungendo un link a questa pagina!
+:::
+
+import { CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+## Articoli e recensioni
+
+Qui trovi una raccolta di post e articoli per saperne di più su Starlight e le esperienze di altre persone:
+
+<CardGrid>
+	<LinkCard
+    href="https://devm.io/open-source/starlight-astro"
+		title="Generazione di siti statici con Starlight"
+		description="“Nessuna idea è troppo grande o troppo piccola quando si progettano componenti” — intervista con Chris Swithinbank, leader di Starlight"
+	/>
+  <LinkCard
+    href="https://frontendatscale.com/blog/hybrid-frontend-architecture/"
+    title="Architettura frontend ibrida con Astro e Starlight"
+    description="Maxi Ferreira e Ben Holmes costruiscono un sito di documentazione con Starlight, TinaCMS e un Playground API interattivo con autenticazione."
+  />
+  <LinkCard
+    href="https://www.olets.dev/posts/comparing-docs-site-builders-vuepress-vs-starlight/"
+    title="Confronto tra generatori di siti di documentazione: VuePress vs Starlight"
+    description="Come si confrontano i due framework?"
+  />
+</CardGrid>
+
+## Ricette e guide
+
+Le ricette sono tipicamente brevi guide pratiche che guidano il lettore attraverso il completamento di un esempio funzionante per uno specifico compito. Le ricette sono un ottimo modo per aggiungere nuove funzionalità o comportamenti al tuo progetto Starlight seguendo istruzioni passo passo! Altre guide potrebbero spiegare concetti specifici, come l'uso di immagini o il lavoro con MDX.
+
+Esplora i contenuti prodotti dalla community e gestiti dagli utenti di Starlight:
+
+<CardGrid>
+  <LinkCard
+    href="https://www.webpro.nl/scraps/versioned-docs-with-starlight-and-vercel"
+    title="Documentazione versionata con Starlight e Vercel"
+    description="Una guida all'implementazione di versioni separate della documentazione per ogni versione principale di un progetto"
+  />
+  <LinkCard
+    href="https://hideoo.dev/notes/starlight-heading-links"
+    title="Aggiungi link agli heading di Starlight"
+    description="Una guida all'uso di un plugin rehype per condividere link a sezioni specifiche della tua documentazione"
+  />
+  <LinkCard
+    href="https://blog.otterlord.dev/posts/starlight-sponsors/"
+    title="Aggiungi sponsor al tuo sito Starlight"
+    description="Una guida per implementare un componente sponsor personalizzato nella sidebar della tua documentazione"
+  />
+  <LinkCard
+    href="https://hideoo.dev/notes/starlight-og-images"
+    title="Aggiungi immagini Open Graph a Starlight"
+    description="Una guida alla generazione di immagini social e dei tag meta corrispondenti per le tue pagine"
+  />
+  <LinkCard
+    href="https://hideoo.dev/notes/starlight-third-party-icon-sets"
+    title="Usa set di icone di terze parti in Starlight"
+    description="Una guida all'uso di unplugin-icons per espandere la selezione di icone disponibili per Starlight"
+  />
+  <LinkCard
+    href="https://hideoo.dev/notes/starlight-custom-html-head"
+    title="Modifica l'HTML head delle pagine di Starlight"
+    description="Scopri come aggiungere contenuti comuni per l'head come analytics web, font e script"
+  />
+  <LinkCard
+    href="https://dev.to/mrrobot/publishing-documentation-with-astro-starlight-691"
+    title="Pubblicare documentazione con Astro Starlight"
+    description="Come iniziare con la documentazione Starlight"
+  />
+
+</CardGrid>
+
+## Contenuti video
+
+Scopri video e canali con contenuti Starlight, incluse live streaming e contenuti educativi.
+
+import YouTubeGrid from '~/components/youtube-grid.astro';
+
+### Video di Astro
+
+<YouTubeGrid
+  videos={[
+    {
+      href: 'https://www.youtube.com/watch?v=5u0Ds7wzUeI',
+      title: 'Starlight by Astro',
+      description: 'Guarda il video di lancio ufficiale di Starlight',
+    },
+    {
+      href: 'https://www.youtube.com/shorts/zjOWezSzd18', 
+      title: '🌟 SUB 1 MINUTE RUN',
+      description: 'Guarda Ben lanciare un nuovo sito Starlight in meno di un minuto!',
+    },
+  ]}
+/>
+
+### Video e live stream della community
+
+<YouTubeGrid
+  videos={[
+    {
+      href: 'https://www.youtube.com/watch?v=sWkkHbwDeQc',
+      title: 'Astro Starlight',
+      description: 'Introduzione a Starlight in meno di un minuto.',
+    },
+    {
+      href: 'https://www.youtube.com/watch?v=-Ki-1E5gNCk',
+      title: 'Astro Starlight Documentation Template (build custom app docs!)',
+      description: 'Crea un nuovo sito Starlight in circa 5 minuti', 
+    },
+  ]}
+/>

--- a/docs/src/content/docs/it/resources/plugins.mdx
+++ b/docs/src/content/docs/it/resources/plugins.mdx
@@ -1,0 +1,75 @@
+---
+title: Plugin e integrazioni
+description: Scopri strumenti della community come plugin e integrazioni che estendono Starlight!  
+sidebar:
+  order: 1
+---
+
+:::tip[Aggiungi il tuo!]
+Hai costruito un plugin o uno strumento per Starlight?
+Apri una PR aggiungendo un link a questa pagina!
+:::
+
+## Plugins
+
+[I plugin](/it/reference/plugins/) possono personalizzare la configurazione, interfaccia utente e comportamento di Starlight, rendendo allo stesso tempo facile la condivisione e il riutilizzo.
+Estendi il tuo sito con plugin ufficiali supportati dal team Starlight e plugin della community gestiti dagli utenti Starlight.  
+
+### Plugin ufficiali
+
+<CardGrid>
+  <LinkCard
+		href="/it/guides/site-search/#algolia-docsearch"
+		title="Algolia DocSearch"
+		description="Sostituisci Pagefind, il provider di ricerca predefinito, con Algolia DocSearch."
+	/>
+</CardGrid>
+
+### Plugin della community
+
+<CardGrid>
+  <LinkCard
+		href="https://github.com/HiDeoo/starlight-links-validator"
+		title="starlight-links-validator"
+		description="Controlla i link rotti nelle tue pagine Starlight."
+	/>
+  <LinkCard
+		href="https://github.com/HiDeoo/starlight-typedoc"
+		title="starlight-typedoc"
+		description="Genera pagine Starlight da TypeScript usando TypeDoc."
+	/>
+</CardGrid>
+
+## Strumenti e integrazioni della community
+
+import { CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+Questi strumenti e integrazioni della community possono essere utilizzati per aggiungere funzionalità al tuo sito Starlight.
+
+<CardGrid>
+  <LinkCard
+		href="https://www.feelback.dev/blog/new-astro-starlight-integration/"
+		title="FeelBack"
+		description="Aggiungi un sistema di feedback utente alle tue pagine di documentazione."
+	/>
+  <LinkCard
+		href="https://github.com/HiDeoo/starlight-blog"
+		title="starlight-blog"
+		description="Aggiungi un blog al tuo sito di documentazione."
+	/>
+  <LinkCard
+		href="https://github.com/HiDeoo/starlight-openapi"
+		title="starlight-openapi"
+		description="Crea pagine di documentazione da specifiche OpenAPI/Swagger."
+	/>
+  <LinkCard
+		href="https://github.com/val-town/notion-to-astro"
+		title="notion-to-astro"
+		description="Converti la tua documentazione da Notion a Starlight"
+	/>
+  <LinkCard
+		href="https://github.com/mattjennings/astro-live-code"
+		title="astro-live-code"
+		description="Rendi interattivi i blocchi di codice MDX"
+	/>
+</CardGrid>

--- a/docs/src/content/docs/it/resources/showcase.mdx
+++ b/docs/src/content/docs/it/resources/showcase.mdx
@@ -1,0 +1,21 @@
+---
+title: Vetrina Starlight
+description: Scopri i siti creati con Starlight!
+sidebar:
+  label: Vetrina siti
+---
+
+:::tip[Aggiungi il tuo!]
+Hai creato un sito con Starlight?
+Apri una PR aggiungendo un link a questa pagina!
+:::
+
+## Siti
+
+import ShowcaseSites from '~/components/showcase-sites.astro';
+
+Starlight è già utilizzato in produzione. Questi sono alcuni dei siti che lo usano:
+
+<ShowcaseSites />
+
+Vedi tutte le [repository di progetti pubblici che usano Starlight su GitHub](https://github.com/withastro/starlight/network/dependents).


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Translated `community-content.mdx`, `plugins.mdx` and `showcase.mdx` so now all of the files in the `resources` folder are available in Italian too. I didn't create 3 different PRs for every file since the files are pretty small.

The `/it/reference/plugins/` link in `plugins.mdx` will be broken because I'm working on it right now in another branch to keep things organized.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
