### PR TITLE
docs: fix prettier formatting

### DIFF
--- a/docs/src/content/docs/guides/css-and-tailwind.mdx
+++ b/docs/src/content/docs/guides/css-and-tailwind.mdx
@@ -12,16 +12,17 @@ You can style your Starlight site with custom CSS files or use the Starlight Tai
 Customize the styles applied to your Starlight site by providing additional CSS files to modify or extend Starlight’s default styles.
 
 <Steps>
+
 1. Add a CSS file to your `src/` directory.
    For example, you could set a wider default column width and larger text size for page titles:
 
-```css
-/* src/styles/custom.css */
-:root {
-	--sl-content-width: 50rem;
-	--sl-text-5xl: 3.5rem;
-}
-```
+   ```css
+   /* src/styles/custom.css */
+   :root {
+   	--sl-content-width: 50rem;
+   	--sl-text-5xl: 3.5rem;
+   }
+   ```
 
 2. Add the path to your CSS file to Starlight’s `customCss` array in `astro.config.mjs`:
 
@@ -43,7 +44,7 @@ Customize the styles applied to your Starlight site by providing additional CSS 
    });
    ```
 
-   </Steps>
+</Steps>
 
 You can see all the CSS custom properties used by Starlight that you can set to customize your site in the [`props.css` file on GitHub](https://github.com/withastro/starlight/blob/main/packages/starlight/style/props.css).
 
@@ -91,6 +92,7 @@ yarn create astro --template starlight/tailwind
 If you already have a Starlight site and want to add Tailwind CSS, follow these steps.
 
 <Steps>
+
 1.  Add Astro’s Tailwind integration:
 
     <Tabs>
@@ -187,18 +189,18 @@ If you already have a Starlight site and want to add Tailwind CSS, follow these 
 
 5.  Add the Starlight Tailwind plugin to `tailwind.config.mjs`:
 
-        ```js ins={2,7}
-        // tailwind.config.mjs
-        import starlightPlugin from '@astrojs/starlight-tailwind';
+    ```js ins={2,7}
+    // tailwind.config.mjs
+    import starlightPlugin from '@astrojs/starlight-tailwind';
 
-        /** @type {import('tailwindcss').Config} */
-        export default {
-        	content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
-        	plugins: [starlightPlugin()],
-        };
-        ```
+    /** @type {import('tailwindcss').Config} */
+    export default {
+    	content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
+    	plugins: [starlightPlugin()],
+    };
+    ```
 
-    </Steps>
+</Steps>
 
 ### Styling Starlight with Tailwind
 

--- a/docs/src/content/docs/guides/customization.mdx
+++ b/docs/src/content/docs/guides/customization.mdx
@@ -13,15 +13,16 @@ When you want to start customizing the look and feel of your Starlight site, thi
 Adding a custom logo to the site header is a quick way to add your individual branding to a Starlight site.
 
 <Steps>
+
 1. Add your logo image file to the `src/assets/` directory:
 
    <FileTree>
 
-- src/
-  - assets/
-    - **my-logo.svg**
-  - content/
-- astro.config.mjs
+   - src/
+     - assets/
+       - **my-logo.svg**
+     - content/
+   - astro.config.mjs
 
    </FileTree>
 
@@ -44,7 +45,7 @@ Adding a custom logo to the site header is a quick way to add your individual br
    });
    ```
 
-   </Steps>
+</Steps>
 
 By default, the logo will be displayed alongside your site’s `title`.
 If your logo image already includes the site title, you can visually hide the title text by setting the `replacesTitle` option.
