### PR TITLE
i18n(fr): fix frontmatter `label` default value translation

### DIFF
--- a/docs/src/content/docs/fr/reference/frontmatter.md
+++ b/docs/src/content/docs/fr/reference/frontmatter.md
@@ -286,7 +286,7 @@ interface SidebarConfig {
 #### `label`
 
 **Type :** `string`  
-**Par défaut :** the page [`title`](#title-obligatoire)
+**Par défaut :** [`title`](#title-obligatoire) de la page
 
 Définir l'étiquette de cette page dans la barre latérale lorsqu'elle est affichée dans un groupe de liens généré automatiquement.
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

While reviewing a translation pull request, I accidentally noticed that the frontmatter `sidebar.label` default value was not translated. This PR fixes that.