### PR TITLE
Fix table of contents highlighting glitch

### DIFF
--- a/.changeset/sharp-cows-buy.md
+++ b/.changeset/sharp-cows-buy.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes a bug where table of contents highlighting could break given very specific combinations of content and viewport size

--- a/packages/starlight/components/TableOfContents/starlight-toc.ts
+++ b/packages/starlight/components/TableOfContents/starlight-toc.ts
@@ -95,8 +95,8 @@ export class StarlightTOC extends HTMLElement {
 		const mobileTocHeight = this.querySelector('summary')?.getBoundingClientRect().height || 0;
 		/** Start intersections at nav height + 2rem padding. */
 		const top = navBarHeight + mobileTocHeight + 32;
-		/** End intersections 1.5rem later. */
-		const bottom = top + 24;
+		/** End intersections `53px` later. This is slightly more than the maximum `margin-top` in Markdown content. */
+		const bottom = top + 53;
 		const height = document.documentElement.clientHeight;
 		return `-${top}px 0% ${bottom - height}px`;
 	}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Fixes #1448
- See https://github.com/withastro/starlight/issues/1448#issuecomment-1927969598 for full details. TL;DR — larger heading top margins increased the likelihood of the table of contents intersection observer falling _between_ elements.
- By increasing the height of the zone we watch for intersections, we can avoid this (unless someone adds content with more extreme top margins, at some point this could still break).

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
