### PR TITLE
[i18nIgnore] docs: fix `editLink` example

### DIFF
--- a/docs/src/content/docs/de/reference/configuration.mdx
+++ b/docs/src/content/docs/de/reference/configuration.mdx
@@ -79,7 +79,7 @@ starlight({
 });
 ```
 
-Mit dieser Konfiguration würde eine `/einfuehrung` einen Bearbeitungslink haben, der auf `https://github.com/withastro/starlight/edit/main/src/docs/einfuehrung.md` zeigt.
+Mit dieser Konfiguration würde eine `/einfuehrung` einen Bearbeitungslink haben, der auf `https://github.com/withastro/starlight/edit/main/src/content/docs/einfuehrung.md` zeigt.
 
 ### `sidebar`
 

--- a/docs/src/content/docs/es/reference/configuration.mdx
+++ b/docs/src/content/docs/es/reference/configuration.mdx
@@ -78,7 +78,7 @@ starlight({
 });
 ```
 
-Con esta configuración, una página `/introduction` tendría un enlace de edición que apunta a `https://github.com/withastro/starlight/edit/main/src/docs/introduction.md`.
+Con esta configuración, una página `/introduction` tendría un enlace de edición que apunta a `https://github.com/withastro/starlight/edit/main/src/content/docs/introduction.md`.
 
 ### `sidebar`
 

--- a/docs/src/content/docs/fr/reference/configuration.mdx
+++ b/docs/src/content/docs/fr/reference/configuration.mdx
@@ -79,7 +79,7 @@ starlight({
 });
 ```
 
-Avec cette configuration, une page `/introduction` aurait un lien d'édition pointant vers `https://github.com/withastro/starlight/edit/main/src/docs/introduction.md`.
+Avec cette configuration, une page `/introduction` aurait un lien d'édition pointant vers `https://github.com/withastro/starlight/edit/main/src/content/docs/introduction.md`.
 
 ### `sidebar`
 

--- a/docs/src/content/docs/id/reference/configuration.mdx
+++ b/docs/src/content/docs/id/reference/configuration.mdx
@@ -79,7 +79,7 @@ starlight({
 });
 ```
 
-Dengan konfigurasi ini, halaman `/introduction` akan memiliki tautan untuk mengedit yang mengarah ke `https://github.com/withastro/starlight/edit/main/src/docs/introduction.md`.
+Dengan konfigurasi ini, halaman `/introduction` akan memiliki tautan untuk mengedit yang mengarah ke `https://github.com/withastro/starlight/edit/main/src/content/docs/introduction.md`.
 
 ### `sidebar`
 

--- a/docs/src/content/docs/it/reference/configuration.mdx
+++ b/docs/src/content/docs/it/reference/configuration.mdx
@@ -79,7 +79,7 @@ starlight({
 });
 ```
 
-Con questa configurazione, una pagina `/introduction` avrà un link di modifica a `https://github.com/withastro/starlight/edit/main/src/docs/introduction.md`.
+Con questa configurazione, una pagina `/introduction` avrà un link di modifica a `https://github.com/withastro/starlight/edit/main/src/content/docs/introduction.md`.
 
 ### `sidebar`
 

--- a/docs/src/content/docs/ja/reference/configuration.mdx
+++ b/docs/src/content/docs/ja/reference/configuration.mdx
@@ -78,7 +78,7 @@ starlight({
 });
 ```
 
-この設定により、`/introduction`ページには`https://github.com/withastro/starlight/edit/main/src/docs/introduction.md`を指す編集リンクが表示されます。
+この設定により、`/introduction`ページには`https://github.com/withastro/starlight/edit/main/src/content/docs/introduction.md`を指す編集リンクが表示されます。
 
 ### `sidebar`
 

--- a/docs/src/content/docs/ko/reference/configuration.mdx
+++ b/docs/src/content/docs/ko/reference/configuration.mdx
@@ -79,7 +79,7 @@ starlight({
 });
 ```
 
-이 구성을 통해 `/introduction` 페이지에 있는 편집 링크는 `https://github.com/withastro/starlight/edit/main/src/docs/introduction.md`를 가리킵니다.
+이 구성을 통해 `/introduction` 페이지에 있는 편집 링크는 `https://github.com/withastro/starlight/edit/main/src/content/docs/introduction.md`를 가리킵니다.
 
 ### `sidebar`
 

--- a/docs/src/content/docs/pt-br/reference/configuration.mdx
+++ b/docs/src/content/docs/pt-br/reference/configuration.mdx
@@ -79,7 +79,7 @@ starlight({
 });
 ```
 
-Com essa configuração, uma página `/introducao` teria um link de edição apontando para `https://github.com/withastro/starlight/edit/main/src/docs/introducao.md`.
+Com essa configuração, uma página `/introducao` teria um link de edição apontando para `https://github.com/withastro/starlight/edit/main/src/content/docs/introducao.md`.
 
 ### `sidebar`
 

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -79,7 +79,7 @@ starlight({
 });
 ```
 
-With this config, a `/introduction` page would have an edit link pointing to `https://github.com/withastro/starlight/edit/main/src/docs/introduction.md`.
+With this config, a `/introduction` page would have an edit link pointing to `https://github.com/withastro/starlight/edit/main/src/content/docs/introduction.md`.
 
 ### `sidebar`
 

--- a/docs/src/content/docs/zh-cn/reference/configuration.mdx
+++ b/docs/src/content/docs/zh-cn/reference/configuration.mdx
@@ -79,7 +79,7 @@ starlight({
 });
 ```
 
-使用此配置，`/introduction` 页面将具有指向 `https://github.com/withastro/starlight/edit/main/src/docs/introduction.md` 的编辑链接。
+使用此配置，`/introduction` 页面将具有指向 `https://github.com/withastro/starlight/edit/main/src/content/docs/introduction.md` 的编辑链接。
 
 ### `sidebar`
 


### PR DESCRIPTION
#### Description

The docs for [`editLink`](https://starlight.astro.build/reference/configuration/#editlink) mention the final GitHub edit URL. But as far as I can see and how current base config is this link is missing the `/content/` part for the final URL. This PR adds that to all translations.

The expected link (including the `content` part) can also be seen in the [test case](https://github.com/withastro/starlight/blob/main/packages/starlight/__tests__/edit-url/edit-url.test.ts#L26) for the editLink property.