### PR TITLE
i18n(fr): improve root locale related content translation

### DIFF
--- a/docs/src/content/docs/fr/guides/i18n.mdx
+++ b/docs/src/content/docs/fr/guides/i18n.mdx
@@ -69,11 +69,11 @@ Starlight offre une prise en charge intégrée des sites multilingues, y compris
 
 Pour les scénarios i18n plus avancés, Starlight prend également en compte la configuration de l'internationalisation à l'aide de l'option de [configuration `i18n` d'Astro](https://docs.astro.build/fr/guides/internationalization/#configure-i18n-routing).
 
-### Utiliser une racine locale
+### Utiliser une locale racine
 
-Vous pouvez utiliser une “racine” locale pour servir une langue sans aucun préfixe i18n dans son chemin. Par exemple, si l'anglais est votre racine locale, le chemin d'une page en anglais ressemblera à `/about` au lieu de `/en/about`.
+Vous pouvez utiliser une locale « racine » pour servir une langue sans aucun préfixe i18n dans son chemin. Par exemple, si l'anglais est votre locale racine, le chemin d'une page en anglais ressemblera à `/about` au lieu de `/en/about`.
 
-Pour définir une racine locale, utilisez la clé `root` dans votre configuration `locales`. Si la racine locale est aussi la locale par défaut de votre contenu, supprimez `defaultLocale` ou donnez-lui la valeur `'root''.
+Pour définir une locale racine, utilisez la clé `root` dans votre configuration `locales`. Si la locale racine est aussi la locale par défaut de votre contenu, supprimez `defaultLocale` ou donnez-lui la valeur `'root'`.
 
 ```js {9,11-14}
 // astro.config.mjs
@@ -88,7 +88,7 @@ export default defineConfig({
 			locales: {
 				root: {
 					label: 'English',
-					lang: 'en', // lang est nécessaire pour les locales de la racine
+					lang: 'en', // lang est nécessaire pour les locales racine
 				},
 				'zh-cn': {
 					label: '简体中文',
@@ -100,7 +100,7 @@ export default defineConfig({
 });
 ```
 
-Lorsque vous utilisez une locale `root`, gardez les pages pour cette langue directement dans `src/content/docs/` au lieu d'un dossier dédié à la langue. Par exemple, voici les fichiers de la page d'accueil pour l'anglais et le chinois en utilisant la configuration ci-dessus :
+Lorsque vous utilisez une locale racine avec la clé `root`, conservez les pages de cette langue directement dans `src/content/docs/` au lieu d'un dossier dédié à cette langue. Par exemple, voici les fichiers de la page d'accueil pour l'anglais et le chinois en utilisant la configuration ci-dessus :
 
 <FileTree>
 

--- a/docs/src/content/docs/fr/reference/configuration.mdx
+++ b/docs/src/content/docs/fr/reference/configuration.mdx
@@ -290,7 +290,7 @@ Le sens d'écriture de cette langue ; `"ltr"` pour gauche à droite (par défaut
 
 #### Locale racine
 
-Vous pouvez servir la langue par défaut sans répertoire `/lang/` en définissant une locale `root` :
+Vous pouvez servir la langue par défaut sans répertoire `/lang/` en définissant une locale avec la clé `root` :
 
 ```js {3-6}
 starlight({
@@ -314,7 +314,7 @@ Par exemple, cela vous permet de servir `/getting-started/` comme une route angl
 
 Définit la langue par défaut pour ce site.
 La valeur doit correspondre à l'une des clés de votre objet [`locales`](#locales).
-(Si votre langue par défaut est votre [root locale](#locale-racine), vous pouvez sauter cette étape).
+(Si votre langue par défaut est votre [locale racine](#locale-racine), vous pouvez sauter cette étape).
 
 La locale par défaut sera utilisée pour fournir un contenu de remplacement lorsque les traductions sont manquantes.
 


### PR DESCRIPTION
#### Description

While reviewing another PR, I noticed that the French version of the documentation related to a root locale was confusing.

It was mostly referred to as "racine locale" which sounds like a "root" (the part of a plant) that would be originating from a specific place (the location). The change proposed here is to use "locale racine" instead, which avoids the confusion and is also consistent with the [version](https://starlight.astro.build/fr/reference/configuration/#locale-racine) already used in the configuration reference.