### PR TITLE
i18n(fr): update `reference/overrides`

### DIFF
--- a/docs/src/content/docs/fr/reference/overrides.md
+++ b/docs/src/content/docs/fr/reference/overrides.md
@@ -56,6 +56,13 @@ Le chemin de base utilisé pour servir une langue. `undefined` pour les slugs de
 
 Le titre du site pour la langue de cette page.
 
+#### `siteTitleHref`
+
+**Type :** `string`
+
+La valeur de l’attribut `href` du titre du site, renvoyant à la page d'accueil, par exemple `/`.
+Pour les sites multilingues, cette valeur inclura la locale actuelle, par exemple `/fr/` ou `/zh-cn/`.
+
 #### `slug`
 
 **Type :** `string`


### PR DESCRIPTION
#### Description

This PR updates the French version of the `reference/overrides` page with the changes of #1842.