### PR TITLE
fix: respond to media query change events when theme is `auto`

### DIFF
--- a/.changeset/swift-files-wave.md
+++ b/.changeset/swift-files-wave.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+fix: respond to media query change events when theme is `auto`

--- a/.changeset/swift-files-wave.md
+++ b/.changeset/swift-files-wave.md
@@ -2,4 +2,4 @@
 '@astrojs/starlight': patch
 ---
 
-fix: respond to media query change events when theme is `auto`
+Fixes responding to system color scheme changes when theme is `auto`

--- a/packages/starlight/components/ThemeSelect.astro
+++ b/packages/starlight/components/ThemeSelect.astro
@@ -42,8 +42,21 @@ const { labels } = Astro.props;
 						this.#onThemeChange(this.#parseTheme(e.currentTarget.value));
 					}
 				});
+
+				const media = window.matchMedia(`(prefers-color-scheme: dark)`);
+				media.addEventListener('change', this.#handleMediaQuery);
 			}
 		}
+
+		#handleMediaQuery = () => {
+			const select = this.querySelector('select');
+
+			if (select?.value !== 'auto') {
+				return;
+			}
+
+			this.#onThemeChange(this.#parseTheme(select.value));
+		};
 
 		/** Get a typesafe theme string from any JS value (unknown values are coerced to `'auto'`). */
 		#parseTheme(theme: unknown): Theme {

--- a/packages/starlight/components/ThemeSelect.astro
+++ b/packages/starlight/components/ThemeSelect.astro
@@ -42,20 +42,12 @@ const { labels } = Astro.props;
 						this.#onThemeChange(this.#parseTheme(e.currentTarget.value));
 					}
 				});
-
-				const media = window.matchMedia(`(prefers-color-scheme: dark)`);
-				media.addEventListener('change', this.#handleMediaQuery);
+				matchMedia(`(prefers-color-scheme: light)`).addEventListener('change', this.#handleMediaQuery);
 			}
 		}
 
-		#handleMediaQuery = () => {
-			const select = this.querySelector('select');
-
-			if (select?.value !== 'auto') {
-				return;
-			}
-
-			this.#onThemeChange(this.#parseTheme(select.value));
+		#handleMediaQuery(): void {
+			if (this.#loadTheme() === 'auto') this.#onThemeChange('auto');
 		};
 
 		/** Get a typesafe theme string from any JS value (unknown values are coerced to `'auto'`). */

--- a/packages/starlight/components/ThemeSelect.astro
+++ b/packages/starlight/components/ThemeSelect.astro
@@ -42,13 +42,11 @@ const { labels } = Astro.props;
 						this.#onThemeChange(this.#parseTheme(e.currentTarget.value));
 					}
 				});
-				matchMedia(`(prefers-color-scheme: light)`).addEventListener('change', this.#handleMediaQuery);
+				matchMedia(`(prefers-color-scheme: light)`).addEventListener('change', () => {
+					if (this.#loadTheme() === 'auto') this.#onThemeChange('auto');
+				});
 			}
 		}
-
-		#handleMediaQuery(): void {
-			if (this.#loadTheme() === 'auto') this.#onThemeChange('auto');
-		};
 
 		/** Get a typesafe theme string from any JS value (unknown values are coerced to `'auto'`). */
 		#parseTheme(theme: unknown): Theme {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #1684
- What does this PR change? Give us a brief description.
Will respond to media change query events and update the theme to system/browser preference when current theme is set to `auto`
- Did you change something visual? A before/after screenshot can be helpful.
Technically it's a visual change but nothing visual about the package changed :)

I didn't see any existing tests in/around the components, specifically `ThemeSelect`.  If I overlooked and/or you'd like me to add some, just let me know.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
