### PR TITLE
Set default color theme in template

### DIFF
--- a/.changeset/famous-ants-sing.md
+++ b/.changeset/famous-ants-sing.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes a CSS bug for users with JavaScript disabled

--- a/packages/starlight/components/Page.astro
+++ b/packages/starlight/components/Page.astro
@@ -42,6 +42,7 @@ const pagefindEnabled =
 	data-has-toc={Boolean(Astro.props.toc)}
 	data-has-sidebar={Astro.props.hasSidebar}
 	data-has-hero={Boolean(Astro.props.entry.data.hero)}
+	data-theme="dark"
 >
 	<head>
 		<Head {...Astro.props} />


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Fixes #1470

- We are not currently setting `data-theme` by default, only when a small inline script runs:

   https://github.com/withastro/starlight/blob/fb89bd115c34067ac47a51a8dd73068a4217e071/packages/starlight/components/ThemeProvider.astro#L14

- For most styles this isn’t an issue because we set dark theme variables on `:root`, light theme variables on `[data-theme="light"]`. But our `light:sl-hidden` and `dark:sl-hidden` classes expect `data-theme` to be set.

- To resolve this, this PR sets `data-theme="dark"` in the prerendered HTML, so we are not dependent on JS running in order for those styles to work.

- There should be no behaviour change for users running JS, only this bug fix for those without.

#### Alternative solutions

I considered an alternative solution of updating the `dark:sl-hidden` style to work when `data-theme` is not set:

```diff
- [data-theme='dark'] .dark\:sl-hidden {
+ :root:not([data-theme='light']) .dark\:sl-hidden {
```

But given that it seems like a whole class of potential bugs could be caused by missing `data-theme` (including potentially in user code), it seemed safest to set the default value at source.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
