### PR TITLE
Remove duplicate from showcase example in `contributing.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -272,9 +272,9 @@ If you’ve built a documentation site with Starlight, adding it to the showcase
    - The `thumbnail` attribute must be the filename of the screenshot you added in step 2.
 
    ```diff
-     <Card title="Example" href="https://example.com" thumbnail="example.com.png" />
+     <Card title="Example" href="https://example.net" thumbnail="example.net.png" />
      <Card title="Last Example" href="https://example.org" thumbnail="example.org.png" />
-   + <Card title="Example" href="https://example.com" thumbnail="example.com.png" />
+   + <Card title="New Example" href="https://example.com" thumbnail="example.com.png" />
    </FluidGrid>
    ```
 


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Something else!

#### Description

When modifying https://github.com/withastro/starlight/pull/1606 during Talking & Doc'ing and playing with URLs, I did not realize that we ended up with an example adding a duplicate entry to the showcase.

This PR updates the example to use a different URL based on the RFC for [Reserved Example Second Level Domain Names](https://www.rfc-editor.org/rfc/rfc2606.html#section-3).