### PR TITLE
Micro-optimization: clean up `<details>` CSS

### DIFF
--- a/.changeset/silly-tools-drop.md
+++ b/.changeset/silly-tools-drop.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Internal refactor: simplify some CSS for the `<details>` element

--- a/packages/starlight/style/markdown.css
+++ b/packages/starlight/style/markdown.css
@@ -128,7 +128,7 @@
 }
 .sl-markdown-content details:not([open]):hover:not(:where(.not-content *)),
 .sl-markdown-content details:has(> summary:hover):not(:where(.not-content *)) {
-	--sl-details-border-color: var(--sl-details-border-color--hover);
+	border-color: var(--sl-details-border-color--hover);
 }
 .sl-markdown-content summary:not(:where(.not-content *)) {
 	color: var(--sl-color-white);

--- a/packages/starlight/style/markdown.css
+++ b/packages/starlight/style/markdown.css
@@ -121,13 +121,14 @@
 /* <details> and <summary> styles */
 .sl-markdown-content details:not(:where(.not-content *)) {
 	--sl-details-border-color: var(--sl-color-gray-5);
+	--sl-details-border-color--hover: var(--sl-color-text-accent);
 
 	border-inline-start: 2px solid var(--sl-details-border-color);
 	padding-inline-start: 1rem;
 }
 .sl-markdown-content details:not([open]):hover:not(:where(.not-content *)),
 .sl-markdown-content details:has(> summary:hover):not(:where(.not-content *)) {
-	--sl-details-border-color: var(--sl-color-text-accent);
+	--sl-details-border-color: var(--sl-details-border-color--hover);
 }
 .sl-markdown-content summary:not(:where(.not-content *)) {
 	color: var(--sl-color-white);
@@ -182,8 +183,5 @@
 /* <details> styles inside asides */
 .sl-markdown-content .starlight-aside details:not(:where(.not-content *)) {
 	--sl-details-border-color: var(--sl-color-asides-border);
-}
-.sl-markdown-content .starlight-aside details:not([open]):hover:not(:where(.not-content *)),
-.sl-markdown-content .starlight-aside details:has(> summary:hover):not(:where(.not-content *)) {
-	--sl-details-border-color: var(--sl-color-asides-text-accent);
+	--sl-details-border-color--hover: var(--sl-color-asides-text-accent);
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- I realised we could simplify the CSS for the `<details>` element a little bit by avoiding to repeat the hover selector logic when setting the custom colours inside asides
- Also makes it a bit easier for customisation. For example, in Astro Docs I wanted to add [an extra custom colour](https://github.com/withastro/docs/pull/8322/commits/1cd6c34daf49e76c3cc1b0579c561d3b2e8db3cd) where we have `<details>` in a purple container. Currently that requires duplicating (again) the `:hover` selectors. With this change it can be done just with the two custom properties.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
