### PR TITLE
Fixes an edge case in custom pagination link processing

### DIFF
--- a/.changeset/small-kangaroos-smile.md
+++ b/.changeset/small-kangaroos-smile.md
@@ -1,0 +1,8 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes an edge case in custom pagination link processing
+
+Custom link values for `prev`/`next` in page frontmatter are now always used as authored.
+Previously this was not the case in some edge cases such as for the first and final pages in the sidebar.

--- a/packages/starlight/__tests__/basics/navigation.test.ts
+++ b/packages/starlight/__tests__/basics/navigation.test.ts
@@ -254,7 +254,7 @@ describe('getPrevNextLinks', () => {
 		expect(withDefaults.prev).toBeUndefined();
 		expect(withCustomLinks.prev).toEqual({
 			type: 'link',
-			href: '/x',
+			href: 'x',
 			label: 'X',
 			isCurrent: false,
 			attrs: {},

--- a/packages/starlight/__tests__/basics/pagination-with-base.test.ts
+++ b/packages/starlight/__tests__/basics/pagination-with-base.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+import type {
+	getPrevNextLinks as getPrevNextLinksType,
+	getSidebar as getSidebarType,
+} from '../../utils/navigation';
+
+vi.mock('astro:content', async () =>
+	(await import('../test-utils')).mockedAstroContent({
+		docs: [
+			['index.mdx', { title: 'Home Page' }],
+			['environmental-impact.md', { title: 'Eco-friendly docs' }],
+			['guides/authoring-content.md', { title: 'Authoring Markdown' }],
+			['guides/components.mdx', { title: 'Components' }],
+			['reference/frontmatter.md', { title: 'Frontmatter Reference' }],
+		],
+	})
+);
+
+describe('without base', async () => {
+	let getPrevNextLinks: typeof getPrevNextLinksType;
+	let getSidebar: typeof getSidebarType;
+	let sidebar: ReturnType<typeof getSidebar>;
+
+	beforeAll(async () => {
+		({ getPrevNextLinks, getSidebar } = await import('../../utils/navigation'));
+		sidebar = getSidebar('/reference/frontmatter/', undefined);
+	});
+
+	test('pagination links are formatted correctly with no frontmatter', () => {
+		const links = getPrevNextLinks(sidebar, true, {});
+		expect(links.prev?.href).toMatchInlineSnapshot(`"/guides/components/"`);
+		expect(links.next?.href).toMatchInlineSnapshot(`undefined`);
+	});
+
+	test('pagination links are formatted correctly with custom links in frontmatter', () => {
+		const links = getPrevNextLinks(sidebar, true, {
+			prev: { link: '/other-page', label: 'Other Page' },
+			next: { link: '/extra-page', label: 'Extra Page' },
+		});
+		expect(links.prev?.href).toMatchInlineSnapshot(`"/other-page"`);
+		expect(links.next?.href).toMatchInlineSnapshot(`"/extra-page"`);
+	});
+});
+
+describe('with base', () => {
+	let getPrevNextLinks: typeof getPrevNextLinksType;
+	let getSidebar: typeof getSidebarType;
+	let sidebar: ReturnType<typeof getSidebar>;
+
+	beforeAll(async () => {
+		vi.resetModules();
+		vi.stubEnv('BASE_URL', '/test-base/');
+		({ getPrevNextLinks, getSidebar } = await import('../../utils/navigation'));
+		sidebar = getSidebar('/test-base/reference/frontmatter/', undefined);
+	});
+
+	afterAll(() => {
+		vi.unstubAllEnvs();
+		vi.resetModules();
+	});
+
+	test('pagination links are formatted correctly with no frontmatter', () => {
+		const links = getPrevNextLinks(sidebar, true, {});
+		expect(links.prev?.href).toMatchInlineSnapshot(`"/test-base/guides/components/"`);
+		expect(links.next?.href).toMatchInlineSnapshot(`undefined`);
+	});
+
+	test('pagination links are formatted correctly with custom links in frontmatter', () => {
+		const links = getPrevNextLinks(sidebar, true, {
+			prev: { link: '/other-page', label: 'Other Page' },
+			next: { link: '/extra-page', label: 'Extra Page' },
+		});
+		expect(links.prev?.href).toMatchInlineSnapshot(`"/other-page"`);
+		expect(links.next?.href).toMatchInlineSnapshot(`"/extra-page"`);
+	});
+});

--- a/packages/starlight/__tests__/basics/pagination-with-base.test.ts
+++ b/packages/starlight/__tests__/basics/pagination-with-base.test.ts
@@ -26,19 +26,21 @@ describe('without base', async () => {
 		sidebar = getSidebar('/reference/frontmatter/', undefined);
 	});
 
-	test('pagination links are formatted correctly with no frontmatter', () => {
+	test('pagination links are inferred correctly with no frontmatter', () => {
 		const links = getPrevNextLinks(sidebar, true, {});
-		expect(links.prev?.href).toMatchInlineSnapshot(`"/guides/components/"`);
-		expect(links.next?.href).toMatchInlineSnapshot(`undefined`);
+		expect(links.prev?.href).toBe('/guides/components/');
+		expect(links.next?.href).toBeUndefined();
 	});
 
-	test('pagination links are formatted correctly with custom links in frontmatter', () => {
+	test('pagination links are used as authored with custom links in frontmatter', () => {
+		const prevLink = '/other-page';
+		const nextLink = '/extra-page';
 		const links = getPrevNextLinks(sidebar, true, {
-			prev: { link: '/other-page', label: 'Other Page' },
-			next: { link: '/extra-page', label: 'Extra Page' },
+			prev: { link: prevLink, label: 'Other Page' },
+			next: { link: nextLink, label: 'Extra Page' },
 		});
-		expect(links.prev?.href).toMatchInlineSnapshot(`"/other-page"`);
-		expect(links.next?.href).toMatchInlineSnapshot(`"/extra-page"`);
+		expect(links.prev?.href).toBe(prevLink);
+		expect(links.next?.href).toBe(nextLink);
 	});
 });
 
@@ -59,18 +61,20 @@ describe('with base', () => {
 		vi.resetModules();
 	});
 
-	test('pagination links are formatted correctly with no frontmatter', () => {
+	test('pagination links are inferred correctly with no frontmatter', () => {
 		const links = getPrevNextLinks(sidebar, true, {});
-		expect(links.prev?.href).toMatchInlineSnapshot(`"/test-base/guides/components/"`);
-		expect(links.next?.href).toMatchInlineSnapshot(`undefined`);
+		expect(links.prev?.href).toBe('/test-base/guides/components/');
+		expect(links.next?.href).toBeUndefined();
 	});
 
-	test('pagination links are formatted correctly with custom links in frontmatter', () => {
+	test('pagination links are used as authored with custom links in frontmatter', () => {
+		const prevLink = '/other-page';
+		const nextLink = '/extra-page';
 		const links = getPrevNextLinks(sidebar, true, {
-			prev: { link: '/other-page', label: 'Other Page' },
-			next: { link: '/extra-page', label: 'Extra Page' },
+			prev: { link: prevLink, label: 'Other Page' },
+			next: { link: nextLink, label: 'Extra Page' },
 		});
-		expect(links.prev?.href).toMatchInlineSnapshot(`"/other-page"`);
-		expect(links.next?.href).toMatchInlineSnapshot(`"/extra-page"`);
+		expect(links.prev?.href).toBe(prevLink);
+		expect(links.next?.href).toBe(nextLink);
 	});
 });

--- a/packages/starlight/utils/navigation.ts
+++ b/packages/starlight/utils/navigation.ts
@@ -130,7 +130,7 @@ function linkFromSidebarLinkItem(
 		if (locale) href = '/' + locale + href;
 	}
 	const label = pickLang(item.translations, localeToLang(locale)) || item.label;
-	return makeLink(href, label, currentPathname, item.badge, item.attrs);
+	return makeSidebarLink(href, label, currentPathname, item.badge, item.attrs);
 }
 
 /** Create a link entry from an automatic internal link item in user config. */
@@ -160,11 +160,11 @@ function linkFromInternalSidebarLinkItem(
 	}
 	const label =
 		pickLang(item.translations, localeToLang(locale)) || item.label || entry.entry.data.title;
-	return makeLink(entry.slug, label, currentPathname, item.badge, item.attrs);
+	return makeSidebarLink(entry.slug, label, currentPathname, item.badge, item.attrs);
 }
 
-/** Create a link entry. */
-function makeLink(
+/** Process sidebar link options to create a link entry. */
+function makeSidebarLink(
 	href: string,
 	label: string,
 	currentPathname: string,
@@ -174,10 +174,24 @@ function makeLink(
 	if (!isAbsolute(href)) {
 		href = formatPath(href);
 	}
-
 	const isCurrent = pathsMatch(encodeURI(href), currentPathname);
+	return makeLink({ label, href, isCurrent, badge, attrs });
+}
 
-	return { type: 'link', label, href, isCurrent, badge, attrs: attrs ?? {} };
+/** Create a link entry */
+function makeLink({
+	isCurrent = false,
+	attrs = {},
+	badge = undefined,
+	...opts
+}: {
+	label: string;
+	href: string;
+	isCurrent?: boolean;
+	badge?: Badge | undefined;
+	attrs?: LinkHTMLAttributes | undefined;
+}): Link {
+	return { type: 'link', ...opts, badge, isCurrent, attrs };
 }
 
 /** Test if two paths are equivalent even if formatted differently. */
@@ -240,7 +254,7 @@ function treeify(routes: Route[], baseDir: string): Dir {
 
 /** Create a link entry for a given content collection entry. */
 function linkFromRoute(route: Route, currentPathname: string): Link {
-	return makeLink(
+	return makeSidebarLink(
 		slugToPathname(route.slug),
 		route.entry.data.sidebar.label || route.entry.data.title,
 		currentPathname,
@@ -388,7 +402,7 @@ function applyPrevNextLinkConfig(
 		} else if (config.link && config.label) {
 			// If there is no link and the frontmatter contains both a URL and a label,
 			// create a new link.
-			return makeLink(config.link, config.label, '');
+			return makeLink({ href: config.link, label: config.label });
 		}
 	}
 	// Otherwise, if the global config is enabled, return the generated link if any.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #1886
- Fixes an edge case how custom prev/next links in frontmatter are handled
- In general a custom prev/next link was applied directly to an existing link object, which produced the correct behaviour. How in the edge case where a link object wasn’t already available (e.g. pagination is disabled, or the page is first/last, so has no prev/next link), we were using a `makeLink()` utility designed for sidebar items that did some additional processing. This rarely caused issues, but if a user had `base` set, this led to inconsistencies where the base would prepended to links **only** in these rare edge cases.
- This PR fixes this by ensuring links created for pagination purposes are never processed and always reflect 1:1 with the authored link in frontmatter
- We had an old test that expected the processing, which converted `x` to `/x`, but I think that was a wrong expectation, so I updated that old test to reflect the new behaviour.
<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
