### PR TITLE
docs: add 'og:image:alt' metadata

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -26,6 +26,7 @@ const NETLIFY_PREVIEW_SITE = process.env.CONTEXT !== 'production' && process.env
 
 const site = NETLIFY_PREVIEW_SITE || 'https://starlight.astro.build/';
 const ogUrl = new URL('og.jpg?v=1', site).href;
+const ogImageAlt = 'Make your docs shine with Starlight';
 
 export default defineConfig({
 	site,
@@ -57,6 +58,10 @@ export default defineConfig({
 				{
 					tag: 'meta',
 					attrs: { property: 'og:image', content: ogUrl },
+				},
+				{
+					tag: 'meta',
+					attrs: { property: 'og:image:alt', content: ogImageAlt },
 				},
 			],
 			customCss: process.env.NO_GRADIENTS ? [] : ['./src/assets/landing.css'],


### PR DESCRIPTION
#### Description

This PR adds a metadata in Starlight documentation to improve the accessibility of Twitter cards when this documentation is shared on this platform, or other cards on different social media platforms.

Feel free to drop this PR if this is a topic that has already been discussed, or if you think this is not necessary. In this case, don't spend too much time on my PR :)

> [!IMPORTANT]  
> After a discussion based on https://github.com/withastro/starlight/pull/2137, this PR will only implement `og:image:alt`, and Twitter will use this as a fallback

##### Twitter/X platform

Let's consider this page: https://astro.build/blog/astro-4120/.
It contains the following metadata:
```html
<meta name="twitter:image" content="https://astro.build/_astro/og_image_4_12.DvriEbIV.webp">
<meta name="twitter:image:alt" content="Astro 4.12: Server Islands">
```
When shared on Twitter (see https://x.com/astrodotbuild/status/1813994888427684008), if you inspect the Twitter card, you'll see that the image has an alternative text, which is good for a11y:
```html
<img alt="Astro 4.12: Server Islands" draggable="true" src="https://pbs.twimg.com/card_img/1813989406337904640/UEz_mzB7?format=jpg&amp;name=small" class="css-9pa8cd">
```

Let's consider our own Starlight documentation at https://starlight.astro.build/ja/getting-started/ (for instance).
It contains the following metadata:
```html
<meta property="twitter:image" content="https://starlight.astro.build/og.jpg?v=1">
```

The image is the following:

<img src="https://starlight.astro.build/og.jpg?v=1" />

But there's no `twitter:image:alt`.
When shared on Twitter (see https://x.com/NewGyu/status/1814669986096685126), if you inspect the Twitter card, you'll see that the image doesn't have any alternative text:
```html
<img alt="" draggable="true" src="https://pbs.twimg.com/card_img/1814058933243318272/eD3h0-Rh?format=jpg&amp;name=small" class="css-9pa8cd">
```

It's probably debatable whether a Twitter card image is decorative or not, and should have an alt text or not. However, our Starlight documentation image contains text that, if important, should be accessible to everyone, so via a screen reader too, as it is an information.

This is the reason why I'm suggesting this enhancement.

##### Other social media platforms

For other social media platforms, they mostly use Open Graph, and it also supports the alternative text for images with `og:image:alt`. So this is basically the same explanation for the same concept

##### Translate or not translate?

I've forced the following English text: "Make your docs shine with Starlight".
The reason is that I'd say we should have the exact same information as in the thumbnail (which is not translated).
But that's debatable. Maybe we can translate it for screen readers users only, for once, they would have the most precise information :)


