### PR TITLE
Remove `<Steps>` component style containment

### DIFF
--- a/.changeset/spotty-points-begin.md
+++ b/.changeset/spotty-points-begin.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Reverts a [change](https://github.com/withastro/starlight/pull/1948) to prevent a numbering issue with the `<Steps>` component in future versions of Chrome.

--- a/packages/starlight/user-components/Steps.astro
+++ b/packages/starlight/user-components/Steps.astro
@@ -23,8 +23,6 @@ const { html } = processSteps(content);
 		padding-bottom: 1px;
 		/* Prevent bullets from touching in short list items. */
 		min-height: calc(var(--bullet-size) + var(--bullet-margin));
-		/* Enforce style containment so that nested lists CSS counters are scoped to the contained element. */
-		contain: style;
 	}
 	.sl-steps > li + li {
 		/* Remove margin between steps. */


### PR DESCRIPTION
#### Description

- Closes #1953

This pull request reverts #1948 which seems to break on some older stable versions of Chrome. Surprisingly, this repro for me on Windows Chrome 125 but not on Mac Chrome 125…

The annoying part is that at the moment, I don't have another fix for the issue addressed in #1948.