@@ -65,16 +66,17 @@ starlight({
 You can display different versions of your logo in light and dark modes.
 
 <Steps>
+
 1. Add an image file for each variant to `src/assets/`:
 
    <FileTree>
 
-- src/
-  - assets/
-    - **light-logo.svg**
-    - **dark-logo.svg**
-  - content/
-- astro.config.mjs
+   - src/
+     - assets/
+       - **light-logo.svg**
+       - **dark-logo.svg**
+     - content/
+   - astro.config.mjs
 
    </FileTree>
 
@@ -90,7 +92,7 @@ You can display different versions of your logo in light and dark modes.
    }),
    ```
 
-   </Steps>
+</Steps>
 
 ## Enable sitemap
 
@@ -316,16 +318,17 @@ To use Google Fonts, follow the [Fontsource set-up guide](#set-up-a-fontsource-f
 #### Set up local font files
 
 <Steps>
+
 1. Add your font files to a `src/fonts/` directory and create an empty `font-face.css` file:
 
    <FileTree>
 
-- src/
-  - content/
-  - fonts/
-    - **CustomFont.woff2**
-    - **font-face.css**
-- astro.config.mjs
+   - src/
+     - content/
+     - fonts/
+       - **CustomFont.woff2**
+       - **font-face.css**
+   - astro.config.mjs
 
    </FileTree>
 
@@ -365,7 +368,7 @@ To use Google Fonts, follow the [Fontsource set-up guide](#set-up-a-fontsource-f
    });
    ```
 
-   </Steps>
+</Steps>
 
 #### Set up a Fontsource font
 
