### PR TITLE
Fix usage of `<StarlightPage>` with a custom `srcDir` configuration

### DIFF
--- a/.changeset/tidy-brooms-complain.md
+++ b/.changeset/tidy-brooms-complain.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes an issue when using the `<StarlightPage>` component in a custom page with a user-defined `srcDir` configuration.

--- a/packages/starlight/__e2e__/collection-config.test.ts
+++ b/packages/starlight/__e2e__/collection-config.test.ts
@@ -1,0 +1,12 @@
+import { expect, testFactory } from './test-utils';
+
+const test = await testFactory('./fixtures/custom-src-dir/');
+
+test('builds a custom page using the `<StarlightPage>` component and a custom `srcDir`', async ({
+	page,
+	starlight,
+}) => {
+	await starlight.goto('/custom');
+
+	await expect(page.getByText('Hello')).toBeVisible();
+});

--- a/packages/starlight/__e2e__/fixtures/custom-src-dir/astro.config.mjs
+++ b/packages/starlight/__e2e__/fixtures/custom-src-dir/astro.config.mjs
@@ -1,0 +1,11 @@
+import starlight from '@astrojs/starlight';
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	srcDir: './www',
+	integrations: [
+		starlight({
+			title: 'Custom src directory',
+		}),
+	],
+});

--- a/packages/starlight/__e2e__/fixtures/custom-src-dir/package.json
+++ b/packages/starlight/__e2e__/fixtures/custom-src-dir/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@e2e/custom-src-dir",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@astrojs/starlight": "workspace:*",
+    "astro": "^4.10.2"
+  }
+}

--- a/packages/starlight/__e2e__/fixtures/custom-src-dir/www/content/config.ts
+++ b/packages/starlight/__e2e__/fixtures/custom-src-dir/www/content/config.ts
@@ -1,0 +1,6 @@
+import { defineCollection } from 'astro:content';
+import { docsSchema } from '@astrojs/starlight/schema';
+
+export const collections = {
+	docs: defineCollection({ schema: docsSchema() }),
+};

--- a/packages/starlight/__e2e__/fixtures/custom-src-dir/www/env.d.ts
+++ b/packages/starlight/__e2e__/fixtures/custom-src-dir/www/env.d.ts
@@ -1,0 +1,2 @@
+/// <reference path="../.astro/types.d.ts" />
+/// <reference types="astro/client" />

--- a/packages/starlight/__e2e__/fixtures/custom-src-dir/www/pages/custom.astro
+++ b/packages/starlight/__e2e__/fixtures/custom-src-dir/www/pages/custom.astro
@@ -1,0 +1,7 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+---
+
+<StarlightPage frontmatter={{ title: 'A custom page' }}>
+	<p>Hello</p>
+</StarlightPage>

--- a/packages/starlight/integrations/virtual-user-config.ts
+++ b/packages/starlight/integrations/virtual-user-config.ts
@@ -50,7 +50,7 @@ export function vitePluginStarlightUserConfig(
 			: 'export const logos = {};',
 		'virtual:starlight/collection-config': `let userCollections;
 			try {
-				userCollections = (await import('/src/content/config.ts')).collections;
+				userCollections = (await import('${new URL('./content/config.ts', srcDir).pathname}')).collections;
 			} catch {}
 			export const collections = userCollections;`,
 		...virtualComponentModules,

--- a/packages/starlight/playwright.config.ts
+++ b/packages/starlight/playwright.config.ts
@@ -12,4 +12,5 @@ export default defineConfig({
 		},
 	],
 	testMatch: '__e2e__/*.test.ts',
+	workers: 1,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,15 @@ importers:
         specifier: ^4.10.2
         version: 4.10.2(@types/node@18.16.19)(typescript@5.4.5)
 
+  packages/starlight/__e2e__/fixtures/custom-src-dir:
+    dependencies:
+      '@astrojs/starlight':
+        specifier: workspace:*
+        version: link:../../..
+      astro:
+        specifier: ^4.10.2
+        version: 4.10.2(@types/node@18.16.19)(typescript@5.4.5)
+
   packages/tailwind:
     dependencies:
       '@astrojs/starlight':


### PR DESCRIPTION
#### Description

- Closes https://github.com/HiDeoo/starlight-blog/issues/60

When using a custom page with the `<StarlightPage>` component, the user docs schema is retrived using the virtual module `virtual:starlight/collection-config` which attempts to import `/src/content/config.ts`. Altho, this does not consider the user having a custom [`srcDir`](https://docs.astro.build/en/reference/configuration-reference/#srcdir).

In such cases, trying to build the project would result in the following error:

> [vite]: Rollup failed to resolve import "/src/content/config.ts" from "virtual:starlight/collection-config".

This PR fixes the issue by taking the `srcDir` into account when importing the user docs schema.

I could not imagine a proper way to test this using a unit test so I ended up adding an e2e one instead which would fail to even build the fixture project before the fix.