### PR TITLE
Update Vitest to `1.6.0`

### DIFF
--- a/packages/starlight/.gitignore
+++ b/packages/starlight/.gitignore
@@ -1,2 +1,4 @@
 # Astro generates this during tests, but we want to ignore it.
 src/env.d.ts
+__tests__/**/env.d.ts
+__tests__/**/types.d.ts

--- a/packages/starlight/__tests__/i18n-non-root-single-locale/config.test.ts
+++ b/packages/starlight/__tests__/i18n-non-root-single-locale/config.test.ts
@@ -2,7 +2,7 @@ import config from 'virtual:starlight/user-config';
 import { expect, test } from 'vitest';
 
 test('test suite is using correct env', () => {
-	expect(config.title).toMatchObject({ fr: 'i18n with a non-root single locale' });
+	expect(config.title).toMatchObject({ 'fr-CA': 'i18n with a non-root single locale' });
 });
 
 test('config.isMultilingual is false with a single locale', () => {
@@ -11,7 +11,7 @@ test('config.isMultilingual is false with a single locale', () => {
 });
 
 test('config.defaultLocale is populated from default locale', () => {
-	expect(config.defaultLocale.lang).toBe('fr');
+	expect(config.defaultLocale.lang).toBe('fr-CA');
 	expect(config.defaultLocale.dir).toBe('ltr');
 	expect(config.defaultLocale.locale).toBe('fr');
 });

--- a/packages/starlight/__tests__/i18n-non-root-single-locale/routing.test.ts
+++ b/packages/starlight/__tests__/i18n-non-root-single-locale/routing.test.ts
@@ -19,11 +19,11 @@ test('route slugs are normalized', () => {
 test('routes for the configured locale have locale data added', () => {
 	for (const route of routes) {
 		if (route.id.startsWith('fr')) {
-			expect(route.lang).toBe('fr');
+			expect(route.lang).toBe('fr-CA');
 			expect(route.dir).toBe('ltr');
 			expect(route.locale).toBe('fr');
 		} else {
-			expect(route.lang).toBe('fr');
+			expect(route.lang).toBe('fr-CA');
 			expect(route.dir).toBe('ltr');
 			expect(route.locale).toBeUndefined();
 		}

--- a/packages/starlight/__tests__/i18n-non-root-single-locale/slugs.test.ts
+++ b/packages/starlight/__tests__/i18n-non-root-single-locale/slugs.test.ts
@@ -7,8 +7,8 @@ describe('slugToLocaleData', () => {
 		expect(slugToLocaleData('fr/dir/test').locale).toBe('fr');
 	});
 	test('returns default locale "fr" lang', () => {
-		expect(slugToLocaleData('fr/test').lang).toBe('fr');
-		expect(slugToLocaleData('fr/dir/test').lang).toBe('fr');
+		expect(slugToLocaleData('fr/test').lang).toBe('fr-CA');
+		expect(slugToLocaleData('fr/dir/test').lang).toBe('fr-CA');
 	});
 	test('returns default locale "ltr" dir', () => {
 		expect(slugToLocaleData('fr/test').dir).toBe('ltr');
@@ -18,7 +18,7 @@ describe('slugToLocaleData', () => {
 
 describe('localeToLang', () => {
 	test('returns lang for default locale', () => {
-		expect(localeToLang('fr')).toBe('fr');
+		expect(localeToLang('fr')).toBe('fr-CA');
 	});
 });
 

--- a/packages/starlight/__tests__/i18n-non-root-single-locale/translations-with-user-config.test.ts
+++ b/packages/starlight/__tests__/i18n-non-root-single-locale/translations-with-user-config.test.ts
@@ -4,7 +4,7 @@ import { useTranslations } from '../../utils/translations';
 
 vi.mock('astro:content', async () =>
 	(await import('../test-utils')).mockedAstroContent({
-		i18n: [['fr', { 'page.editLink': 'Modifier cette doc!' }]],
+		i18n: [['fr-CA', { 'page.editLink': 'Modifier cette doc!' }]],
 	})
 );
 

--- a/packages/starlight/__tests__/i18n-non-root-single-locale/vitest.config.ts
+++ b/packages/starlight/__tests__/i18n-non-root-single-locale/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineVitestConfig({
 	title: 'i18n with a non-root single locale',
 	defaultLocale: 'fr',
 	locales: {
-		fr: { label: 'Français', lang: 'fr' },
+		fr: { label: 'Français', lang: 'fr-CA' },
 	},
 });

--- a/packages/starlight/package.json
+++ b/packages/starlight/package.json
@@ -186,9 +186,9 @@
     "@astrojs/markdown-remark": "^4.2.1",
     "@playwright/test": "^1.43.1",
     "@types/node": "^18.16.19",
-    "@vitest/coverage-v8": "^1.3.1",
+    "@vitest/coverage-v8": "^1.6.0",
     "astro": "^4.3.5",
-    "vitest": "^1.3.1"
+    "vitest": "^1.6.0"
   },
   "dependencies": {
     "@astrojs/mdx": "^2.1.1",

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -23,9 +23,9 @@
     "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "^1.3.1",
+    "@vitest/coverage-v8": "^1.6.0",
     "postcss": "^8.4.33",
-    "vitest": "^1.3.1"
+    "vitest": "^1.6.0"
   },
   "peerDependencies": {
     "@astrojs/starlight": ">=0.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,14 +201,14 @@ importers:
         specifier: ^18.16.19
         version: 18.16.19
       '@vitest/coverage-v8':
-        specifier: ^1.3.1
-        version: 1.3.1(vitest@1.3.1)
+        specifier: ^1.6.0
+        version: 1.6.0(vitest@1.6.0)
       astro:
         specifier: ^4.3.5
         version: 4.3.5(@types/node@18.16.19)(typescript@5.4.5)
       vitest:
-        specifier: ^1.3.1
-        version: 1.3.1(@types/node@18.16.19)
+        specifier: ^1.6.0
+        version: 1.6.0(@types/node@18.16.19)
 
   packages/starlight/__e2e__/fixtures/basics:
     dependencies:
@@ -232,14 +232,14 @@ importers:
         version: 3.4.1
     devDependencies:
       '@vitest/coverage-v8':
-        specifier: ^1.3.1
-        version: 1.3.1(vitest@1.3.1)
+        specifier: ^1.6.0
+        version: 1.6.0(vitest@1.6.0)
       postcss:
         specifier: ^8.4.33
         version: 8.4.33
       vitest:
-        specifier: ^1.3.1
-        version: 1.3.1(@types/node@18.16.19)
+        specifier: ^1.6.0
+        version: 1.6.0(@types/node@18.16.19)
 
 packages:
 
@@ -1629,10 +1629,6 @@ packages:
       ci-info: 3.9.0
     dev: true
 
-  /@types/istanbul-lib-coverage@2.0.4:
-    resolution: {integrity: sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==}
-    dev: true
-
   /@types/mdast@4.0.3:
     resolution: {integrity: sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==}
     dependencies:
@@ -1701,10 +1697,10 @@ packages:
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
-  /@vitest/coverage-v8@1.3.1(vitest@1.3.1):
-    resolution: {integrity: sha512-UuBnkSJUNE9rdHjDCPyJ4fYuMkoMtnghes1XohYa4At0MS3OQSAo97FrbwSLRshYsXThMZy1+ybD/byK5llyIg==}
+  /@vitest/coverage-v8@1.6.0(vitest@1.6.0):
+    resolution: {integrity: sha512-KvapcbMY/8GYIG0rlwwOKCVNRc0OL20rrhFkg/CHNzncV03TE2XWvO5w9uZYoxNiMEBacAJt3unSOiZ7svePew==}
     peerDependencies:
-      vitest: 1.3.1
+      vitest: 1.6.0
     dependencies:
       '@ampproject/remapping': 2.2.1
       '@bcoe/v8-coverage': 0.2.3
@@ -1718,44 +1714,43 @@ packages:
       picocolors: 1.0.0
       std-env: 3.7.0
       test-exclude: 6.0.0
-      v8-to-istanbul: 9.2.0
-      vitest: 1.3.1(@types/node@18.16.19)
+      vitest: 1.6.0(@types/node@18.16.19)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@vitest/expect@1.3.1:
-    resolution: {integrity: sha512-xofQFwIzfdmLLlHa6ag0dPV8YsnKOCP1KdAeVVh34vSjN2dcUiXYCD9htu/9eM7t8Xln4v03U9HLxLpPlsXdZw==}
+  /@vitest/expect@1.6.0:
+    resolution: {integrity: sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==}
     dependencies:
-      '@vitest/spy': 1.3.1
-      '@vitest/utils': 1.3.1
+      '@vitest/spy': 1.6.0
+      '@vitest/utils': 1.6.0
       chai: 4.4.1
     dev: true
 
-  /@vitest/runner@1.3.1:
-    resolution: {integrity: sha512-5FzF9c3jG/z5bgCnjr8j9LNq/9OxV2uEBAITOXfoe3rdZJTdO7jzThth7FXv/6b+kdY65tpRQB7WaKhNZwX+Kg==}
+  /@vitest/runner@1.6.0:
+    resolution: {integrity: sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==}
     dependencies:
-      '@vitest/utils': 1.3.1
+      '@vitest/utils': 1.6.0
       p-limit: 5.0.0
       pathe: 1.1.2
     dev: true
 
-  /@vitest/snapshot@1.3.1:
-    resolution: {integrity: sha512-EF++BZbt6RZmOlE3SuTPu/NfwBF6q4ABS37HHXzs2LUVPBLx2QoY/K0fKpRChSo8eLiuxcbCVfqKgx/dplCDuQ==}
+  /@vitest/snapshot@1.6.0:
+    resolution: {integrity: sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==}
     dependencies:
       magic-string: 0.30.5
       pathe: 1.1.2
       pretty-format: 29.7.0
     dev: true
 
-  /@vitest/spy@1.3.1:
-    resolution: {integrity: sha512-xAcW+S099ylC9VLU7eZfdT9myV67Nor9w9zhf0mGCYJSO+zM2839tOeROTdikOi/8Qeusffvxb/MyBSOja1Uig==}
+  /@vitest/spy@1.6.0:
+    resolution: {integrity: sha512-leUTap6B/cqi/bQkXUu6bQV5TZPx7pmMBKBQiI0rJA8c3pB56ZsaTbREnF7CJfmvAS4V2cXIBAh/3rVwrrCYgw==}
     dependencies:
       tinyspy: 2.2.0
     dev: true
 
-  /@vitest/utils@1.3.1:
-    resolution: {integrity: sha512-d3Waie/299qqRyHTm2DjADeTaNdNSVsnwHPWrs20JMpjh6eiVq7ggggweO8rc4arhf6rRkWuHKwvxGvejUXZZQ==}
+  /@vitest/utils@1.6.0:
+    resolution: {integrity: sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==}
     dependencies:
       diff-sequences: 29.6.3
       estree-walker: 3.0.3
@@ -6871,15 +6866,6 @@ packages:
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  /v8-to-istanbul@9.2.0:
-    resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
-    engines: {node: '>=10.12.0'}
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.19
-      '@types/istanbul-lib-coverage': 2.0.4
-      convert-source-map: 2.0.0
-    dev: true
-
   /validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
     dependencies:
@@ -6920,8 +6906,8 @@ packages:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  /vite-node@1.3.1(@types/node@18.16.19):
-    resolution: {integrity: sha512-azbRrqRxlWTJEVbzInZCTchx0X69M/XPTCz4H+TLvlTcR/xH/3hkRqhOakT41fMJCMzXTu4UvegkZiEoJAWvng==}
+  /vite-node@1.6.0(@types/node@18.16.19):
+    resolution: {integrity: sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     dependencies:
@@ -6986,15 +6972,15 @@ packages:
     dependencies:
       vite: 5.0.12(@types/node@18.16.19)
 
-  /vitest@1.3.1(@types/node@18.16.19):
-    resolution: {integrity: sha512-/1QJqXs8YbCrfv/GPQ05wAZf2eakUPLPa18vkJAKE7RXOKfVHqMZZ1WlTjiwl6Gcn65M5vpNUB6EFLnEdRdEXQ==}
+  /vitest@1.6.0(@types/node@18.16.19):
+    resolution: {integrity: sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 1.3.1
-      '@vitest/ui': 1.3.1
+      '@vitest/browser': 1.6.0
+      '@vitest/ui': 1.6.0
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -7012,11 +6998,11 @@ packages:
         optional: true
     dependencies:
       '@types/node': 18.16.19
-      '@vitest/expect': 1.3.1
-      '@vitest/runner': 1.3.1
-      '@vitest/snapshot': 1.3.1
-      '@vitest/spy': 1.3.1
-      '@vitest/utils': 1.3.1
+      '@vitest/expect': 1.6.0
+      '@vitest/runner': 1.6.0
+      '@vitest/snapshot': 1.6.0
+      '@vitest/spy': 1.6.0
+      '@vitest/utils': 1.6.0
       acorn-walk: 8.3.2
       chai: 4.4.1
       debug: 4.3.4
@@ -7028,9 +7014,9 @@ packages:
       std-env: 3.7.0
       strip-literal: 2.0.0
       tinybench: 2.6.0
-      tinypool: 0.8.2
-      vite: 5.0.12(@types/node@18.16.19)
-      vite-node: 1.3.1(@types/node@18.16.19)
+      tinypool: 0.8.4
+      vite: 5.2.11(@types/node@18.16.19)
+      vite-node: 1.6.0(@types/node@18.16.19)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1302,6 +1302,13 @@ packages:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
+  /@jridgewell/trace-mapping@0.3.25:
+    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
   /@kwsites/file-exists@1.1.1:
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
     dependencies:
@@ -1707,12 +1714,13 @@ packages:
       debug: 4.3.4
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 4.0.1
+      istanbul-lib-source-maps: 5.0.4
       istanbul-reports: 3.1.6
       magic-string: 0.30.5
       magicast: 0.3.3
       picocolors: 1.0.0
       std-env: 3.7.0
+      strip-literal: 2.0.0
       test-exclude: 6.0.0
       vitest: 1.6.0(@types/node@18.16.19)
     transitivePeerDependencies:
@@ -4057,13 +4065,13 @@ packages:
       supports-color: 7.2.0
     dev: true
 
-  /istanbul-lib-source-maps@4.0.1:
-    resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
+  /istanbul-lib-source-maps@5.0.4:
+    resolution: {integrity: sha512-wHOoEsNJTVltaJp8eVkm8w+GVkVNHT2YDYo53YdzQEL2gWm1hBX5cGFR9hQJtuGLebidVX7et3+dmDZrmclduw==}
     engines: {node: '>=10'}
     dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
       debug: 4.3.4
       istanbul-lib-coverage: 3.2.2
-      source-map: 0.6.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6180,11 +6188,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
   /source-map@0.7.4:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
@@ -6574,8 +6577,8 @@ packages:
     resolution: {integrity: sha512-N8hW3PG/3aOoZAN5V/NSAEDz0ZixDSSt5b/a05iqtpgfLWMSVuCo7w0k2vVvEjdrIoeGqZzweX2WlyioNIHchA==}
     dev: true
 
-  /tinypool@0.8.2:
-    resolution: {integrity: sha512-SUszKYe5wgsxnNOVlBYO6IC+8VGWdVGZWAqUxp3UErNBtptZvWbwyUOyzNL59zigz2rCA92QiL3wvG+JDSdJdQ==}
+  /tinypool@0.8.4:
+    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -7015,7 +7018,7 @@ packages:
       strip-literal: 2.0.0
       tinybench: 2.6.0
       tinypool: 0.8.4
-      vite: 5.2.11(@types/node@18.16.19)
+      vite: 5.0.12(@types/node@18.16.19)
       vite-node: 1.6.0(@types/node@18.16.19)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:


### PR DESCRIPTION
~~**This PR is targetting #1846.**~~

#### Description

This PR updates the Vitest version used in the monorepo to the latest version instead of the initial `1.4.0` bump due to a test failure.

**Why was this test failing when upgrading to at least Vitest `1.5.0`?**

- Vitest `1.5.0` introduced a [change](https://github.com/vitest-dev/vitest/pull/5476) to the workspace feature current working directory (`cwd`) making it the config directory.
  - Using version `1.4.0`, the current working directory would be `packages/starlight/`
  - Using version `1.5.0`, the current working directory would be `packages/starlight/__tests__/i18n-non-root-single-locale/` for the `i18n-non-root-single-locale` test suite.
- Our tests use `getViteConfig()` which will internally call [`resolveConfig()`](https://github.com/withastro/astro/blob/ad9227c7d1474881fac9b1db15aa7b5a888b42b8/packages/astro/src/config/index.ts#L37) which calls [`resolveRoot()`](https://github.com/withastro/astro/blob/ad9227c7d1474881fac9b1db15aa7b5a888b42b8/packages/astro/src/core/config/config.ts#L190) with an `undefined` argument which would end up using [`process.cwd()`](https://github.com/withastro/astro/blob/ad9227c7d1474881fac9b1db15aa7b5a888b42b8/packages/astro/src/core/config/config.ts#L73C35-L73C48).
- With Astro now using `packages/starlight/__tests__/i18n-non-root-single-locale/` as the root, `packages/starlight/__tests__/i18n-non-root-single-locale/src/content/i18n/fr.json` would be automatically loaded when we call `getCollection()` which was not the case before.

**Why is only the `i18n-non-root-single-locale` test suite failing and not the `i18n` test suite which uses a similar setup?**

- The `i18n` test suite is not impacted because the default locale is `en` but is configured with a `lang` using a regional subtag (`en-US`) which means the user config overrides needs to be in for `en-US` and thus not being impacted by `en.json` being loaded.

**How is this PR fixing the issue?**

- This PR updates the `i18n-non-root-single-locale` test suite to use the `fr-CA` for the `lang` of the default locale to use the same setup as the `i18n` test suite.

**What alternatives were considered?**

- Using Astro 4.8.0 `getViteConfig()` new second argument to specify the `root` in the inline Astro config to fallback to the previous behavior and avoid using `process.cwd()` but I think this is wrong to just assume the CWD is not the root of the test suite.
- Moving out the `packages/starlight/__tests__/i18n-non-root-single-locale/translations-fs.test.ts` to another dedicated suite (where we do not mix real CC files and CC mocking). I think this is a valid one but we would need I think to do the same for the `i18n` test suite which is not failing. I think it's better to have a consistent setup for all the test suites but I'm open to feedback on this.

**Why are the `.gitignore` changes in this PR required?**

By Astro now using the proper root, and `getViteConfig()` somehow triggering someting close to `astro sync`, we end up with all the extra files in each test suites instead of just `packages/starlight/` like before when this folder was considered the CWD.