### PR TITLE
Fix Tailwind `font-family` reset when using Starlight plugin

### DIFF
--- a/.changeset/fresh-plums-bow.md
+++ b/.changeset/fresh-plums-bow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight-tailwind': patch
+---
+
+Fixes default `font-family` in non-Starlight pages when using Tailwind plugin

--- a/packages/tailwind/__tests__/tailwind.test.ts
+++ b/packages/tailwind/__tests__/tailwind.test.ts
@@ -37,6 +37,12 @@ describe('@tailwind base;', async () => {
 			::before, ::after {
 			    --tw-content: ;
 			}
+			html, :host {
+			    font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+			}
+			code, kbd, samp, pre {
+			    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+			}
 			:root {
 			    --sl-font: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 			    --sl-font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
@@ -104,6 +110,12 @@ describe('@tailwind base;', async () => {
 			}
 			::before, ::after {
 			    --tw-content: ;
+			}
+			html, :host {
+			    font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+			}
+			code, kbd, samp, pre {
+			    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 			}
 			:root {
 			    --sl-font: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";

--- a/packages/tailwind/index.ts
+++ b/packages/tailwind/index.ts
@@ -68,6 +68,9 @@ const StarlightTailwindPlugin = () =>
 					borderColor: theme('borderColor.DEFAULT', 'currentColor'),
 				},
 				'::before, ::after': { '--tw-content': '' },
+				// Keep base font-family styles even in non-Starlight pages.
+				'html, :host': { 'font-family': theme('fontFamily.sans') },
+				'code, kbd, samp, pre': { 'font-family': theme('fontFamily.mono') },
 
 				// Wire up Starlight theme to use Tailwind config.
 				':root': {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #1651
- Ensures a default `font-family` style is present even in non-Starlight pages.
- Currently we only set `--sl-font` and then rely on Starlight’s CSS to apply it, but we can safely add this for Tailwind users to make their lives easier.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
