### PR TITLE
css: move overflow wrap rule to `markdown.css`

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting Started
+title: Getting Started xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx xxxxx xxxx
 description: Learn how to start building your next documentation site with Starlight by Astro.
 ---
 

--- a/packages/starlight/style/markdown.css
+++ b/packages/starlight/style/markdown.css
@@ -1,3 +1,15 @@
+.sl-markdown-content p,
+.sl-markdown-content h1,
+.sl-markdown-content h2,
+.sl-markdown-content h3,
+.sl-markdown-content h4,
+.sl-markdown-content h5,
+.sl-markdown-content h6,
+.sl-markdown-content code {
+	background-color: rgba(0, 255, 0, 0.2);
+	overflow-wrap: anywhere;
+}
+
 .sl-markdown-content
 	:not(a, strong, em, del, span, input, code)
 	+ :not(a, strong, em, del, span, input, code, :where(.not-content *)) {

--- a/packages/starlight/style/reset.css
+++ b/packages/starlight/style/reset.css
@@ -40,7 +40,7 @@ h4,
 h5,
 h6,
 code {
-	overflow-wrap: anywhere;
+	background-color: rgba(255, 0, 0, 0.2);
 }
 
 code {

--- a/packages/starlight/translations/en.json
+++ b/packages/starlight/translations/en.json
@@ -11,7 +11,7 @@
   "languageSelect.accessibleLabel": "Select language",
   "menuButton.accessibleLabel": "Menu",
   "sidebarNav.accessibleLabel": "Main",
-  "tableOfContents.onThisPage": "On this page",
+  "tableOfContents.onThisPage": "On this page xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx xxxxx xxxxxxxx",
   "tableOfContents.overview": "Overview",
   "i18n.untranslatedContent": "This content is not available in your language yet.",
   "page.editLink": "Edit page",


### PR DESCRIPTION
⚠️ This PR is a draft

---

## Description

This PR is a follow-up of what's been discussed in https://github.com/withastro/starlight/pull/1736#pullrequestreview-2060043908

> I do wonder if our generic set-up for this in reset.css ought really also to be moved to markdown.css:
> [...]
> In a quick check, I think the only element this currently applies to which is outside of the Markdown content is the page title.
> But that can happen as follow-up work to keep this PR focused on the specific fix.

Basically, we move the `p ,h1, h2, h3, h4, h5, h6, code { overflow-wrap: anywhere; }` rule to the `markdown.css`.

Temporarily, the red code shows the elements impacted by the previous rule, and the green one shows the elements impacted by the new rule.