### PR TITLE
Use `directory`-style path formatting with `build.format: 'preserve'`

### DIFF
--- a/.changeset/curvy-pots-ring.md
+++ b/.changeset/curvy-pots-ring.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes support for Astro’s `build: { format: 'preserve' }` configuration option

--- a/packages/starlight/utils/createPathFormatter.ts
+++ b/packages/starlight/utils/createPathFormatter.ts
@@ -12,15 +12,18 @@ interface FormatPathOptions {
 	trailingSlash?: AstroConfig['trailingSlash'];
 }
 
+const defaultFormatStrategy = {
+	addBase: pathWithBase,
+	handleExtension: (href: string) => stripHtmlExtension(href),
+};
+
 const formatStrategies = {
 	file: {
 		addBase: fileWithBase,
 		handleExtension: (href: string) => ensureHtmlExtension(href),
 	},
-	directory: {
-		addBase: pathWithBase,
-		handleExtension: (href: string) => stripHtmlExtension(href),
-	},
+	directory: defaultFormatStrategy,
+	preserve: defaultFormatStrategy,
 };
 
 const trailingSlashStrategies = {
@@ -34,7 +37,6 @@ function formatPath(
 	href: string,
 	{ format = 'directory', trailingSlash = 'ignore' }: FormatPathOptions
 ) {
-	// @ts-expect-error — TODO: add support for `preserve` (https://github.com/withastro/starlight/issues/1781)
 	const formatStrategy = formatStrategies[format];
 	const trailingSlashStrategy = trailingSlashStrategies[trailingSlash];
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Fixes #1781
- Astro v4.3 added the `build: { format: 'preserve' }` config option, which we haven’t been handling up until now. 
- I tested using this option and Starlight still produces files like `guides/example/index.html` for all its pages. Given this, it seemed safest to treat this the same way we treat `build: { format: 'directory' }` and render links as `guides/example/`.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
