### PR TITLE
docs: add `starlight-image-zoom` to the plugin showcase

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -58,6 +58,11 @@ Extend your site with official plugins supported by the Starlight team and commu
 		title="starlight-ghostcms"
 		description="Add your GhostCMS blog posts alongside your Starlight Docs"
 	/>
+	<LinkCard
+		href="https://github.com/HiDeoo/starlight-image-zoom"
+		title="starlight-image-zoom"
+		description="Add zoom capabilities to your documentation images."
+	/>
 </CardGrid>
 
 ## Community tools and integrations


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content

#### Description

This PR adds the [`starlight-image-zoom` plugin](https://github.com/HiDeoo/starlight-image-zoom) to the plugin showcase.