### PR TITLE
Fix CI workflow for `main` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       packages: ${{ steps.filter.outputs.packages }}
     steps:
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:


### PR DESCRIPTION
This PR attempts to fix the `main` branch CI failure due to #2077.

Skipping checkout [seems](https://github.com/dorny/paths-filter/issues/212) to only be possible for PRs but as we're running this workflow on push to the `main` branch too, we need to checkout the code first in the `changes` job.

Extra PRs that seems to have fixed the same issue using the same solution:
- https://github.com/JuliaTime/TZJData.jl/pull/25/files
- https://github.com/bountonw/translate/pull/312/files