### PR TITLE
i18n(fr): update `guides/components` and add `syncKey` to various pages

### DIFF
--- a/docs/src/content/docs/fr/getting-started.mdx
+++ b/docs/src/content/docs/fr/getting-started.mdx
@@ -15,7 +15,7 @@ Consultez les [instructions d'installation manuelle](/fr/manual-setup/) pour ajo
 
 Créez un nouveau projet Astro + Starlight en lançant la commande suivante dans votre terminal :
 
-<Tabs>
+<Tabs syncKey="pkg">
 <TabItem label="npm">
 
 ```sh
@@ -52,7 +52,7 @@ Lorsque vous travaillez localement, [le serveur de développement d'Astro](https
 
 À l'intérieur du répertoire de votre projet, exécutez la commande suivante pour démarrer le serveur de développement :
 
-<Tabs>
+<Tabs syncKey="pkg">
 <TabItem label="npm">
 
 ```sh
@@ -103,7 +103,7 @@ Assurez-vous de mettre à jour Starlight régulièrement !
 
 Starlight est une intégration Astro. Vous pouvez la mettre à jour ainsi que tous autres packages Astro en exécutant la commande suivante dans votre terminal :
 
-<Tabs>
+<Tabs syncKey="pkg">
 <TabItem label="npm">
 
 ```sh

--- a/docs/src/content/docs/fr/guides/components.mdx
+++ b/docs/src/content/docs/fr/guides/components.mdx
@@ -87,6 +87,51 @@ Le code ci-dessus génère les onglets suivants sur la page :
 	</TabItem>
 </Tabs>
 
+#### Onglets synchronisés
+
+Conservez plusieurs groupes d'onglets synchronisés en ajoutant l'attribut `syncKey`.
+
+Tous les composants `<Tabs>` sur une page avec la même valeur `syncKey` afficheront le même label actif.
+Cela permet à votre lecteur de choisir une fois (par exemple, leur système d'exploitation ou leur gestionnaire de paquets) et de voir leur choix reflété sur l'ensemble de la page.
+
+Pour synchroniser des onglets liés, ajoutez une propriété `syncKey` identique à chaque composant `<Tabs>` et assurez-vous qu'ils utilisent tous les mêmes libellés de `<TabItem>` :
+
+```mdx 'syncKey="constellations"'
+# src/content/docs/exemple.mdx
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+_Quelques étoiles :_
+
+<Tabs syncKey="constellations">
+	<TabItem label="Orion">Bellatrix, Rigel, Bételgeuse</TabItem>
+	<TabItem label="Gémeaux">Pollux, Castor A, Castor B</TabItem>
+</Tabs>
+
+_Quelques exoplanètes :_
+
+<Tabs syncKey="constellations">
+	<TabItem label="Orion">HD 34445 b, Gliese 179 b, Wasp-82 b</TabItem>
+	<TabItem label="Gémeaux">Pollux b, HAT-P-24b, HD 50554 b</TabItem>
+</Tabs>
+```
+
+Le code ci-dessus génère les onglets suivants sur la page :
+
+_Quelques étoiles :_
+
+<Tabs syncKey="constellations">
+	<TabItem label="Orion">Bellatrix, Rigel, Bételgeuse</TabItem>
+	<TabItem label="Gémeaux">Pollux, Castor A, Castor B</TabItem>
+</Tabs>
+
+_Quelques exoplanètes :_
+
+<Tabs syncKey="constellations">
+	<TabItem label="Orion">HD 34445 b, Gliese 179 b, Wasp-82 b</TabItem>
+	<TabItem label="Gémeaux">Pollux b, HAT-P-24b, HD 50554 b</TabItem>
+</Tabs>
+
 ### Cartes
 
 import { Card, CardGrid } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/fr/guides/css-and-tailwind.mdx
+++ b/docs/src/content/docs/fr/guides/css-and-tailwind.mdx
@@ -63,7 +63,7 @@ Le module d'extension Tailwind de Starlight applique la configuration suivante :
 
 Démarrez un nouveau projet Starlight avec Tailwind CSS préconfiguré en utilisant `create astro` :
 
-<Tabs>
+<Tabs syncKey="pkg">
 <TabItem label="npm">
 
 ```sh
@@ -95,7 +95,7 @@ Si vous avez déjà un site Starlight et que vous souhaitez ajouter Tailwind CSS
 
 1.  Ajoutez l'intégration Astro pour Tailwind :
 
-    <Tabs>
+    <Tabs syncKey="pkg">
 
     <TabItem label="npm">
 
@@ -125,7 +125,7 @@ Si vous avez déjà un site Starlight et que vous souhaitez ajouter Tailwind CSS
 
 2.  Installez le module d'extension Tailwind de Starlight :
 
-    <Tabs>
+    <Tabs syncKey="pkg">
 
     <TabItem label="npm">
 

--- a/docs/src/content/docs/fr/guides/customization.mdx
+++ b/docs/src/content/docs/fr/guides/customization.mdx
@@ -130,7 +130,7 @@ Vous pouvez personnaliser - ou même désactiver - la table des matières global
 
 Par défaut, les titres `<h2>` et `<h3>` sont inclus dans la table des matières. Modifiez les niveaux de titres à inclure à l’échelle du site à l’aide des options `minHeadingLevel` et `maxHeadingLevel` dans votre option de configuration [globale `tableOfContents`](/fr/reference/configuration/#tableofcontents). Remplacez ces valeurs par défaut sur une page individuelle en ajoutant les propriétés [frontmatter `tableOfContents`](/fr/reference/frontmatter/#tableofcontents) correspondantes :
 
-<Tabs>
+<Tabs syncKey="config-type">
   <TabItem label="Frontmatter">
 
 ```md {4-6}
@@ -164,7 +164,7 @@ defineConfig({
 
 Désactivez la table des matières complètement en définissant l’option `tableOfContents` à `false`:
 
-<Tabs>
+<Tabs syncKey="config-type">
   <TabItem label="Frontmatter">
 
 ```md {4}


### PR DESCRIPTION
#### Description

This PR updates the French version of the `guides/components.mdx` page with the changes of #640.

It also adds the `syncKey` prop to the French version of the following pages as it felt small enough to be done in one go:

- `getting-started.mdx`
- `guides/css-and-tailwind.mdx`
- `guides/customization.mdx`