### PR TITLE
i18n(fr): update `manual-setup`

### DIFF
--- a/docs/src/content/docs/fr/manual-setup.mdx
+++ b/docs/src/content/docs/fr/manual-setup.mdx
@@ -125,4 +125,6 @@ import FileTree from '~/components/file-tree.astro';
 
 ### Utiliser Starlight avec SSR
 
-À l'heure actuelle, Starlight ne supporte pas [le déploiement avec rendu côté serveur (SSR)](https://docs.astro.build/fr/guides/server-side-rendering/) en utilisant les adaptateurs de serveur d'Astro. Nous espérons pouvoir le supporter bientôt.
+Vous pouvez utiliser Starlight en parallèle de pages personnalisées rendues à la demande dans votre projet en suivant le guide [« Adaptateurs de rendu à la demande »](https://docs.astro.build/fr/guides/server-side-rendering/) dans la documentation d'Astro.
+
+À l'heure actuelle, les pages de documentation générées par Starlight sont toujours pré-rendues, quel que soit le mode de rendu de votre projet. Nous espérons pouvoir bientôt supporter le rendu à la demande pour les pages de Starlight.


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

This PR updates the French version of the `manual-setup` page with the changes from #1454.