### PR TITLE
Fixes: Warning about mdx indentation

### DIFF
--- a/.changeset/good-fans-cheat.md
+++ b/.changeset/good-fans-cheat.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': minor
+---
+
+Added warning to MDX/Markdown Indent Issue.

--- a/docs/src/content/docs/guides/components.mdx
+++ b/docs/src/content/docs/guides/components.mdx
@@ -368,6 +368,10 @@ import { Steps } from '@astrojs/starlight/components';
 
 </Steps>
 
+:::caution
+When using [MDX or Markdown](/guides/authoring-content/) Try to `indent` if your running into an issue. Learn more about example of [indenting here](https://www.markdownguide.org/basic-syntax/#ordered-lists)
+:::
+
 ### Icon
 
 import { Icon } from '@astrojs/starlight/components';

--- a/packages/starlight/__tests__/remark-rehype/rehype-steps.test.ts
+++ b/packages/starlight/__tests__/remark-rehype/rehype-steps.test.ts
@@ -7,7 +7,7 @@ test('empty component throws an error', () => {
 		"[AstroUserError]:
 			The \`<Steps>\` component expects its content to be a single ordered list (\`<ol>\`) but found no child elements.
 		Hint:
-			To learn more about the \`<Steps>\` component, see https://starlight.astro.build/guides/components/#steps"
+			To learn more about the \`<Steps>\` component, see https://starlight.astro.build/guides/components/#steps | If your using \`mdx\` you may have to do indentation to fix this error."
 	`
 	);
 });
@@ -18,7 +18,7 @@ test('component with non-element content throws an error', () => {
 		"[AstroUserError]:
 			The \`<Steps>\` component expects its content to be a single ordered list (\`<ol>\`) but found no child elements.
 		Hint:
-			To learn more about the \`<Steps>\` component, see https://starlight.astro.build/guides/components/#steps"
+			To learn more about the \`<Steps>\` component, see https://starlight.astro.build/guides/components/#steps | If your using \`mdx\` you may have to do indentation to fix this error."
 	`
 	);
 });
@@ -29,7 +29,7 @@ test('component with non-`<ol>` content throws an error', () => {
 			"[AstroUserError]:
 				The \`<Steps>\` component expects its content to be a single ordered list (\`<ol>\`) but found the following element: \`<p>\`.
 			Hint:
-				To learn more about the \`<Steps>\` component, see https://starlight.astro.build/guides/components/#steps"
+				To learn more about the \`<Steps>\` component, see https://starlight.astro.build/guides/components/#steps | If your using \`mdx\` you may have to do indentation to fix this error."
 		`);
 });
 
@@ -38,7 +38,7 @@ test('component with multiple children throws an error', () => {
 		"[AstroUserError]:
 			The \`<Steps>\` component expects its content to be a single ordered list (\`<ol>\`) but found multiple child elements: \`<ol>\`, \`<ol>\`.
 		Hint:
-			To learn more about the \`<Steps>\` component, see https://starlight.astro.build/guides/components/#steps"
+			To learn more about the \`<Steps>\` component, see https://starlight.astro.build/guides/components/#steps | If your using \`mdx\` you may have to do indentation to fix this error."
 	`);
 });
 

--- a/packages/starlight/user-components/rehype-steps.ts
+++ b/packages/starlight/user-components/rehype-steps.ts
@@ -52,7 +52,7 @@ class StepsError extends AstroError {
 	constructor(message: string) {
 		super(
 			message,
-			'To learn more about the `<Steps>` component, see https://starlight.astro.build/guides/components/#steps'
+			'To learn more about the `<Steps>` component, see https://starlight.astro.build/guides/components/#steps | If your using `mdx` you may have to do indentation to fix this error.'
 		);
 	}
 }


### PR DESCRIPTION
### Changes to: 

- Documentation under `/guide/components`
- Core under `packages/starlight/user-components/rehype-steps.ts` and `packages/starlight/__tests__/remark-rehype/rehype-steps.test.ts`

I have found no issues on this but I know a lot of people in the `discord` have been having this issue.

#### Description

a lot of people in the `discord` have been having the indentation issue, So this adds a little hint message about indentation in `Markdown & MDX` both in documentation and error.

##### Resources used: 

- [markdown-guide ordered lists](https://www.markdownguide.org/basic-syntax/#ordered-lists)