### PR TITLE
docs: Add more plugins & tools

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -38,6 +38,21 @@ Extend your site with official plugins supported by the Starlight team and commu
 		title="starlight-typedoc"
 		description="Generate Starlight pages from TypeScript using TypeDoc."
 	/>
+	<LinkCard
+		href="https://github.com/HiDeoo/starlight-blog"
+		title="starlight-blog"
+		description="Add a blog to your documentation site."
+	/>
+	<LinkCard
+		href="https://github.com/HiDeoo/starlight-openapi"
+		title="starlight-openapi"
+		description="Create documentation pages from OpenAPI/Swagger specifications."
+	/>
+	<LinkCard
+		href="https://github.com/HiDeoo/starlight-obsidian"
+		title="starlight-obsidian"
+		description="Publish Obsidian vaults in your Starlight site."
+	/>
 </CardGrid>
 
 ## Community tools and integrations
@@ -53,16 +68,6 @@ These community tools and integrations can be used to add features to your Starl
 		description="Add a user feedback system to your docs pages."
 	/>
 	<LinkCard
-		href="https://github.com/HiDeoo/starlight-blog"
-		title="starlight-blog"
-		description="Add a blog to your documentation site."
-	/>
-	<LinkCard
-		href="https://github.com/HiDeoo/starlight-openapi"
-		title="starlight-openapi"
-		description="Create documentation pages from OpenAPI/Swagger specifications."
-	/>
-	<LinkCard
 		href="https://github.com/val-town/notion-to-astro"
 		title="notion-to-astro"
 		description="Convert Notion exports to Astro Starlight docs"
@@ -71,5 +76,10 @@ These community tools and integrations can be used to add features to your Starl
 		href="https://github.com/mattjennings/astro-live-code"
 		title="astro-live-code"
 		description="Render your MDX code blocks as interactive components"
+	/>
+	<LinkCard
+		href="https://github.com/HiDeoo/starlight-i18n"
+		title="starlight-i18n"
+		description="Visual Studio Code extension to help translate Starlight pages."
 	/>
 </CardGrid>


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

Following the release of Starlight [`v0.19.0`](https://github.com/withastro/starlight/releases/tag/%40astrojs%2Fstarlight%400.19.0), `starlight-blog` and `starlight-openapi` have now been refactored to Starlight plugins. This PR moves them to the appropriate section in the docs site.

The PR also adds `starlight-obsidian` to the plugin list and `starlight-i18n` to the tools list.