### PR TITLE
[TEST] Don’t inline keyboard shortcut script

### DIFF
--- a/packages/starlight/components/Search.astro
+++ b/packages/starlight/components/Search.astro
@@ -56,27 +56,6 @@ const pagefindTranslations = {
 	</dialog>
 </site-search>
 
-{
-	/**
-	 * This is intentionally inlined to avoid briefly showing an invalid shortcut.
-	 * Purposely using the deprecated `navigator.platform` property to detect Apple devices, as the
-	 * user agent is spoofed by some browsers when opening the devtools.
-	 */
-}
-<script is:inline>
-	(() => {
-		const openBtn = document.querySelector('button[data-open-modal]');
-		const shortcut = openBtn?.querySelector('kbd');
-		if (!openBtn || !(shortcut instanceof HTMLElement)) return;
-		const platformKey = shortcut.querySelector('kbd');
-		if (platformKey && /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)) {
-			platformKey.textContent = '⌘';
-			openBtn.setAttribute('aria-keyshortcuts', 'Meta+K');
-		}
-		shortcut.style.display = '';
-	})();
-</script>
-
 <script>
 	class SiteSearch extends HTMLElement {
 		constructor() {
@@ -85,6 +64,18 @@ const pagefindTranslations = {
 			const closeBtn = this.querySelector<HTMLButtonElement>('button[data-close-modal]')!;
 			const dialog = this.querySelector('dialog')!;
 			const dialogFrame = this.querySelector('.dialog-frame')!;
+
+			// Display a keyboard shortcut appropriate to the user’s OS.
+			const shortcut = openBtn?.querySelector('kbd');
+			if (!openBtn || !(shortcut instanceof HTMLElement)) return;
+			const platformKey = shortcut.querySelector('kbd');
+			// Purposely using the deprecated `navigator.platform` property to detect Apple devices, as the
+			// user agent is spoofed by some browsers when opening the devtools.
+			if (platformKey && /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)) {
+				platformKey.textContent = '⌘';
+				openBtn.setAttribute('aria-keyshortcuts', 'Meta+K');
+			}
+			shortcut.style.display = '';
 
 			/** Close the modal if a user clicks on a link or outside of the modal. */
 			const onClick = (event: MouseEvent) => {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #2133 <!-- Add an issue number if this PR will close it. -->
- Tries moving the script for displaying keyboard shortcuts to the bundled `SiteSearch` custom element script to avoid blocking later UI elements.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
