### PR TITLE
i18n(fr): update `guides/pages.mdx`

### DIFF
--- a/docs/src/content/docs/fr/guides/pages.mdx
+++ b/docs/src/content/docs/fr/guides/pages.mdx
@@ -105,6 +105,7 @@ Les propriétés suivantes diffèrent du frontmatter en Markdown :
 - La propriété [`slug`](/fr/reference/frontmatter/#slug) n'est pas supportée et est automatiquement définie en fonction de l'URL de la page personnalisée.
 - L'option [`editUrl`](/fr/reference/frontmatter/#editurl) nécessite une URL pour afficher un lien d'édition.
 - La propriété [`sidebar`](/fr/reference/frontmatter/#sidebar) du frontmatter permettant de personnaliser l'affichage de la page dans les [groupes de liens autogénérés](/fr/reference/configuration/#sidebar) n'est pas disponible. Les pages utilisant le composant `<StarlightPage />` ne font pas partie d'une collection et ne peuvent pas être ajoutées à un groupe de liens autogénérés.
+- L'option [`draft`](/fr/reference/frontmatter/#draft) affiche uniquement une [note](/fr/reference/overrides/#draftcontentnotice) indiquant que la page est une ébauche, mais ne l'exclut pas automatiquement des déploiements en production.
 
 ##### `sidebar`
 


### PR DESCRIPTION
#### Description

This PR update the French version of the `guides/pages.mdx` page with the changes of #1613.

The links checker should be run again after #1802 and #1803 are merged.