@@ -373,6 +376,7 @@ The [Fontsource](https://fontsource.org/) project simplifies using Google Fonts 
 It provides npm modules you can install for the fonts you want to use and includes ready-made CSS files to add to your project.
 
 <Steps>
+
 1.  Find the font you want to use in [Fontsource’s catalog](https://fontsource.org/).
     This example will use [IBM Plex Serif](https://fontsource.org/fonts/ibm-plex-serif).
 
@@ -409,28 +413,28 @@ It provides npm modules you can install for the fonts you want to use and includ
 
 3.  Add Fontsource CSS files to Starlight’s `customCss` array in `astro.config.mjs`:
 
-        ```diff lang="js"
-        // astro.config.mjs
-        import { defineConfig } from 'astro/config';
-        import starlight from '@astrojs/starlight';
+    ```diff lang="js"
+    // astro.config.mjs
+    import { defineConfig } from 'astro/config';
+    import starlight from '@astrojs/starlight';
 
-        export default defineConfig({
-        	integrations: [
-        		starlight({
-        			title: 'Docs With a Custom Typeface',
-        			customCss: [
-        +				// Fontsource files for to regular and semi-bold font weights.
-        +				'@fontsource/ibm-plex-serif/400.css',
-        +				'@fontsource/ibm-plex-serif/600.css',
-        			],
-        		}),
-        	],
-        });
-        ```
+    export default defineConfig({
+    	integrations: [
+    		starlight({
+    			title: 'Docs With a Custom Typeface',
+    			customCss: [
+    +				// Fontsource files for to regular and semi-bold font weights.
+    +				'@fontsource/ibm-plex-serif/400.css',
+    +				'@fontsource/ibm-plex-serif/600.css',
+    			],
+    		}),
+    	],
+    });
+    ```
 
-        Fontsource ships multiple CSS files for each font. See the [Fontsource documentation](https://fontsource.org/docs/getting-started/install#4-weights-and-styles) on including different weights and styles to understand which to use.
+    Fontsource ships multiple CSS files for each font. See the [Fontsource documentation](https://fontsource.org/docs/getting-started/install#4-weights-and-styles) on including different weights and styles to understand which to use.
 
-    </Steps>
+</Steps>
 
 ### Use fonts
 

--- a/docs/src/content/docs/guides/i18n.mdx
+++ b/docs/src/content/docs/guides/i18n.mdx
@@ -10,41 +10,42 @@ Starlight provides built-in support for multilingual sites, including routing, f
 ## Configure i18n
 
 <Steps>
+
 1. Tell Starlight about the languages you support by passing [`locales`](/reference/configuration/#locales) and [`defaultLocale`](/reference/configuration/#defaultlocale) to the Starlight integration:
 
-```js {9-26}
-// astro.config.mjs
-import { defineConfig } from 'astro/config';
-import starlight from '@astrojs/starlight';
+   ```js {9-26}
+   // astro.config.mjs
+   import { defineConfig } from 'astro/config';
+   import starlight from '@astrojs/starlight';
 
-export default defineConfig({
-	integrations: [
-		starlight({
-			title: 'My Docs',
-			// Set English as the default language for this site.
-			defaultLocale: 'en',
-			locales: {
-				// English docs in `src/content/docs/en/`
-				en: {
-					label: 'English',
-				},
-				// Simplified Chinese docs in `src/content/docs/zh-cn/`
-				'zh-cn': {
-					label: '简体中文',
-					lang: 'zh-CN',
-				},
-				// Arabic docs in `src/content/docs/ar/`
-				ar: {
-					label: 'العربية',
-					dir: 'rtl',
-				},
-			},
-		}),
-	],
-});
-```
+   export default defineConfig({
+   	integrations: [
+   		starlight({
+   			title: 'My Docs',
+   			// Set English as the default language for this site.
+   			defaultLocale: 'en',
+   			locales: {
+   				// English docs in `src/content/docs/en/`
+   				en: {
+   					label: 'English',
+   				},
+   				// Simplified Chinese docs in `src/content/docs/zh-cn/`
+   				'zh-cn': {
+   					label: '简体中文',
+   					lang: 'zh-CN',
+   				},
+   				// Arabic docs in `src/content/docs/ar/`
+   				ar: {
+   					label: 'العربية',
+   					dir: 'rtl',
+   				},
+   			},
+   		}),
+   	],
+   });
+   ```
 
-Your `defaultLocale` will be used for fallback content and UI labels, so choose the language you are most likely to start writing content in, or already have content for.
+   Your `defaultLocale` will be used for fallback content and UI labels, so choose the language you are most likely to start writing content in, or already have content for.
 
 2. Create a directory for each language in `src/content/docs/`.
    For example, for the configuration shown above, create the following folders:
@@ -64,7 +65,7 @@ Your `defaultLocale` will be used for fallback content and UI labels, so choose 
 
    For example, create `ar/index.md` and `en/index.md` to represent the homepage for Arabic and English respectively.
 
-   </Steps>
+</Steps>
 
 ### Use a root locale
 
@@ -155,18 +156,19 @@ and we welcome [contributions to add more default languages](https://github.com/
 You can provide translations for additional languages you support — or override our default labels — via the `i18n` data collection.
 
 <Steps>
+
 1. Configure the `i18n` data collection in `src/content/config.ts` if it isn’t configured already:
 
-```diff lang="js" ins=/, (i18nSchema)/
-// src/content/config.ts
-import { defineCollection } from 'astro:content';
-import { docsSchema, i18nSchema } from '@astrojs/starlight/schema';
+   ```diff lang="js" ins=/, (i18nSchema)/
+   // src/content/config.ts
+   import { defineCollection } from 'astro:content';
+   import { docsSchema, i18nSchema } from '@astrojs/starlight/schema';
 
-export const collections = {
-	docs: defineCollection({ schema: docsSchema() }),
-+	i18n: defineCollection({ type: 'data', schema: i18nSchema() }),
-};
-```
+   export const collections = {
+   	docs: defineCollection({ schema: docsSchema() }),
+   +	i18n: defineCollection({ type: 'data', schema: i18nSchema() }),
+   };
+   ```
 
 2. Create a JSON file in `src/content/i18n/` for each additional locale you want to provide UI translation strings for.
    For example, this would add translation files for Arabic and Simplified Chinese:
@@ -184,8 +186,6 @@ export const collections = {
 3. Add translations for the keys you want to translate to the JSON files. Translate only the values, leaving the keys in English (e.g. `"search.label": "Buscar"`).
 
    These are the English defaults of the existing strings Starlight ships with:
-
-   {' '}
 
    <UIStringsList />
 
@@ -218,7 +218,7 @@ export const collections = {
    }
    ```
 
-   </Steps>
+ </Steps>
 
 ### Extend translation schema
 

--- a/docs/src/content/docs/guides/overriding-components.mdx
+++ b/docs/src/content/docs/guides/overriding-components.mdx
@@ -20,10 +20,11 @@ Overriding Starlight’s default components can be useful when:
 ## How to override
 
 <Steps>
+
 1. Choose the Starlight component you want to override.
    You can find a full list of components in the [Overrides Reference](/reference/overrides/).
 
-This example will override Starlight’s [`SocialIcons`](/reference/overrides/#socialicons) component in the page nav bar.
+   This example will override Starlight’s [`SocialIcons`](/reference/overrides/#socialicons) component in the page nav bar.
 
 2. Create an Astro component to replace the Starlight component with.
    This example renders a contact link.
@@ -57,7 +58,7 @@ This example will override Starlight’s [`SocialIcons`](/reference/overrides/#s
    });
    ```
 
-   </Steps>
+</Steps>
 
 ## Reuse a built-in component
 

--- a/docs/src/content/docs/guides/site-search.mdx
+++ b/docs/src/content/docs/guides/site-search.mdx
@@ -49,31 +49,32 @@ This text will be hidden from search.
 If you have access to [Algolia’s DocSearch program](https://docsearch.algolia.com/) and want to use it instead of Pagefind, you can use the official Starlight DocSearch plugin.
 
 <Steps>
+
 1. Install `@astrojs/starlight-docsearch`:
 
    <Tabs>
 
    <TabItem label="npm">
 
-```sh
-npm install @astrojs/starlight-docsearch
-```
+   ```sh
+   npm install @astrojs/starlight-docsearch
+   ```
 
    </TabItem>
 
    <TabItem label="pnpm">
 
-```sh
-pnpm add @astrojs/starlight-docsearch
-```
+   ```sh
+   pnpm add @astrojs/starlight-docsearch
+   ```
 
    </TabItem>
 
    <TabItem label="Yarn">
 
-```sh
-yarn add @astrojs/starlight-docsearch
-```
+   ```sh
+   yarn add @astrojs/starlight-docsearch
+   ```
 
    </TabItem>
 
@@ -103,7 +104,7 @@ yarn add @astrojs/starlight-docsearch
    });
    ```
 
-   </Steps>
+</Steps>
 
 With this updated configuration, the search bar on your site will now open an Algolia modal instead of the default search modal.
 
@@ -113,22 +114,23 @@ DocSearch only provides English UI strings by default.
 Add translations of the modal UI for your language using Starlight’s built-in [internationalization system](/guides/i18n/#translate-starlights-ui).
 
 <Steps>
+
 1. Extend Starlight’s `i18n` content collection definition with the DocSearch schema in `src/content/config.ts`:
 
-```js ins={4} ins=/{ extend: .+ }/
-// src/content/config.ts
-import { defineCollection } from 'astro:content';
-import { docsSchema, i18nSchema } from '@astrojs/starlight/schema';
-import { docSearchI18nSchema } from '@astrojs/starlight-docsearch/schema';
+   ```js ins={4} ins=/{ extend: .+ }/
+   // src/content/config.ts
+   import { defineCollection } from 'astro:content';
+   import { docsSchema, i18nSchema } from '@astrojs/starlight/schema';
+   import { docSearchI18nSchema } from '@astrojs/starlight-docsearch/schema';
 
-export const collections = {
-	docs: defineCollection({ schema: docsSchema() }),
-	i18n: defineCollection({
-		type: 'data',
-		schema: i18nSchema({ extend: docSearchI18nSchema() }),
-	}),
-};
-```
+   export const collections = {
+   	docs: defineCollection({ schema: docsSchema() }),
+   	i18n: defineCollection({
+   		type: 'data',
+   		schema: i18nSchema({ extend: docSearchI18nSchema() }),
+   	}),
+   };
+   ```
 
 2. Add translations to your JSON files in `src/content/i18n/`.
 
@@ -167,4 +169,4 @@ export const collections = {
    }
    ```
 
-   </Steps>
+</Steps>


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Minor content fixes (broken links, typos, etc.)

#### Description

#1637 was missing some line breaks to not make Prettier format the code in a weird way. After being merged, the code was formatted improperly.

This PR reverts the formatting changes from this [run](https://github.com/withastro/starlight/commit/7fcb8eb07e891d0a0ae0f18185221d8eabe1a409) and adds the missing line breaks.

I tested manually by running `pnpm format` locally after the changes and no changes were made to the files.