### PR TITLE
Fix sidebar badge outline style with Tailwind CSS

### DIFF
--- a/.changeset/eight-grapes-watch.md
+++ b/.changeset/eight-grapes-watch.md
@@ -1,0 +1,8 @@
+---
+'@astrojs/starlight': minor
+---
+
+Fixes the outline style of sidebar badges when using Tailwind CSS.
+
+This involves changing the name of an internal CSS class name to avoid a collision with Tailwind CSS utility classes.
+If you were relying on the previous (`.outline`) class name for custom styling, you will need to update your custom CSS to use the new class name (`.sl-outline`).

--- a/packages/starlight/components/Badge.astro
+++ b/packages/starlight/components/Badge.astro
@@ -6,9 +6,10 @@ interface Props {
 	text?: string;
 }
 const { variant = 'default', text } = Astro.props;
+const variantClass = variant === 'outline' ? 'sl-outline' : variant;
 ---
 
-<span class:list={['sl-badge', variant]} set:html={text} />
+<span class:list={['sl-badge', variantClass]} set:html={text} />
 
 <style>
 	.sl-badge {
@@ -25,7 +26,7 @@ const { variant = 'default', text } = Astro.props;
 		overflow-wrap: anywhere;
 	}
 
-	.outline {
+	.sl-outline {
 		--sl-color-bg-badge: transparent;
 		--sl-color-border-badge: currentColor;
 		color: inherit;


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes to Starlight code

#### Description

- Closes #1764

Outlined sidebar badges looks like this by default in Starlight:

<img width="263" alt="SCR-20240418-kksc" src="https://github.com/withastro/starlight/assets/494699/98c59164-3a85-4ca0-b136-9b23bab22c43">

When using Tailwind CSS, the outline style is thicker:

<img width="264" alt="SCR-20240418-kfwo" src="https://github.com/withastro/starlight/assets/494699/9a04df97-8e17-49b6-91b3-e57261c60d4b">

This is due to the variant (`outline`) being used as a CSS class name which collides with Tailwind CSS [`outline`](https://tailwindcss.com/docs/outline-style) utility adding `	outline-style: solid;`.

This PR renames the class name to `sl-outline` to avoid the collision and get the following result matching the default Starlight style:

<img width="263" alt="SCR-20240418-kgbg" src="https://github.com/withastro/starlight/assets/494699/e58670ab-75ea-44ac-802e-5d63ecb828cb">

#### Alternative approach

Edit: a potential alternative solution suggested by @martrapp could be to remove entirely the need of a CSS class for this and rely on a selector like `[aria-current='page'] :global(.sl-badge)`. This would mean not exposing the `outline` variant in #1530 (which is the current approach) but we would need to confirm that first.

#### How to test

1. Edit `examples/tailwind/astro.config.mjs` to add a badge to the "Example Guide" sidebar link.
1. Run `pnpm dev` in the `examples/tailwind/` directory.
1. Navigate to `http://localhost:4321/guides/example/`