### PR TITLE
Git ignore Playwright test results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ pnpm-debug.log*
 # Vitest
 __coverage__/
 
+# Playwright
+test-results/
+
 # Vercel output
 .vercel
 


### PR DESCRIPTION
#### Description

In #2007, Playwright was updated from the version `1.43.1` to the version `1.44.1`. The version [`v1.44.0`](https://github.com/microsoft/playwright/releases/tag/v1.44.0) adds a new `--last-failed` CLI option to run only tests that failed in the previous run. To support this feature, Playwright saves some state in `packages/starlight/test-results/.last-run.json`.

This PR adds the `test-results/` directory to the `.gitignore` file (which could technically have been done since we started using Playwright but we don't have any tests generating artifacts yet).