### PR TITLE
docs: fix "Astro → Starlight" in site title i18n docs

### DIFF
--- a/docs/src/content/docs/guides/i18n.mdx
+++ b/docs/src/content/docs/guides/i18n.mdx
@@ -145,7 +145,7 @@ If a translation is not yet available for a language, Starlight will show reader
 
 ## Translate the site title
 
-By default, Astro will use the same site title for all languages.
+By default, Starlight will use the same site title for all languages.
 If you need to customize the title for each locale, you can pass an object to [`title`](/reference/configuration/#title-required) in Starlight’s options:
 
 ```diff lang="js"


### PR DESCRIPTION
#### Description

This PR fixes a small typo in the ["Translate the site title"](https://starlight.astro.build/guides/i18n/#translate-the-site-title) i18n guide where Starlight should be used instead of Astro.