### PR TITLE
removed the default outline style of select:focus for theme-select an…

### DIFF
--- a/.changeset/clear-select-outline.md
+++ b/.changeset/clear-select-outline.md
@@ -2,9 +2,4 @@
 "@astrojs/starlight": patch
 ---
 
-Commit Message:
-- removed the default outline style of select:focus for theme-select and language-select
-
-File Changes:
-- packages/starlight/components/Select.astro
-- packages/starlight/components/LanguageSelect.astro
+removed the default outline style of select:focus for theme-select and language-select

--- a/.changeset/clear-select-outline.md
+++ b/.changeset/clear-select-outline.md
@@ -1,0 +1,10 @@
+---
+"@astrojs/starlight": patch
+---
+
+Commit Message:
+- removed the default outline style of select:focus for theme-select and language-select
+
+File Changes:
+- packages/starlight/components/Select.astro
+- packages/starlight/components/LanguageSelect.astro

--- a/packages/starlight/components/LanguageSelect.astro
+++ b/packages/starlight/components/LanguageSelect.astro
@@ -48,3 +48,9 @@ const { labels } = Astro.props;
 	}
 	customElements.define('starlight-lang-select', StarlightLanguageSelect);
 </script>
+
+<style>
+	select:focus {
+		outline: 0;
+	}
+</style>

--- a/packages/starlight/components/LanguageSelect.astro
+++ b/packages/starlight/components/LanguageSelect.astro
@@ -48,9 +48,3 @@ const { labels } = Astro.props;
 	}
 	customElements.define('starlight-lang-select', StarlightLanguageSelect);
 </script>
-
-<style>
-	select:focus {
-		outline: 0;
-	}
-</style>

--- a/packages/starlight/components/Select.astro
+++ b/packages/starlight/components/Select.astro
@@ -71,6 +71,10 @@ interface Props {
 		appearance: none;
 	}
 
+	select:focus {
+		outline: 0;
+	}
+
 	option {
 		background-color: var(--sl-color-bg-nav);
 		color: var(--sl-color-gray-1);

--- a/packages/starlight/components/ThemeSelect.astro
+++ b/packages/starlight/components/ThemeSelect.astro
@@ -87,3 +87,9 @@ const { labels } = Astro.props;
 
 	customElements.define('starlight-theme-select', StarlightThemeSelect);
 </script>
+
+<style>
+	select:focus {
+		outline: 0;
+	}
+</style>

--- a/packages/starlight/components/ThemeSelect.astro
+++ b/packages/starlight/components/ThemeSelect.astro
@@ -7,7 +7,7 @@ const { labels } = Astro.props;
 
 <starlight-theme-select>
 	{/* TODO: Can we give this select a width that works well for each language’s strings? */}
-	<Select
+		<Select
 		icon="laptop"
 		label={labels['themeSelect.accessibleLabel']}
 		value="auto"
@@ -87,9 +87,3 @@ const { labels } = Astro.props;
 
 	customElements.define('starlight-theme-select', StarlightThemeSelect);
 </script>
-
-<style>
-	select:focus {
-		outline: 0;
-	}
-</style>


### PR DESCRIPTION
#### Description

- the theme-select and language-select which on the top-right nav part of astro doc has a default blue outline after clicking
- remove the outline style might be better
### before
<img width="325" alt="image" src="https://github.com/withastro/starlight/assets/98088843/e142bb7c-89f5-411a-b4f8-192ca20ea627">

### after
<img width="325" alt="image" src="https://github.com/withastro/starlight/assets/98088843/be906b4e-b6bd-4cc2-97d9-63694fa056f6">


