### PR TITLE
Ensure link to current page is visible in sidebar

### DIFF
--- a/packages/starlight/components/SidebarSublist.astro
+++ b/packages/starlight/components/SidebarSublist.astro
@@ -18,6 +18,7 @@ const { sublist, nested } = Astro.props;
 				{entry.type === 'link' ? (
 					<a
 						href={entry.href}
+						data-sl-current-page-link={entry.isCurrent}
 						aria-current={entry.isCurrent && 'page'}
 						class:list={[{ large: !nested }, entry.attrs.class]}
 						{...entry.attrs}
@@ -55,6 +56,34 @@ const { sublist, nested } = Astro.props;
 		))
 	}
 </ul>
+
+{
+	// Only include the script on the top level, once per page
+	!nested && (
+		<script>
+			// This little script makes sure that the sidebar link for the
+			// curent page is visible.
+
+			document.addEventListener("DOMContentLoaded", () => {
+				const linkElement = document.querySelector("[data-sl-current-page-link]");
+				if (!linkElement) return;
+
+				// Use an intersection observer to make sure that we
+				// only scroll if the link isn't visible
+				const observer = new IntersectionObserver((entries, observer)=>{
+					if (entries[0] && !entries[0].isIntersecting) {
+						// This can be changed to "smooth" if desig
+						linkElement.scrollIntoView({ behavior: "instant" })
+					}
+
+					// Shut down the observer after the first time it fires
+					observer.disconnect();
+				});
+				observer.observe(linkElement);
+			})
+		</script>
+	)
+}
 
 <style>
 	ul {

--- a/packages/starlight/components/SidebarSublist.astro
+++ b/packages/starlight/components/SidebarSublist.astro
@@ -72,7 +72,7 @@ const { sublist, nested } = Astro.props;
 				// only scroll if the link isn't visible
 				const observer = new IntersectionObserver((entries, observer)=>{
 					if (entries[0] && !entries[0].isIntersecting) {
-						// This can be changed to "smooth" if desig
+						// This can be changed to "smooth" if desired
 						linkElement.scrollIntoView({ behavior: "instant" })
 					}
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

When navigating sites with long sidebars (like the Astro docs), it can be quite disorientating when you click on a link and suddenly lose the context of where you are in the sidebar because it disappears. I see this behaviour in Firefox 126 and Chrome canary, so I assume it isn't just a browser quirk.

This PR solves the problem by adding a little script that is injected with the top-level sidebar. The script checks if the sidebar link to the current page is visible, and if it isn't, it is scrolled into view.

I have it set to jump instantly, but it could be jarring if the page loads really slowly. If this proves to be an issue, you could consider changing the behaviour to `"smooth"`. This can be annoying if you see it happen on every page load though.

It seems like Vite isn't processing the script right now, which is probably because of my conditional rendering of it. I  assume we want Vite to process it, but it could also be bad if it causes the JS to be loaded externally. I'd appreciate some guidance here.