### PR TITLE
Update `starlight-links-validator` to v0.5.3

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -29,7 +29,7 @@
     "hastscript": "^8.0.0",
     "pa11y-ci": "^3.0.1",
     "rehype": "^13.0.1",
-    "starlight-links-validator": "^0.5.1",
+    "starlight-links-validator": "^0.5.3",
     "start-server-and-test": "^2.0.0",
     "unist-util-visit": "^5.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,8 +73,8 @@ importers:
         specifier: ^13.0.1
         version: 13.0.1
       starlight-links-validator:
-        specifier: ^0.5.1
-        version: 0.5.1(@astrojs/starlight@packages+starlight)(astro@4.2.1)
+        specifier: ^0.5.3
+        version: 0.5.3(@astrojs/starlight@packages+starlight)(astro@4.2.1)
       start-server-and-test:
         specifier: ^2.0.0
         version: 2.0.0
@@ -3763,6 +3763,11 @@ packages:
       side-channel: 1.0.4
     dev: true
 
+  /is-absolute-url@4.0.1:
+    resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
+
   /is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
     dev: false
@@ -6178,8 +6183,8 @@ packages:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
 
-  /starlight-links-validator@0.5.1(@astrojs/starlight@packages+starlight)(astro@4.2.1):
-    resolution: {integrity: sha512-6iNl/bTTFN65T3fx1oMdspZltlYyonmrnno4dWjMzJuFHO79ZGKyzrtuMD59kiM9Y85eSy3MOpU1wuPoY28fMg==}
+  /starlight-links-validator@0.5.3(@astrojs/starlight@packages+starlight)(astro@4.2.1):
+    resolution: {integrity: sha512-v79rwmzjQlEMVL8sZ4dalD/jhFOUvGZ2/f4CvxCySZ9KbEN9nDmgV8zJgfpmTzhbcYQ35wzyUinF4QNxgKVA4g==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       '@astrojs/starlight': '>=0.15.0'
@@ -6190,6 +6195,7 @@ packages:
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.1
       hast-util-has-property: 3.0.0
+      is-absolute-url: 4.0.1
       kleur: 4.1.5
       mdast-util-to-string: 4.0.0
       unist-util-visit: 5.0.0


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Something else!

#### Description

This PR updates `starlight-links-validator` used in the docs to the latest version [`0.5.3`](https://github.com/HiDeoo/starlight-links-validator/releases/tag/v0.5.3) which includes a fix that would have prevented https://github.com/withastro/starlight/pull/1428.

<img width="393" alt="image" src="https://github.com/withastro/starlight/assets/494699/d6cde0a2-ed91-4c2a-8ad0-52454f567146">