### PR TITLE
fix: "Adding a new Language" link points to new i18n guides 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,13 +214,13 @@ Visit **<https://i18n.starlight.astro.build>** to track translation progress for
 
 #### Adding a new language to Starlight’s docs
 
-To add a language, you will need its BCP-47 tag and a label. See [“Adding a new language”](https://github.com/withastro/docs/blob/main/contributor-guides/translating-astro-docs.md#adding-a-new-language) in the Astro docs repo for some helpful tips around choosing these.
+To add a language, you will need its BCP-47 tag and a label. See [“Adding a new language”](https://contribute.docs.astro.build/guides/i18n/#adding-a-new-language) in the Astro docs repo for some helpful tips around choosing these.
 
 - Add your language to the `locales` config in `docs/astro.config.mjs`
 - Add your language to the `locales` config in `docs/lunaria.config.json`
 - Add your language’s subtag to the i18n label config in `.github/labeler.yml`
 - Add your language to the `pa11y` script’s `--sitemap-exclude` flag in `package.json`
-- Create the first translated page for your language.  
+- Create the first translated page for your language.
    This must be the Starlight landing page: `docs/src/content/docs/{language}/index.mdx`.
 - Open a pull request on GitHub to add your changes to Starlight!
 


### PR DESCRIPTION
#### Fixed broken "Adding a new Language" link.

- The "Adding a new Language" link on the Contributing.md doc was pointing to a broken link because guides where moved to new location. 
