### PR TITLE
Fix search modal height in Safari

### DIFF
--- a/.changeset/curly-swans-clean.md
+++ b/.changeset/curly-swans-clean.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes a search dialog height issue in Safari.

--- a/packages/starlight/components/Search.astro
+++ b/packages/starlight/components/Search.astro
@@ -197,7 +197,7 @@ const pagefindTranslations = {
 		box-shadow: var(--sl-shadow-lg);
 	}
 	dialog[open] {
-		display: grid;
+		display: flex;
 	}
 
 	dialog::backdrop {
@@ -208,6 +208,7 @@ const pagefindTranslations = {
 
 	.dialog-frame {
 		flex-direction: column;
+		flex-grow: 1;
 		gap: 1rem;
 		padding: 1rem;
 	}


### PR DESCRIPTION
#### Description

This PR fixes an issue with the search modal height in Safari (probably this [issue](https://bugs.webkit.org/show_bug.cgi?id=260461) which would also apply for `max-content` and `min-content`) by removing the grid layout and using flexbox instead.

##### No search query

|        | Chrome   | Firefox  | Safari   |
| ------ | -------- | -------- | -------- |
| Before | ![chrome_before_1](https://github.com/withastro/starlight/assets/494699/e52715ed-b6a0-48d4-bba9-4b37f6d5b504) | ![firefox_before_1](https://github.com/withastro/starlight/assets/494699/bbd68be4-d6bb-44e9-afcb-2b5ca390ae4d) | <img width="1085" alt="safari_before_1" src="https://github.com/withastro/starlight/assets/494699/437d88e6-2a72-4fcf-a121-c02e005c1dcf"> |
| After  | ![chrome_after_1](https://github.com/withastro/starlight/assets/494699/05342257-f096-4aec-ba07-9398f697900f) | ![firefox_after_1](https://github.com/withastro/starlight/assets/494699/acfd7de5-70f8-407c-ba2a-8b576b6bf1c4) | ![safari_after_1](https://github.com/withastro/starlight/assets/494699/4a42486d-faa4-42fe-94a8-3fffd8a35e77) |

##### No results

|        | Chrome   | Firefox  | Safari   |
| ------ | -------- | -------- | -------- |
| Before | ![chrome_before_2](https://github.com/withastro/starlight/assets/494699/717e5f92-c23e-4d5a-b0c8-92ee7a2fe5fb) | ![firefox_before_2](https://github.com/withastro/starlight/assets/494699/87a9c054-8a71-498e-b7f8-270376265089) | <img width="1085" alt="safari_before_2" src="https://github.com/withastro/starlight/assets/494699/42bdd06a-8aaf-49a0-bb3c-0f62dd9804eb"> |
| After  | ![chrome_after_2](https://github.com/withastro/starlight/assets/494699/40671450-e725-414d-ac39-b05cd3b3687c) | ![firefox_after_2](https://github.com/withastro/starlight/assets/494699/a1162b0e-5e54-4765-80e1-0e23c109ee16) | ![safari_after_2](https://github.com/withastro/starlight/assets/494699/b7701d17-8f95-417b-8ea4-aa11e985a2ea) |

##### Some results

|        | Chrome   | Firefox  | Safari   |
| ------ | -------- | -------- | -------- |
| Before | ![chrome_before_3](https://github.com/withastro/starlight/assets/494699/da83db18-474e-481d-93d5-f903b9ca820c) | ![firefox_before_3](https://github.com/withastro/starlight/assets/494699/951d85cf-c19e-4248-bb43-26869e73c325) | <img width="1085" alt="safari_before_3" src="https://github.com/withastro/starlight/assets/494699/75891228-f1db-46c7-b6a8-5f85e981c292"> |
| After  | ![chrome_after_3](https://github.com/withastro/starlight/assets/494699/d9275b01-2e3c-467b-ba0c-ecf787ecde25) | ![firefox_after_3](https://github.com/withastro/starlight/assets/494699/ef64092e-bfc7-4697-b6f8-070937c75473) | <img width="1085" alt="safari_after_3" src="https://github.com/withastro/starlight/assets/494699/d13492b4-2e98-484d-9289-97c6a13a70da"> |

##### Some results with overflow

|        | Chrome   | Firefox  | Safari   |
| ------ | -------- | -------- | -------- |
| Before | ![chrome_before_4](https://github.com/withastro/starlight/assets/494699/bda50d34-8920-4aee-9430-fa94f99c83ed) | ![firefox_before_4](https://github.com/withastro/starlight/assets/494699/f3eea209-6e2d-47ed-98cd-7102f795acd7) | <img width="1085" alt="safari_before_4" src="https://github.com/withastro/starlight/assets/494699/8dc0e176-86a2-4475-8da9-1a7995795195"> |
| After  | ![chrome_after_4](https://github.com/withastro/starlight/assets/494699/cf3a4919-f41d-41fa-9feb-1d6145c8e270) | ![firefox_after_4](https://github.com/withastro/starlight/assets/494699/43721e21-6735-4825-91bd-317ed4646b82) | <img width="1085" alt="safari_after_4" src="https://github.com/withastro/starlight/assets/494699/6d2c539c-db94-4892-a869-273aadb27aa0"> |
