### PR TITLE
Fix an Astro i18n → Starlight i18n config conversion issue

### DIFF
--- a/.changeset/large-bananas-beg.md
+++ b/.changeset/large-bananas-beg.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes an i18n configuration issue for multilingual sites when using Astro’s `i18n` config with `prefixDefaultLocale` set to `false`.

--- a/packages/starlight/__tests__/basics/i18n.test.ts
+++ b/packages/starlight/__tests__/basics/i18n.test.ts
@@ -162,7 +162,7 @@ describe('processI18nConfig', () => {
 					locales: ['en', { codes: ['fr'], path: 'french' }],
 				},
 				expected: {
-					defaultLocale: { label: 'English', lang: 'en', dir: 'ltr', locale: 'en' },
+					defaultLocale: { label: 'English', lang: 'en', dir: 'ltr', locale: undefined },
 					locales: {
 						root: { label: 'English', lang: 'en', dir: 'ltr' },
 						french: { label: 'Français', lang: 'fr', dir: 'ltr' },
@@ -180,7 +180,7 @@ describe('processI18nConfig', () => {
 					routing: { prefixDefaultLocale: false },
 				},
 				expected: {
-					defaultLocale: { label: 'فارسی', lang: 'fa', dir: 'rtl', locale: 'fa' },
+					defaultLocale: { label: 'فارسی', lang: 'fa', dir: 'rtl', locale: undefined },
 					locales: {
 						root: { label: 'فارسی', lang: 'fa', dir: 'rtl' },
 						de: { label: 'Deutsch', lang: 'de', dir: 'ltr' },

--- a/packages/starlight/utils/i18n.ts
+++ b/packages/starlight/utils/i18n.ts
@@ -118,11 +118,12 @@ function getStarlightI18nConfig(
 		locales,
 		defaultLocale: {
 			...inferStarlightLocaleFromAstroLocale(defaultAstroLocale),
-			locale: isMonolingualWithRootLocale
-				? undefined
-				: isAstroLocaleExtendedConfig(defaultAstroLocale)
-					? defaultAstroLocale.codes[0]
-					: defaultAstroLocale,
+			locale:
+				isMonolingualWithRootLocale || (isMultilingual && !prefixDefaultLocale)
+					? undefined
+					: isAstroLocaleExtendedConfig(defaultAstroLocale)
+						? defaultAstroLocale.codes[0]
+						: defaultAstroLocale,
 		},
 	};
 }


### PR DESCRIPTION
#### Description

This PR fixes the issue identified in this [comment](https://github.com/withastro/starlight/pull/1923#issuecomment-2213744449).

When using Astro’s `i18n` config for a multilingual site with a root locale (`prefixDefaultLocale` set to `false`), the `config.defaultLocale.locale` value was not being set correctly to `undefined` as expected in this case when converting the config to a Starlight i18n config.

This PR fixes the issue by checking for this specific case. No new tests are added as we already have tests covering this scenario but the expected Starlight i18n config output was incorrect so we just needed to update it.

Another potential, but more manual test, is to use the Astro’s `i18n` config from #1923 in the documentation and visiting a non-existent page.
