### PR TITLE
test: fix Windows path separator test issues

### DIFF
--- a/packages/starlight/__tests__/basics/git.test.ts
+++ b/packages/starlight/__tests__/basics/git.test.ts
@@ -56,13 +56,13 @@ describe('getNewestCommitDate', () => {
 
 	test('throws when failing to retrieve the git history for a file', () => {
 		expect(() => getNewestCommitDate(getFilePath('../not-a-starlight-test-repo/test.md'))).toThrow(
-			/^Failed to retrieve the git history for file "[/\\-\w ]+\/test\.md"/
+			/^Failed to retrieve the git history for file "[/\\:-\w ]+[/\\]test\.md"/
 		);
 	});
 
 	test('throws when trying to get the history of a non-existing or untracked file', () => {
 		const expectedError =
-			/^Failed to validate the timestamp for file "[/\\-\w ]+\/(?:unknown|untracked)\.md"$/;
+			/^Failed to validate the timestamp for file "[/\\:-\w ]+[/\\](?:unknown|untracked)\.md"$/;
 		writeFile('untracked.md', 'content');
 
 		expect(() => getNewestCommitDate(getFilePath('unknown.md'))).toThrow(expectedError);

--- a/packages/starlight/__tests__/i18n-root-locale/routing.test.ts
+++ b/packages/starlight/__tests__/i18n-root-locale/routing.test.ts
@@ -82,8 +82,8 @@ test('fallback routes use fallback entry last updated dates', () => {
 
 	expect(getNewestCommitDate).toHaveBeenCalledOnce();
 	expect(getNewestCommitDate.mock.lastCall?.[0]).toMatch(
-		/src\/content\/docs\/guides\/authoring-content.md$/
-		//                          ^ no `en/` prefix
+		/src[/\\]content[/\\]docs[/\\]guides[/\\]authoring-content.md$/
+		//                                       ^ no `en/` prefix
 	);
 
 	getNewestCommitDate.mockRestore();


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Something else!

#### Description

While testing another PR on Windows, I noticed that some tests where failing. They are all related to tests with regex matching paths where the path separators were invalid and `:` was sometimes missing for `X:` drives.