### PR TITLE
Tweak CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     name: Run unit tests
     needs: changes
     if: ${{ needs.changes.outputs.packages == 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
@@ -72,7 +72,7 @@ jobs:
 
   type-check:
     name: Run type checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
@@ -89,7 +89,7 @@ jobs:
 
   pa11y:
     name: Check for accessibility issues
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -135,7 +135,7 @@ jobs:
     name: Check for broken links
     needs: changes
     if: ${{ needs.changes.outputs.docs == 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,27 @@ env:
   ASTRO_TELEMETRY_DISABLED: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+      packages: ${{ steps.filter.outputs.packages }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+            packages:
+              - 'packages/**'
+
   unit-test:
     name: Run unit tests
+    needs: changes
+    if: ${{ needs.changes.outputs.packages == 'true' }}
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -33,6 +52,8 @@ jobs:
 
   e2e-test:
     name: 'Run E2E tests (${{ matrix.os }})'
+    needs: changes
+    if: ${{ needs.changes.outputs.packages == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -112,6 +133,8 @@ jobs:
 
   links:
     name: Check for broken links
+    needs: changes
+    if: ${{ needs.changes.outputs.docs == 'true' }}
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout


### PR DESCRIPTION
This pull request apply some changes to the CI GitHub Actions workflow.

First, it updates all Linux jobs to use `ubuntu-latest` as the base image as before this was a mixed bag of `ubuntu-20.04` and `ubuntu-latest`.

Second, it adds a new job using [`dorny/paths-filter`](https://github.com/dorny/paths-filter) (recommended by Chris, thanks a lot) to detect changes in various directories (`docs/` and `packages/` at the moment). Later on, this new job can be used a a dependency for other jobs to only run them when changes are detected in the specified directories.

Modified jobs:

- `unit-test`: updated to only run when changes are detected in the `packages/` directory.
- `e2e-test`: updated to only run when changes are detected in the `packages/` directory.
- `links`: updated to only run when changes are detected in the `docs/` directory.

Unmodified jobs:

- `type-check`: this runs on the entire monorepo and we can introduce an error from a change in the `docs/` or `packages/` directory.
- `pa11y`: we can introduce an accessibility error from a change in the documentation (a custom component for example) or in Starlight itself.
- `windows-smoke`: I guess we can break this from either the `docs/` or `packages/` directory.