### PR TITLE
i18n(es): update `guides/components` and add `syncKey` to various pages

### DIFF
--- a/docs/src/content/docs/es/getting-started.mdx
+++ b/docs/src/content/docs/es/getting-started.mdx
@@ -15,7 +15,7 @@ Consulta las [instrucciones de configuración manual](/es/manual-setup/) para ag
 
 Crea un nuevo proyecto de Astro + Starlight ejecutando el siguiente comando en tu terminal:
 
-<Tabs>
+<Tabs syncKey="pkg">
 <TabItem label="npm">
 
 ```sh
@@ -52,7 +52,7 @@ Cuando trabajas localmente, el [servidor de desarrollo de Astro](https://docs.as
 
 Dentro del directorio de tu proyecto, ejecuta el siguiente comando para iniciar el servidor de desarrollo:
 
-<Tabs>
+<Tabs syncKey="pkg">
 <TabItem label="npm">
 
 ```sh
@@ -103,7 +103,7 @@ Debido a que Starlight es un software beta, habrá actualizaciones y mejoras fre
 
 Starlight es una integración Astro. Puedes actualizarlo y otros paquetes de Astro ejecutando el siguiente comando en tu terminal:
 
-<Tabs>
+<Tabs syncKey="pkg">
 <TabItem label="npm">
 
 ```sh

--- a/docs/src/content/docs/es/guides/components.mdx
+++ b/docs/src/content/docs/es/guides/components.mdx
@@ -84,6 +84,50 @@ El código anterior genera las siguientes pestañas en la página:
 	</TabItem>
 </Tabs>
 
+#### Pestañas sincronizadas
+
+Manten varias pestañas sincronizadas añadiendo el atributo `syncKey`.
+
+Todas las `<Tabs>` en una página con el mismo valor de `syncKey` mostrarán la misma etiqueta activa. Esto permite a tu lector elegir una vez (por ejemplo, su sistema operativo o gestor de paquetes) y ver su elección reflejada en toda la página.
+
+Para sincronizar pestañas relacionadas, añade una propiedad `syncKey` idéntica a cada componente `<Tabs>` y asegúrate de que todos usen las mismas etiquetas `<TabItem>`:
+
+```mdx 'syncKey="constellations"'
+# src/content/docs/example.mdx
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+_Algunas estrellas:_
+
+<Tabs syncKey="constellations">
+	<TabItem label="Orion">Bellatrix, Rigel, Betelgeuse</TabItem>
+	<TabItem label="Gemini">Pollux, Cástor A, Cástor B</TabItem>
+</Tabs>
+
+_Algunos exoplanetas:_
+
+<Tabs syncKey="constellations">
+	<TabItem label="Orion">HD 34445 b, Gliese 179 b, Wasp-82 b</TabItem>
+	<TabItem label="Gemini">Pollux b, HAT-P-24b, HD 50554 b</TabItem>
+</Tabs>
+```
+
+El código anterior genera lo siguiente en la página:
+
+_Algunas estrellas:_
+
+<Tabs syncKey="constellations">
+	<TabItem label="Orion">Bellatrix, Rigel, Betelgeuse</TabItem>
+	<TabItem label="Gemini">Pollux, Cástor A, Cástor B</TabItem>
+</Tabs>
+
+_Some exoplanets:_
+
+<Tabs syncKey="constellations">
+	<TabItem label="Orion">HD 34445 b, Gliese 179 b, Wasp-82 b</TabItem>
+	<TabItem label="Gemini">Pollux b, HAT-P-24b, HD 50554 b</TabItem>
+</Tabs>
+
 ### Tarjetas
 
 import { Card, CardGrid } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/es/guides/components.mdx
+++ b/docs/src/content/docs/es/guides/components.mdx
@@ -121,7 +121,7 @@ _Algunas estrellas:_
 	<TabItem label="Gemini">Pollux, Cástor A, Cástor B</TabItem>
 </Tabs>
 
-_Some exoplanets:_
+_Algunos exoplanetas:_
 
 <Tabs syncKey="constellations">
 	<TabItem label="Orion">HD 34445 b, Gliese 179 b, Wasp-82 b</TabItem>

--- a/docs/src/content/docs/es/guides/css-and-tailwind.mdx
+++ b/docs/src/content/docs/es/guides/css-and-tailwind.mdx
@@ -63,7 +63,7 @@ El plugin Starlight Tailwind aplica la siguiente configuración:
 
 Empieza un nuevo proyecto en Starlight con Tailwind CSS preconfigurado usando `create astro`:
 
-<Tabs>
+<Tabs syncKey="pkg">
 <TabItem label="npm">
 
 ```sh
@@ -95,7 +95,7 @@ Si ya tienes un sitio en Starlight y quieres agregar Tailwind CSS, sigue estos p
 
 1.  Agrega la integración de Tailwind de Astro:
 
-    <Tabs>
+    <Tabs syncKey="pkg">
 
     <TabItem label="npm">
 
@@ -125,7 +125,7 @@ Si ya tienes un sitio en Starlight y quieres agregar Tailwind CSS, sigue estos p
 
 2.  Instala el plugin Starlight Tailwind:
 
-    <Tabs>
+    <Tabs syncKey="pkg">
 
     <TabItem label="npm">
 

--- a/docs/src/content/docs/es/guides/customization.mdx
+++ b/docs/src/content/docs/es/guides/customization.mdx
@@ -127,7 +127,7 @@ Starlight muestra una tabla de contenidos en cada página para facilitar que los
 
 De forma predeterminada, los encabezados `<h2>` y `<h3>` se incluyen en la tabla de contenidos. Puedes cambiar qué niveles de encabezados se incluyen en toda la página utilizando las opciones `minHeadingLevel` y `maxHeadingLevel` en tu configuración [global de `tableOfContents`](/es/reference/configuration/#tableofcontents). Puedes anular estas configuraciones predeterminadas en una página individual agregando las propiedades correspondientes de [`tableOfContents` en el frontmatter](/es/reference/frontmatter/#tableofcontents):
 
-<Tabs>
+<Tabs syncKey="config-type">
   <TabItem label="Frontmatter">
 
 ```md {4-6}
@@ -161,7 +161,7 @@ defineConfig({
 
 Desactiva completamente la tabla de contenidos estableciendo la opción `tableOfContents` en `false`:
 
-<Tabs>
+<Tabs syncKey="config-type">
   <TabItem label="Frontmatter">
 
 ```md {4}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes # N/A<!-- Add an issue number if this PR will close it. -->
- What does this PR change? Give us a brief description.

This PR updates the spanish version of the `guides/components.mdx` based on this commit #640.

It also adds the `syncKey` prop to the French version of the following pages as it felt small enough to be done in one go:

- `getting-started.mdx`
- `guides/css-and-tailwind.mdx`
- `guides/customization.mdx`

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
