### PR TITLE
fix: add right sidebar scrollbar (#1746)

### DIFF
--- a/packages/starlight/components/PageSidebar.astro
+++ b/packages/starlight/components/PageSidebar.astro
@@ -54,6 +54,7 @@ import TableOfContents from 'virtual:starlight/components/TableOfContents';
 						) * 0.25 /* MAGIC NUMBER 🥲 */
 				)
 			);
+			width: auto;
 		}
 	}
 </style>

--- a/packages/starlight/components/TwoColumnContent.astro
+++ b/packages/starlight/components/TwoColumnContent.astro
@@ -30,14 +30,14 @@ import type { Props } from '../props';
 		}
 
 		.right-sidebar {
-			position: fixed;
-			top: 0;
+			position: sticky;
+			top: var(--sl-nav-height);
 			border-inline-start: 1px solid var(--sl-color-gray-6);
-			padding-top: var(--sl-nav-height);
-			width: 100%;
-			height: 100vh;
-			overflow-y: auto;
-			scrollbar-width: none;
+			max-width: var(--sl-sidebar-width);
+			width: auto;
+			height: calc(100vh - var(--sl-nav-height));
+			overflow-y: auto;			
+			margin-right: var(--sl-sidebar-pad-x);
 		}
 
 		.main-pane {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #1746
- What does this PR change? Give us a brief description.
Adds a scrollbar to `right-sidebar` for accessibility and navigation.  See details & discussion in #1746.
- Did you change something visual? A before/after screenshot can be helpful.
Yes, scrollbar added.

Before:

![image](https://github.com/withastro/starlight/assets/4323995/7aabfe82-d700-4605-85d1-5c1438436358)

After:

![image](https://github.com/withastro/starlight/assets/4323995/a4f0dd0c-18de-477a-9b36-a6f35ef9b86b)

## Additional Information
- I was unable to decipher why the [`sl-container`](https://github.com/techfg/starlight/blob/issue-1746/packages/starlight/components/PageSidebar.astro#L28) had a width specified but then a [max-width](https://github.com/techfg/starlight/blob/issue-1746/packages/starlight/components/PageSidebar.astro#L49) set when `min-width: 72rem` when it only appears that the entire component would ever be visible at `min-width: 72rem`.  I needed to ensure `width: auto` now that the parent (`.right-sidebar`) has a max-width, otherwise a horizontal scrollbar would display which wasn't necessary so to minimize risk in case I'm overlooking something, I just set width to `auto` when `min-width: 72rem` to be consistent with styles applied on `.right-sidebar`.  Based on what I'm seeing in this component, the both the `sl-container` width and `max-width` could likely be removed completely but decided to play it safe - let me know if you think these can be removed.
- The [margin-right](https://github.com/techfg/starlight/blob/issue-1746/packages/starlight/components/TwoColumnContent.astro#L40) on `right-sidebar` is to provide spacing away from the window scrollbar so they don't end up immediately next to each other.
