### PR TITLE
Tweak E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ concurrency:
 
 env:
   NODE_VERSION: 18
+  ASTRO_TELEMETRY_DISABLED: true
 
 jobs:
   unit-test:

--- a/packages/starlight/__e2e__/fixtures/basics/astro.config.mjs
+++ b/packages/starlight/__e2e__/fixtures/basics/astro.config.mjs
@@ -5,6 +5,7 @@ export default defineConfig({
 	integrations: [
 		starlight({
 			title: 'Basics',
+			pagefind: false,
 		}),
 	],
 });

--- a/packages/starlight/__e2e__/fixtures/custom-src-dir/astro.config.mjs
+++ b/packages/starlight/__e2e__/fixtures/custom-src-dir/astro.config.mjs
@@ -6,6 +6,7 @@ export default defineConfig({
 	integrations: [
 		starlight({
 			title: 'Custom src directory',
+			pagefind: false,
 		}),
 	],
 });

--- a/packages/starlight/__e2e__/test-utils.ts
+++ b/packages/starlight/__e2e__/test-utils.ts
@@ -4,6 +4,8 @@ import { build, preview } from 'astro';
 
 export { expect, type Locator } from '@playwright/test';
 
+process.env.ASTRO_TELEMETRY_DISABLED = 'true';
+
 // Setup a test environment that will build and start a preview server for a given fixture path and
 // provide a Starlight Playwright fixture accessible from within all tests.
 export async function testFactory(fixturePath: string) {

--- a/packages/starlight/package.json
+++ b/packages/starlight/package.json
@@ -180,7 +180,7 @@
   },
   "devDependencies": {
     "@astrojs/markdown-remark": "^5.1.0",
-    "@playwright/test": "^1.44.1",
+    "@playwright/test": "^1.45.0",
     "@types/node": "^18.16.19",
     "@vitest/coverage-v8": "^1.6.0",
     "astro": "^4.10.2",

--- a/packages/starlight/playwright.config.ts
+++ b/packages/starlight/playwright.config.ts
@@ -12,5 +12,6 @@ export default defineConfig({
 		},
 	],
 	testMatch: '__e2e__/*.test.ts',
+	timeout: 40 * 1_000,
 	workers: 1,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,8 +195,8 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
       '@playwright/test':
-        specifier: ^1.44.1
-        version: 1.44.1
+        specifier: ^1.45.0
+        version: 1.45.0
       '@types/node':
         specifier: ^18.16.19
         version: 18.16.19
@@ -1865,12 +1865,12 @@ packages:
     dev: false
     optional: true
 
-  /@playwright/test@1.44.1:
-    resolution: {integrity: sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==}
-    engines: {node: '>=16'}
+  /@playwright/test@1.45.0:
+    resolution: {integrity: sha512-TVYsfMlGAaxeUllNkywbwek67Ncf8FRGn8ZlRdO291OL3NjG9oMbfVhyP82HQF0CZLMrYsvesqoUekxdWuF9Qw==}
+    engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      playwright: 1.44.1
+      playwright: 1.45.0
     dev: true
 
   /@rollup/rollup-android-arm-eabi@4.17.2:
@@ -5850,18 +5850,18 @@ packages:
       pathe: 1.1.2
     dev: true
 
-  /playwright-core@1.44.1:
-    resolution: {integrity: sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==}
-    engines: {node: '>=16'}
+  /playwright-core@1.45.0:
+    resolution: {integrity: sha512-lZmHlFQ0VYSpAs43dRq1/nJ9G/6SiTI7VPqidld9TDefL9tX87bTKExWZZUF5PeRyqtXqd8fQi2qmfIedkwsNQ==}
+    engines: {node: '>=18'}
     hasBin: true
     dev: true
 
-  /playwright@1.44.1:
-    resolution: {integrity: sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==}
-    engines: {node: '>=16'}
+  /playwright@1.45.0:
+    resolution: {integrity: sha512-4z3ac3plDfYzGB6r0Q3LF8POPR20Z8D0aXcxbJvmfMgSSq1hkcgvFRXJk9rUq5H/MJ0Ktal869hhOdI/zUTeLA==}
+    engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      playwright-core: 1.44.1
+      playwright-core: 1.45.0
     optionalDependencies:
       fsevents: 2.3.2
     dev: true


### PR DESCRIPTION
This PR teaks a bit our E2E tests to speed them up a little bit and avoid some failure we have started to observe on Windows due to timeouts.

I've started this investigation by comparing our setup to the Astro ones which also involves Playwright. Regarding the timeout issue, I've noticed that Astro uses a custom timeout of 40s instead of the default 30s. Maybe that's a better number for a test building a fixture and serving it (at least on Windows as Linux seems to be fine with 30s).

Here is a summary of the changes:

- Increase per-test timeout to 40s
- Disable telemetry in the entire CI workflow
- Disable telemetry when running E2E tests locally
- Disable pagefind in the E2E tests (as long as we're not explicitly testing pagefind related features, I think it's pointless to have it enabled considering we already have the docs build and the smoke docs build on Windows)
- Updated Playwright to the latest version

With all these changes, I've managed to trim down 2 seconds from the E2E tests execution time on my machine. On CI, this brings down the execution time close to 1m 7s on Linux and 3m 7s on Windows (this is the time of the entire job in this PR (which does not include a deps cache as we installed a new version of Playwright))

#### Windows

Something interesting I noted on the Windows runs is that our tests are not even that slow. For example, in the last run of this PR, our tests took 34.2s.

So what is the deal with these 3m 7s? Here is a summary of the time spent on the largest step (which runs the E2E tests):

```
# Beginnings of the step
$ playwright install --with-deps chromium && playwright test
#
# At least 1m 35s on average to install the Windows dependencies
#
#
#
# Nothing, not even some debug logs…
#
#
#
# Finally starting to download Chrome
Downloading Chromium 127.0.6533.17 (playwright build v1124) from https://playwright.azureedge.net/builds/chromium/1124/chromium-win64.zip
# And not even 10s later, starting the tests
········
  8 passed (34.2s)
```

It looks like on Windows, the main bottleneck is the installation of the dependencies. I don't think we can do much about it, it's not even flagged as unusual on the Playwright side. Maybe it's just the way it is on Windows?

One potential question is if we could cache browsers? Yes, but this is [not recommended](https://playwright.dev/docs/ci#caching-browsers) as regarding the browsers themselves, the amount of time it takes to restore the cache is comparable to the time it takes to download the binaries. And this is confirmed by the report I shared above. On Windows, downloading Chrome takes less than 10s. The issue is the installation of the dependencies which can't be cached.

Here are my thoughts on potential routes to take from here:

- Accept on Windows it takes a long time to start the tests and move on
- Stop running the E2E tests on Windows and keep them only on Linux
  - We would restrict E2E tests to visual/browser-related tests only (e.g. tabs, later on state restoration, etc.)
  - We move non-visual and non-unit tests to another kind of tests with another runner that does not install a browser on Windows (e.g. the custom `srcDir` tests and later on some SSR tests)
  - Linux time are more than fine but we could even speed them up by using a Docker image maintained by Playwright which already includes all the dependencies.

