### PR TITLE
Enable `BASE_URL` tests

### DIFF
--- a/packages/starlight/__tests__/basics/base.test.ts
+++ b/packages/starlight/__tests__/basics/base.test.ts
@@ -11,14 +11,21 @@ describe('fileWithBase()', () => {
 		});
 	});
 
-	// TODO: Stubbing BASE_URL is not currently possible.
-	// Astro controls BASE_URL via its `vite-plugin-env`, which prevents Vitest’s stubbing from
-	// working and there’s also no way to pass in Astro config in Astro’s `getViteConfig` helper.
-	describe.todo('with base', () => {
-		test('prepends base', () => {
+	describe('with base', () => {
+		test('prepends base', async () => {
+			// Reset the modules registry so that re-importing `../../utils/base` re-evaluates the module
+			// and re-computes the base. Re-importing the module is necessary because top-level imports
+			// cannot be re-evaluated.
+			vi.resetModules();
+			// Set the base URL.
 			vi.stubEnv('BASE_URL', '/base/');
+			// Re-import the module to re-evaluate it.
+			const { fileWithBase } = await import('../../utils/base');
+
 			expect(fileWithBase('/img.svg')).toBe('/base/img.svg');
+
 			vi.unstubAllEnvs();
+			vi.resetModules();
 		});
 	});
 });
@@ -33,5 +40,17 @@ describe('pathWithBase()', () => {
 		});
 	});
 
-	describe.todo('with base');
+	describe('with base', () => {
+		test('prepends base', async () => {
+			// See the first test with a base in this file for an explanation of the environment stubbing.
+			vi.resetModules();
+			vi.stubEnv('BASE_URL', '/base/');
+			const { pathWithBase } = await import('../../utils/base');
+
+			expect(pathWithBase('/path/')).toBe('/base/path/');
+
+			vi.unstubAllEnvs();
+			vi.resetModules();
+		});
+	});
 });

--- a/packages/starlight/__tests__/basics/slugs.test.ts
+++ b/packages/starlight/__tests__/basics/slugs.test.ts
@@ -95,10 +95,7 @@ describe('urlToSlug', () => {
 		);
 	});
 
-	// It is currently not possible to test this as stubbing BASE_URL is not supported due to
-	// `vite-plugin-env` controlling it and the lack of a way to pass in an Astro config using
-	// `getViteConfig()` from `astro/config`.
-	test.todo('returns slugs with a custom `base` option', () => {
+	test('returns slugs with a custom `base` option', () => {
 		vi.stubEnv('BASE_URL', '/base/');
 		expect(urlToSlug(new URL('https://example.com/base'))).toBe('');
 		expect(urlToSlug(new URL('https://example.com/base/slug'))).toBe('slug');


### PR DESCRIPTION
#### Description

Following the merge of #1613, this PR enables the `BASE_URL` tests we had in the codebase using a similar approach as the one used to stub the `MODE` to `production` in the tests.