### PR TITLE
Fix Starlight component imports with EC disabled

### DIFF
--- a/.changeset/rare-timers-judge.md
+++ b/.changeset/rare-timers-judge.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes a bundling issue that caused imports from `@astrojs/starlight/components` to fail when using the config setting `expressiveCode: false`.

--- a/packages/starlight/integrations/expressive-code/index.ts
+++ b/packages/starlight/integrations/expressive-code/index.ts
@@ -163,7 +163,40 @@ export const starlightExpressiveCode = ({
 	starlightConfig,
 	useTranslations,
 }: StarlightEcIntegrationOptions): AstroIntegration[] => {
-	if (starlightConfig.expressiveCode === false) return [];
+	// If Expressive Code is disabled, add a shim to prevent build errors and provide
+	// a helpful error message in case the user tries to use the `<Code>` component
+	if (starlightConfig.expressiveCode === false) {
+		const modules: Record<string, string> = {
+			'virtual:astro-expressive-code/api': 'export default {}',
+			'virtual:astro-expressive-code/config': 'export default {}',
+			'virtual:astro-expressive-code/preprocess-config': `throw new Error("Starlight's
+				Code component requires Expressive Code, which is disabled in your Starlight config.
+				Please remove \`expressiveCode: false\` from your config or import Astro's built-in
+				Code component from 'astro:components' instead.")`.replace(/\s+/g, ' '),
+		};
+
+		return [
+			{
+				name: 'astro-expressive-code-shim',
+				hooks: {
+					'astro:config:setup': async ({ updateConfig }) => {
+						updateConfig({
+							vite: {
+								plugins: [
+									{
+										name: 'vite-plugin-astro-expressive-code-shim',
+										enforce: 'post',
+										resolveId: (id) => (id in modules ? `\0${id}` : undefined),
+										load: (id) => (id?.[0] === '\0' ? modules[id.slice(1)] : undefined),
+									},
+								],
+							},
+						});
+					},
+				},
+			},
+		];
+	}
 
 	const configArgs =
 		typeof starlightConfig.expressiveCode === 'object'

--- a/packages/starlight/integrations/expressive-code/index.ts
+++ b/packages/starlight/integrations/expressive-code/index.ts
@@ -179,7 +179,7 @@ export const starlightExpressiveCode = ({
 			{
 				name: 'astro-expressive-code-shim',
 				hooks: {
-					'astro:config:setup': async ({ updateConfig }) => {
+					'astro:config:setup': ({ updateConfig }) => {
 						updateConfig({
 							vite: {
 								plugins: [


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Fixes #1624 by providing shims for the failing virtual imports when using the config setting `expressiveCode: false`.
- This is only necessary because tree shaking is currently not supported for barrel files in Astro projects. Once this is fixed upstream, the `Code` component exported from `@astrojs/starlight/components` should no longer be included in the bundle when it's unused, and the shims should not be required anymore.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
