### PR TITLE
Move site title `href` to route data for easier overrides

### DIFF
--- a/.changeset/polite-cheetahs-help.md
+++ b/.changeset/polite-cheetahs-help.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Moves the `href` used in the site title link to Starlight’s route data object. This makes it possible for overrides to change the title link while reusing Starlight’s default component implemenation.

--- a/docs/src/content/docs/reference/overrides.md
+++ b/docs/src/content/docs/reference/overrides.md
@@ -61,7 +61,7 @@ The site title for this page’s locale.
 **Type:** `string`
 
 The value for the site title’s `href` attribute, linking back to the homepage, e.g. `/`.
-For multilingual sites this will include the current locale, e.g. `/en/` or `/zh-CN/`.
+For multilingual sites this will include the current locale, e.g. `/en/` or `/zh-cn/`.
 
 #### `slug`
 

--- a/docs/src/content/docs/reference/overrides.md
+++ b/docs/src/content/docs/reference/overrides.md
@@ -56,6 +56,13 @@ The base path at which a language is served. `undefined` for root locale slugs.
 
 The site title for this page’s locale.
 
+#### `siteTitleHref`
+
+**Type:** `string`
+
+The value for the site title’s `href` attribute, linking back to the homepage, e.g. `/`.
+For multilingual sites this will include the current locale, e.g. `/en/` or `/zh-CN/`.
+
 #### `slug`
 
 **Type:** `string`

--- a/packages/starlight/components/SiteTitle.astro
+++ b/packages/starlight/components/SiteTitle.astro
@@ -2,13 +2,10 @@
 import { logos } from 'virtual:starlight/user-images';
 import config from 'virtual:starlight/user-config';
 import type { Props } from '../props';
-import { formatPath } from '../utils/format-path';
-
-const { siteTitle } = Astro.props;
-const href = formatPath(Astro.props.locale || '/');
+const { siteTitle, siteTitleHref } = Astro.props;
 ---
 
-<a {href} class="site-title sl-flex">
+<a href={siteTitleHref} class="site-title sl-flex">
 	{
 		config.logo && logos.dark && (
 			<>

--- a/packages/starlight/utils/route-data.ts
+++ b/packages/starlight/utils/route-data.ts
@@ -9,6 +9,7 @@ import { ensureTrailingSlash } from './path';
 import type { Route } from './routing';
 import { localizedId } from './slugs';
 import { useTranslations } from './translations';
+import { formatPath } from './format-path';
 
 export interface PageProps extends Route {
 	headings: MarkdownHeading[];
@@ -17,6 +18,8 @@ export interface PageProps extends Route {
 export interface StarlightRouteData extends Route {
 	/** Title of the site. */
 	siteTitle: string;
+	/** URL or path used as the link when clicking on the site title. */
+	siteTitleHref: string;
 	/** Array of Markdown headings extracted from the current page. */
 	headings: MarkdownHeading[];
 	/** Site navigation sidebar entries for this page. */
@@ -48,6 +51,7 @@ export function generateRouteData({
 	return {
 		...props,
 		siteTitle,
+		siteTitleHref: getSiteTitleHref(locale),
 		sidebar,
 		hasSidebar: entry.data.template !== 'splash',
 		pagination: getPrevNextLinks(sidebar, config.pagination, entry.data),
@@ -117,4 +121,8 @@ export function getSiteTitle(lang: string): string {
 		return config.title[lang] as string;
 	}
 	return config.title[defaultLang] as string;
+}
+
+export function getSiteTitleHref(locale: string | undefined): string {
+	return formatPath(locale || '/');
 }

--- a/packages/starlight/utils/starlight-page.ts
+++ b/packages/starlight/utils/starlight-page.ts
@@ -3,7 +3,13 @@ import { type ContentConfig, type SchemaContext } from 'astro:content';
 import config from 'virtual:starlight/user-config';
 import { parseWithFriendlyErrors } from './error-map';
 import { stripLeadingAndTrailingSlashes } from './path';
-import { getSiteTitle, getToC, type PageProps, type StarlightRouteData } from './route-data';
+import {
+	getSiteTitle,
+	getSiteTitleHref,
+	getToC,
+	type PageProps,
+	type StarlightRouteData,
+} from './route-data';
 import type { StarlightDocsEntry } from './routing';
 import { slugToLocaleData, urlToSlug } from './slugs';
 import { getPrevNextLinks, getSidebar } from './navigation';
@@ -224,6 +230,7 @@ export async function generateStarlightPageRouteData({
 		pagination: getPrevNextLinks(sidebar, config.pagination, entry.data),
 		sidebar,
 		siteTitle: getSiteTitle(localeData.lang),
+		siteTitleHref: getSiteTitleHref(localeData.locale),
 		slug,
 		toc: getToC({
 			...routeProps,


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Currently `<SiteTitle>` calculates the value of its link internally. This makes it tricky for people to set the link while reusing the default component implemenation.
- This PR adds a `siteTitleHref` property to the route data object (and the one for `StarlightPage`), moving the logic for working out the link path there.
- This means in an override you can set `Astro.props.siteTitleHref = '/custom-link/'` if you need and still use the default component implementation.

#### Considerations

- This is still more complex than adding a dedicated Starlight option for the site title link. Should we consider that? There’s a bit of complexity due to how this intersects with i18n locales, so not 100% what a good config would look like.
- I’ve named the new prop `siteTitleHref` for now, but it could also be something more generic like `homeLink` I guess?

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
