### PR TITLE
Allow opening social links in new tab

### DIFF
--- a/packages/starlight/components/SocialIcons.astro
+++ b/packages/starlight/components/SocialIcons.astro
@@ -12,7 +12,7 @@ const links = Object.entries(config.social || {}) as [Platform, SocialConfig][];
 	links.length > 0 && (
 		<>
 			{links.map(([platform, { label, url }]) => (
-				<a href={url} rel="me" class="sl-flex">
+				<a href={url} target="_blank" rel="me" class="sl-flex">
 					<span class="sr-only">{label}</span>
 					<Icon name={platform} />
 				</a>


### PR DESCRIPTION
before this change, clicking on the social icons opens the link in the same tab, but it is a better experience to keep the docs in its tab and then open the link in a blank tab.