### PR TITLE
fix: avoid badges with `undefined` class

### DIFF
--- a/.changeset/cyan-snails-laugh.md
+++ b/.changeset/cyan-snails-laugh.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Avoid badges with `undefined` class

--- a/packages/starlight/components/SidebarSublist.astro
+++ b/packages/starlight/components/SidebarSublist.astro
@@ -26,7 +26,7 @@ const { sublist, nested } = Astro.props;
 						{entry.badge && (
 							<Badge
 								variant={entry.badge.variant}
-								class={entry.badge.class ? entry.badge.class : ''}
+								class={entry.badge.class ?? ''}
 								text={entry.badge.text}
 							/>
 						)}
@@ -41,7 +41,7 @@ const { sublist, nested } = Astro.props;
 								{entry.badge && (
 									<Badge
 										variant={entry.badge.variant}
-										class={entry.badge.class ? entry.badge.class : ''}
+										class={entry.badge.class ?? ''}
 										text={entry.badge.text}
 									/>
 								)}

--- a/packages/starlight/components/SidebarSublist.astro
+++ b/packages/starlight/components/SidebarSublist.astro
@@ -26,7 +26,7 @@ const { sublist, nested } = Astro.props;
 						{entry.badge && (
 							<Badge
 								variant={entry.badge.variant}
-								class={entry.badge.class}
+								class={entry.badge.class ? entry.badge.class : ''}
 								text={entry.badge.text}
 							/>
 						)}
@@ -41,7 +41,7 @@ const { sublist, nested } = Astro.props;
 								{entry.badge && (
 									<Badge
 										variant={entry.badge.variant}
-										class={entry.badge.class}
+										class={entry.badge.class ? entry.badge.class : ''}
 										text={entry.badge.text}
 									/>
 								)}


### PR DESCRIPTION
#### Description

In the actual Starlight documentation at https://starlight.astro.build/fr/getting-started/, the "New" badge in the sidemenu contains a class named "undefined".

![Screenshot 2024-07-04 at 13 44 01](https://github.com/withastro/starlight/assets/17381666/cd7dad76-14b9-427b-9523-1a731489b957)

This PR suggests a possible fix in the `SidebarSublist` Astro component directly to create an empty string if the `entry.badge.class` var is undefined.

Please note that:
* I'm not too much familiar with Starlight's codebase, so maybe this fix must be done at another level in the code
* there's maybe another syntax that would be better for this fix

Don't hesitate to nuke this PR or update it directly if there's a better way to fix that. I can also just close it if the quality is not there, and just create an issue instead :)