### PR TITLE
Fix overflow of long site titles on narrow viewports

### DIFF
--- a/.changeset/four-fishes-clean.md
+++ b/.changeset/four-fishes-clean.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes overflow of very long site titles on narrow viewports

--- a/packages/starlight/components/Header.astro
+++ b/packages/starlight/components/Header.astro
@@ -40,6 +40,7 @@ const shouldRenderSearch =
 	}
 
 	.title-wrapper {
+		/* Prevent long titles overflowing and covering the search and menu buttons on narrow viewports. */
 		overflow: hidden;
 	}
 

--- a/packages/starlight/components/Header.astro
+++ b/packages/starlight/components/Header.astro
@@ -16,7 +16,7 @@ const shouldRenderSearch =
 ---
 
 <div class="header sl-flex">
-	<div class="sl-flex">
+	<div class="title-wrapper sl-flex">
 		<SiteTitle {...Astro.props} />
 	</div>
 	<div class="sl-flex">
@@ -37,6 +37,10 @@ const shouldRenderSearch =
 		justify-content: space-between;
 		align-items: center;
 		height: 100%;
+	}
+
+	.title-wrapper {
+		overflow: hidden;
 	}
 
 	.right-group,

--- a/packages/starlight/components/SiteTitle.astro
+++ b/packages/starlight/components/SiteTitle.astro
@@ -38,9 +38,6 @@ const href = formatPath(Astro.props.locale || '/');
 
 <style>
 	.site-title {
-		justify-self: flex-start;
-		max-width: 100%;
-		overflow: hidden;
 		align-items: center;
 		gap: var(--sl-nav-gap);
 		font-size: var(--sl-text-h4);


### PR DESCRIPTION

#### Description

- Fixes #1433 <!-- Add an issue number if this PR will close it. -->
- This bug was previously fixed in #413, but returned in #709 when an intermediate wrapper was added around the site title.

| Before | After |
|--------|-------|
| <img alt="a long site title overflows behind Starlight’s search and menu button" src="https://github.com/withastro/starlight/assets/357379/515a6896-6167-479d-9a7c-0b6dc457e6be" width="375"> | <img alt="a long site title is clipped so as not to cover Starlight’s search and menu buttons" src="https://github.com/withastro/starlight/assets/357379/050097d3-a34c-4962-afb9-819a37b681a0" width="375"> |
