### PR TITLE
docs: add `starlight-package-managers` & `starlight-showcases` to the community resources

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -98,4 +98,14 @@ These community tools and integrations can be used to add features to your Starl
 		title="starlight-i18n"
 		description="Visual Studio Code extension to help translate Starlight pages."
 	/>
+	<LinkCard
+		href="https://github.com/HiDeoo/starlight-package-managers"
+		title="starlight-package-managers"
+		description="Quickly display npm related commands for multiple package managers."
+	/>
+	<LinkCard
+		href="https://github.com/HiDeoo/starlight-showcases"
+		title="starlight-showcases"
+		description="Set of Starlight components to author showcase pages."
+	/>
 </CardGrid>


### PR DESCRIPTION
#### Description

This pull request adds [`starlight-package-managers`](https://github.com/HiDeoo/starlight-package-managers) & [`starlight-showcases`](https://github.com/HiDeoo/starlight-showcases) to the list of community resources.