### PR TITLE
Fixed issue #1725. Added styling to table inside the aside component.

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -27,6 +27,7 @@ import AboutAstro from '~/components/about-astro.astro';
 import TestimonialGrid from '~/components/testimonial-grid.astro';
 import Testimonial from '~/components/testimonial.astro';
 
+
 <CardGrid stagger>
 	<Card title="Documentation that delights" icon="open-book">
 		Includes: Site navigation, search, internationalization, SEO, easy-to-read

--- a/packages/starlight/style/asides.css
+++ b/packages/starlight/style/asides.css
@@ -8,20 +8,43 @@
 	border-color: var(--sl-color-blue);
 	background-color: var(--sl-color-blue-low);
 }
+
+ .starlight-aside--note tr:nth-child(even) {
+	--sl-color-asides-text-accent: var(--sl-color-blue-low);
+	background-color: hsl(234, 39%, 44%,0.277);;
+}
+
 .starlight-aside--tip {
 	--sl-color-asides-text-accent: var(--sl-color-purple-high);
 	border-color: var(--sl-color-purple);
 	background-color: var(--sl-color-purple-low);
 }
+
+ .starlight-aside--tip tr:nth-child(even) {
+	--sl-color-asides-text-accent: var(--sl-color-purple-high);
+	background-color: hsla(281, 39%, 44%, 0.277);
+}
+
 .starlight-aside--caution {
 	--sl-color-asides-text-accent: var(--sl-color-orange-high);
 	border-color: var(--sl-color-orange);
 	background-color: var(--sl-color-orange-low);
 }
+
+ .starlight-aside--caution tr:nth-child(even) {
+	--sl-color-asides-text-accent: var(--sl-color-orange-high);
+	background-color: hsla(var(--sl-hue-orange), 39%, 44%,0.277);
+}
+
 .starlight-aside--danger {
 	--sl-color-asides-text-accent: var(--sl-color-red-high);
 	border-color: var(--sl-color-red);
 	background-color: var(--sl-color-red-low);
+}
+
+.starlight-aside--danger tr:nth-child(even){
+	--sl-color-asides-text-accent: var(--sl-color-red-low);
+	background-color: hsla(var(--sl-hue-red), 39%, 44%,0.277);	
 }
 
 .starlight-aside__title {
@@ -47,3 +70,4 @@
 .starlight-aside__content a {
 	color: var(--sl-color-asides-text-accent);
 }
+


### PR DESCRIPTION

#### Description

- Closes #1725  <!-- Add an issue number if this PR will close it. -->
- This PR resolves the issue of styling of a table inside an aside element.
-  One example of the visual change made by this PR is the screenshot below.

![名称未設定のデザイン](https://github.com/withastro/starlight/assets/101443426/02994400-f44c-4932-812e-6a3b859d81b2)

Right now with this PR, the table inside the aside element looks like the screenshots below:

<img width="412" alt="スクリーンショット 2024-04-29 17 20 37" src="https://github.com/withastro/starlight/assets/101443426/454b9260-89d9-4705-8903-34cf2323ae44">

<img width="415" alt="スクリーンショット 2024-04-29 17 20 48" src="https://github.com/withastro/starlight/assets/101443426/b25df039-14cd-4591-b8b5-1f38648c47d6">

<img width="445" alt="スクリーンショット 2024-04-29 17 21 11" src="https://github.com/withastro/starlight/assets/101443426/69af7ed1-d220-47cc-871a-91a3d69f0b94">

<img width="423" alt="スクリーンショット 2024-04-29 17 21 22" src="https://github.com/withastro/starlight/assets/101443426/982c8081-b804-4346-ac32-b2ec9892f1fa">

<img width="436" alt="スクリーンショット 2024-04-29 17 21 54" src="https://github.com/withastro/starlight/assets/101443426/ce3e21bf-160e-45f8-8823-39b28d2d34e4">

<img width="449" alt="スクリーンショット 2024-04-29 17 22 17" src="https://github.com/withastro/starlight/assets/101443426/bd081819-e1a8-40b9-83d5-5b3a53955063">

