### PR TITLE
Enforce style containment to `<Steps>` list items

### DIFF
--- a/.changeset/cuddly-bugs-count.md
+++ b/.changeset/cuddly-bugs-count.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes a `<Steps>` component numbering issue with the next Chrome stable version when a step contains a nested list.

--- a/packages/starlight/user-components/Steps.astro
+++ b/packages/starlight/user-components/Steps.astro
@@ -23,6 +23,8 @@ const { html } = processSteps(content);
 		padding-bottom: 1px;
 		/* Prevent bullets from touching in short list items. */
 		min-height: calc(var(--bullet-size) + var(--bullet-margin));
+		/* Enforce style containment so that nested lists CSS counters are scoped to the contained element. */
+		contain: style;
 	}
 	.sl-steps > li + li {
 		/* Remove margin between steps. */


### PR DESCRIPTION
#### Description

This pull request enforces style containment to the `<Steps>` component list items.

Even tho this change was not technically required until now, Chrome 126 having an Early Stable release date sets to [Wed, Jun 5, 2024](https://chromiumdash.appspot.com/schedule) breaks the current implementation.

Any `<Steps>` component containing a nested list items (Markdown/HTML list, tabs, file tree, etc.) will have its counter broken. Here is an [example](https://starlight.astro.build/guides/css-and-tailwind/#add-tailwind-to-an-existing-project) from the Starlight documentation with this change:

<img width="757" alt="image" src="https://github.com/withastro/starlight/assets/494699/b3239ae6-4448-4001-a444-fa01aabc62f2">

The change is probably part of Chrome [re-write](https://issues.chromium.org/issues/40638899) of CSS counters and ordered list numbering code but it's a bit difficult to figure out if the behavior is a bug or a proper implementation of the spec considering the `whatwg` repository contains many issues related to this topic, some efforts have been done to clarify the behavior but it's still a bit unclear and there seems to be some exceptions when the default counter (the one we use) is read from a `::before` pseudo element.

I'll open an issue in the Chromium tracker altho, even if it ends up being a bug, a fix will probably take a while to be released (Wed, Aug 14, 2024 at the earliest) so I think it's better to enforce the [style containment](https://developer.mozilla.org/en-US/docs/Web/CSS/contain#style_containment) now considering it's the behavior we want.

Note that to reproduce the issue, you need at least Chrome Beta (126 at the time of the PR).
