### PR TITLE
fix: Add inline padding to `Select`

### DIFF
--- a/.changeset/angry-pots-yawn.md
+++ b/.changeset/angry-pots-yawn.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': minor
+---
+
+Increase theme and language select inline padding

--- a/.changeset/angry-pots-yawn.md
+++ b/.changeset/angry-pots-yawn.md
@@ -1,5 +1,5 @@
 ---
-'@astrojs/starlight': minor
+'@astrojs/starlight': patch
 ---
 
 Increase theme and language select inline padding

--- a/packages/starlight/components/Select.astro
+++ b/packages/starlight/components/Select.astro
@@ -30,7 +30,8 @@ interface Props {
 <style>
 	label {
 		--sl-label-icon-size: 0.875rem;
-		--sl-caret-size: 1.25rem;
+		--sl-caret-size: 1rem;
+		--sl-inline-padding: 0.5rem;
 		position: relative;
 		display: flex;
 		align-items: center;
@@ -62,8 +63,9 @@ interface Props {
 	select {
 		border: 0;
 		padding-block: 0.625rem;
-		padding-inline: calc(var(--sl-label-icon-size) + 0.25rem) calc(var(--sl-caret-size) + 0.25rem);
-		width: var(--sl-select-width);
+		padding-inline: calc(var(--sl-label-icon-size) + var(--sl-inline-padding) + 0.25rem) calc(var(--sl-caret-size) + var(--sl-inline-padding) + 0.25rem);
+		margin-inline: calc(var(--sl-inline-padding) * -1);
+		width: calc(var(--sl-select-width) + var(--sl-inline-padding) * 2);
 		background-color: transparent;
 		text-overflow: ellipsis;
 		color: inherit;

--- a/packages/starlight/components/Select.astro
+++ b/packages/starlight/components/Select.astro
@@ -30,7 +30,7 @@ interface Props {
 <style>
 	label {
 		--sl-label-icon-size: 0.875rem;
-		--sl-caret-size: 1rem;
+		--sl-caret-size: 1.25rem;
 		--sl-inline-padding: 0.5rem;
 		position: relative;
 		display: flex;


### PR DESCRIPTION
#### Description

- Closes #1552 
- Supersedes #1939 (thanks @rgilsimoes!)
- Adds additional inline padding to the `Select` component with an equivalent negative inline margin to increase the hit area and give visual space between the outline and the contents of the component
- Does not affect existing alignment of text

Comparison:
https://github.com/withastro/starlight/assets/4117920/ed8851b1-afab-4d9c-8903-0c8c406fe26e