### PR TITLE
docs: sort icons alphabetically

### DIFF
--- a/docs/src/components/icons-list.astro
+++ b/docs/src/components/icons-list.astro
@@ -2,7 +2,9 @@
 import { Icon } from '@astrojs/starlight/components';
 import { Icons } from '../../../packages/starlight/components/Icons';
 
-const icons = Object.keys(Icons) as (keyof typeof Icons)[];
+const icons = [...(Object.keys(Icons) as (keyof typeof Icons)[])].sort((a, b) =>
+	a.localeCompare(b, 'en')
+);
 ---
 
 <div class="icons-grid">


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes or translations of Starlight docs site content
- Something else!

#### Description

This pull request address this [Discord message](https://discord.com/channels/830184174198718474/1070481941863878697/1225768815397310574):

> Would you be open to sorting the icons alphabetically? I surf on mobile and tablet a lot and not easy to find a specific icon when it's not sorted. Find functionality is too many steps on mobile

Until we get a better story for icons in the documentation, some search feature, etc., I think this is a good idea. This PR sorts the icons alphabetically (always using the same locale to ensure a consistent order in all languages which I think makes sense in this specific case).