### PR TITLE
i18n(es): fix syntax highlighting with `diff`-like syntax example

### DIFF
--- a/docs/src/content/docs/es/guides/authoring-content.md
+++ b/docs/src/content/docs/es/guides/authoring-content.md
@@ -298,7 +298,7 @@ Algunos de los ejemplos más comunes se muestran a continuación:
     function thisIsJavaScript() {
       // ¡El bloque completo se resalta como JavaScript,
       // y aún podemos añadir marcadores de diferencias a él!
-  -   console.log('Código antiguo a eliminar'')
+  -   console.log('Código antiguo a eliminar')
   +   console.log('¡Nuevo y brillante código!')
     }
   ```
@@ -308,8 +308,8 @@ Algunos de los ejemplos más comunes se muestran a continuación:
     function thisIsJavaScript() {
       // ¡El bloque completo se resalta como JavaScript,
       // y aún podemos añadir marcadores de diferencias a él!
-  -   console.log('Old code to be removed')
-  +   console.log('New and shiny code!')
+  -   console.log('Código antiguo a eliminar')
+  +   console.log('¡Nuevo y brillante código!')
     }
   ```
   ````


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

While reviewing a pull request, I accidentally stumbled upon issues with the authoring content guide for the syntax highlighting with `diff`-like syntax example:

- Extra `'`
- Markdown example not matching the rendered output