### PR TITLE
Improve locale text direction detection mechanism

### DIFF
--- a/.changeset/olive-oranges-poke.md
+++ b/.changeset/olive-oranges-poke.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes issues with the locale text direction detection mechanism in some environments like WebContainers or Bun.

--- a/packages/starlight/__tests__/basics/i18n.test.ts
+++ b/packages/starlight/__tests__/basics/i18n.test.ts
@@ -280,7 +280,7 @@ describe('getLocaleDir', () => {
 		expect(starlightConfig.defaultLocale.dir).toBe('rtl');
 	});
 
-	test.only('fallbacks to a list of well-known RTL languages when `textInfo` and `getTextInfo()` are not available', async () => {
+	test('fallbacks to a list of well-known RTL languages when `textInfo` and `getTextInfo()` are not available', async () => {
 		// @ts-expect-error - We are simulating the absence of `textInfo` and `getTextInfo()`.
 		vi.spyOn(global.Intl, 'Locale').mockImplementation((tag) => ({ language: tag }));
 

--- a/packages/starlight/__tests__/basics/i18n.test.ts
+++ b/packages/starlight/__tests__/basics/i18n.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, expect, test } from 'vitest';
+import { assert, describe, expect, test, vi } from 'vitest';
 import config from 'virtual:starlight/user-config';
 import { processI18nConfig, pickLang } from '../../utils/i18n';
 import type { AstroConfig } from 'astro';
@@ -247,6 +247,54 @@ describe('processI18nConfig', () => {
 				expect(astroI18nConfig).toEqual(astroI18nConfig);
 			}
 		);
+	});
+});
+
+describe('getLocaleDir', () => {
+	test('uses the Node.js implementation to figure out the text direction', () => {
+		const { starlightConfig } = processI18nConfig(
+			config,
+			getAstroI18nTestConfig({
+				defaultLocale: 'en',
+				locales: ['en'],
+			})
+		);
+
+		expect(starlightConfig.defaultLocale.dir).toBe('ltr');
+	});
+
+	test('uses `getTextInfo()` when `textInfo` is not available', async () => {
+		// @ts-expect-error - `getTextInfo` is not typed but is available in some non-v8 based environments.
+		vi.spyOn(global.Intl, 'Locale').mockImplementation(() => ({
+			getTextInfo: () => ({ direction: 'rtl' }),
+		}));
+
+		const { starlightConfig } = processI18nConfig(
+			config,
+			getAstroI18nTestConfig({
+				defaultLocale: 'en',
+				locales: ['en'],
+			})
+		);
+
+		expect(starlightConfig.defaultLocale.dir).toBe('rtl');
+	});
+
+	test.only('fallbacks to a list of well-known RTL languages when `textInfo` and `getTextInfo()` are not available', async () => {
+		// @ts-expect-error - We are simulating the absence of `textInfo` and `getTextInfo()`.
+		vi.spyOn(global.Intl, 'Locale').mockImplementation((tag) => ({ language: tag }));
+
+		const { starlightConfig } = processI18nConfig(
+			config,
+			getAstroI18nTestConfig({
+				defaultLocale: 'en',
+				locales: ['en', 'fa'],
+			})
+		);
+
+		expect(starlightConfig.defaultLocale.dir).toBe('ltr');
+		expect(starlightConfig.locales?.root?.dir).toBe('ltr');
+		expect(starlightConfig.locales?.fa?.dir).toBe('rtl');
 	});
 });
 

--- a/packages/starlight/utils/i18n.ts
+++ b/packages/starlight/utils/i18n.ts
@@ -175,10 +175,10 @@ function getLocaleInfo(lang: string) {
  */
 function getLocaleDir(locale: Intl.Locale): 'ltr' | 'rtl' {
 	if ('textInfo' in locale) {
-		// @ts-expect-error - `textInfo` is typed but is available in v8 based environments.
+		// @ts-expect-error - `textInfo` is not typed but is available in v8 based environments.
 		return locale.textInfo.direction;
 	} else if ('getTextInfo' in locale) {
-		// @ts-expect-error - `getTextInfo` is typed but is available in some non-v8 based environments.
+		// @ts-expect-error - `getTextInfo` is not typed but is available in some non-v8 based environments.
 		return locale.getTextInfo().direction;
 	}
 	// Firefox does not support `textInfo` or `getTextInfo` yet so we fallback to a well-known list


### PR DESCRIPTION
#### Description

- Closes #1961 and #1986

The newly locale text direction detection mechanism introduced in Starlight `0.24.0` is based on the v8 implementation of [`getTextInfo()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTextInfo) where it is implemented as an accessor property (`textInfo`).

#1961 and #1986 surfaced that this broke in Bun which respects the spec and implements `getTextInfo()` as a method.

This is also an issue when running Starlight in a WebContainers, e.g. StackBlitz, where the implementation can vary between browsers.

- v8 based browsers do not follow the spec and implement `getTextInfo()` as an accessor property.
- Safari properly uses `getTextInfo()` as a method.
- Firefox does not support `getTextInfo()` or `textInfo`.

To handle with all these cases, the new version will use the following mechanism to detect the text direction:

1. Try to access `textInfo` as an accessor property.
2. If it fails, fallback to `getTextInfo()` as a method.
3. If it fails, fallback to a well-known list of RTL locales.

Here are some screenshots of the checks in the Node.js and Bun REPLs:

<img width="243" alt="SCR-20240609-lhsm" src="https://github.com/withastro/starlight/assets/494699/bc1a64ba-cd0f-45aa-8175-e39a2f3da0af">
<img width="616" alt="SCR-20240609-libc" src="https://github.com/withastro/starlight/assets/494699/a4aeb9d2-c557-4e72-8f78-4dc85125b264">

Regarding the list of well-known RTL locales, I picked all the RTL languages from this [list of common primary language subtags](https://en.wikipedia.org/wiki/IETF_language_tag#List_of_common_primary_language_subtags).