### PR TITLE
Add passed style for the Table of Contents Links

### DIFF
--- a/.changeset/metal-melons-arrive.md
+++ b/.changeset/metal-melons-arrive.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Adds a `passed` style to the Table of Contents links, allowing to further distinct where on the page you are.

--- a/packages/starlight/components/PageSidebar.astro
+++ b/packages/starlight/components/PageSidebar.astro
@@ -38,7 +38,7 @@ import TableOfContents from 'virtual:starlight/components/TableOfContents';
 		display: block;
 		font-size: var(--sl-text-xs);
 		text-decoration: none;
-		color: var(--sl-color-gray-3);
+		color: var(--sl-color-gray-2);
 		overflow-wrap: anywhere;
 	}
 	.right-sidebar-panel :global(:where(a):hover) {

--- a/packages/starlight/components/TableOfContents/TableOfContentsList.astro
+++ b/packages/starlight/components/TableOfContents/TableOfContentsList.astro
@@ -38,6 +38,9 @@ const { toc, isMobile = false, depth = 0 } = Astro.props;
 		padding-inline: calc(1rem * var(--depth) + var(--pad-inline)) var(--pad-inline);
 		line-height: 1.25;
 	}
+  a[aria-passed='true'] {
+      color: var(--sl-color-gray-3);
+  }
 	a[aria-current='true'] {
 		color: var(--sl-color-text-accent);
 	}
@@ -56,6 +59,9 @@ const { toc, isMobile = false, depth = 0 } = Astro.props;
 	}
 	.isMobile:first-child > li:first-child > a {
 		border-top: 0;
+	}
+	.isMobile a[aria-passed='true'] {
+		color: var(--sl-color-gray-3);
 	}
 	.isMobile a[aria-current='true'],
 	.isMobile a[aria-current='true']:hover,

--- a/packages/starlight/components/TableOfContents/starlight-toc.ts
+++ b/packages/starlight/components/TableOfContents/starlight-toc.ts
@@ -6,6 +6,21 @@ export class StarlightTOC extends HTMLElement {
 	private maxH = parseInt(this.dataset.maxH || '3', 10);
 
 	protected set current(link: HTMLAnchorElement) {
+		let passed = true;
+		for (const element of this.querySelectorAll('a')) {
+			if (passed && element !== link) {
+				if (element.getAttribute('aria-passed') !== 'true') {
+					element.setAttribute('aria-passed', 'true');
+				}
+			} else {
+				element.removeAttribute('aria-passed');
+			}
+
+			if (element === link) {
+				passed = false;
+			}
+		}
+
 		if (link === this._current) return;
 		if (this._current) this._current.removeAttribute('aria-current');
 		link.setAttribute('aria-current', 'true');


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

This PR adds a `passed` attribute to the links of the Table of Contents. This allows for further distinction of where exactly on the page you are. 
Additionally, to prevent the links getting too dark, the "default" color has been changed from `--sl-color-gray-3` to `--sl-color-gray-2`.

I've added this because I am porting a page from MkDocs (Material) to Starlight, and this was something that I missed with Starlight.

Before:
![Gif of how it was before](https://github.com/withastro/starlight/assets/19424922/0aaaca59-5912-4b72-9960-328fcebf9cf5)

After: 
![Gif of how it is now](https://github.com/withastro/starlight/assets/19424922/edec1723-3713-493a-b2fa-a3cf1061a711)