### PR TITLE
Fix rendering issue for text with unhandled generic Markdown directives

### DIFF
--- a/.changeset/many-knives-type.md
+++ b/.changeset/many-knives-type.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes a potential text rendering issue with text containing colons.

--- a/packages/starlight/__tests__/remark-rehype/asides.test.ts
+++ b/packages/starlight/__tests__/remark-rehype/asides.test.ts
@@ -143,3 +143,22 @@ test('runs without locales config', async () => {
 	const res = await processor.render(':::note\nTest\n::');
 	expect(res.code.includes('aria-label=Note"'));
 });
+
+test('tranforms back unhandled text directives', async () => {
+	const res = await processor.render(
+		`This is a:test of a sentence with a text:name[content]{key=val} directive.`
+	);
+	expect(res.code).toMatchInlineSnapshot(`
+		"<p>This is a:test
+		 of a sentence with a text:name[content]{key="val"}
+		 directive.</p>"
+	`);
+});
+
+test('tranforms back unhandled leaf directives', async () => {
+	const res = await processor.render(`::video[Title]{v=xxxxxxxxxxx}`);
+	expect(res.code).toMatchInlineSnapshot(`
+		"<p>::video[Title]{v="xxxxxxxxxxx"}
+		</p>"
+	`);
+});

--- a/packages/starlight/integrations/asides.ts
+++ b/packages/starlight/integrations/asides.ts
@@ -2,7 +2,14 @@
 
 import type { AstroConfig, AstroUserConfig } from 'astro';
 import { h as _h, s as _s, type Properties } from 'hastscript';
-import type { Paragraph as P, Root } from 'mdast';
+import type { Node, Paragraph as P, Parent, Root } from 'mdast';
+import {
+	type Directives,
+	directiveToMarkdown,
+	type TextDirective,
+	type LeafDirective,
+} from 'mdast-util-directive';
+import { toMarkdown } from 'mdast-util-to-markdown';
 import remarkDirective from 'remark-directive';
 import type { Plugin, Transformer } from 'unified';
 import { remove } from 'unist-util-remove';
@@ -35,6 +42,40 @@ function s(el: string, attrs: Properties = {}, children: any[] = []): P {
 		data: { hName: tagName, hProperties: properties },
 		children,
 	};
+}
+
+/** Checks if a node is a directive. */
+function isNodeDirective(node: Node): node is Directives {
+	return (
+		node.type === 'textDirective' ||
+		node.type === 'leafDirective' ||
+		node.type === 'containerDirective'
+	);
+}
+
+/**
+ * Transforms back directives not handled by Starlight to avoid breaking user content.
+ * For example, a user might write `x:y` in the middle of a sentence, where `:y` would be
+ * identified as a text directive, which are not used by Starlight, and we definitely want that
+ * text to be rendered verbatim in the output.
+ */
+function transformUnhandledDirective(
+	node: TextDirective | LeafDirective,
+	index: number,
+	parent: Parent
+) {
+	const textNode = {
+		type: 'text',
+		value: toMarkdown(node, { extensions: [directiveToMarkdown()] }),
+	} as const;
+	if (node.type === 'textDirective') {
+		parent.children[index] = textNode;
+	} else {
+		parent.children[index] = {
+			type: 'paragraph',
+			children: [textNode],
+		};
+	}
 }
 
 /**
@@ -102,7 +143,11 @@ function remarkAsides(options: AsidesOptions): Plugin<[], Root> {
 		const locale = pathToLocale(file.history[0], options);
 		const t = options.useTranslations(locale);
 		visit(tree, (node, index, parent) => {
-			if (!parent || index === undefined || node.type !== 'containerDirective') {
+			if (!parent || index === undefined || !isNodeDirective(node)) {
+				return;
+			}
+			if (node.type === 'textDirective' || node.type === 'leafDirective') {
+				transformUnhandledDirective(node, index, parent);
 				return;
 			}
 			const variant = node.name;

--- a/packages/starlight/package.json
+++ b/packages/starlight/package.json
@@ -187,6 +187,7 @@
     "hast-util-select": "^6.0.2",
     "hastscript": "^8.0.0",
     "mdast-util-directive": "^3.0.0",
+    "mdast-util-to-markdown": "^2.1.0",
     "pagefind": "^1.0.3",
     "rehype": "^13.0.1",
     "remark-directive": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       mdast-util-directive:
         specifier: ^3.0.0
         version: 3.0.0
+      mdast-util-to-markdown:
+        specifier: ^2.1.0
+        version: 2.1.0
       pagefind:
         specifier: ^1.0.3
         version: 1.0.3


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to Starlight code

#### Description

This PR is a follow-up to this Discord [discussion](https://discord.com/channels/830184174198718474/1206539738824314912).

The `remark-directive` plugin used to handle [asides](https://starlight.astro.build/guides/authoring-content/#asides) based on [generic directives](https://talk.commonmark.org/t/generic-directives-plugins-syntax/444) is responsible of parsing 3 different types of directives:

- text directives
- leaf directives
- container directives

Starlight only uses the last type but all types are parsed by the plugin. This means that content that may accidentally contain a directive of another type will be parsed as such and may lead to unexpected results. For example:

> AWS re:Invent is a learning conference hosted by AWS.

The above sentence will be rendered as:

<img width="315" alt="SCR-20240212-ocsm" src="https://github.com/withastro/starlight/assets/494699/4eed2cb7-5d39-489d-82a7-a63a8905c900">

This PR fixes the issue by transforming the unhandled directive so that they render verbatim.

<img width="423" alt="SCR-20240212-ocvn" src="https://github.com/withastro/starlight/assets/494699/a83f3cfb-830b-4bb4-8575-e93e8a86803f">

Note: this relies on `mdast-util-to-markdown` so that we can pass down to it the official `directiveToMarkdown` extension and automatically get the correct rendering for the directive including any attributes.