### PR TITLE
test: extend default `coverage.exclude`

### DIFF
--- a/packages/starlight/vitest.config.ts
+++ b/packages/starlight/vitest.config.ts
@@ -1,20 +1,4 @@
-import { defineConfig } from 'vitest/config';
-
-// Copy of https://github.com/vitest-dev/vitest/blob/8693449b412743f20a63fd9bfa1a9054aa74613f/packages/vitest/src/defaults.ts#L13C1-L26C1
-const defaultCoverageExcludes = [
-	'coverage/**',
-	'dist/**',
-	'packages/*/test?(s)/**',
-	'**/*.d.ts',
-	'cypress/**',
-	'test?(s)/**',
-	'test?(-*).?(c|m)[jt]s?(x)',
-	'**/*{.,-}{test,spec}.?(c|m)[jt]s?(x)',
-	'**/__tests__/**',
-	'**/__e2e__/**',
-	'**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,playwright}.config.*',
-	'**/.{eslint,mocha,prettier}rc.{?(c|m)js,yml}',
-];
+import { coverageConfigDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
@@ -22,7 +6,9 @@ export default defineConfig({
 			all: true,
 			reportsDirectory: './__coverage__',
 			exclude: [
-				...defaultCoverageExcludes,
+				...coverageConfigDefaults.exclude,
+				'**/__e2e__/**',
+				'playwright.config.*',
 				'**/vitest.*',
 				'components.ts',
 				'types.ts',


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- What does this PR change? Give us a brief description.
  - Instead of manually copying Vitest's default values, use the default values from their public API: 
    - > This option overrides all default options. Extend the default options when adding new patterns to ignore:
    - https://vitest.dev/config/#coverage-exclude

- Did you change something visual? A before/after screenshot can be helpful.
  - Nope

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
