### PR TITLE
Define well-known RTL locales before calling `getLocaleInfo()` for default locale

### DIFF
--- a/.changeset/odd-sheep-love.md
+++ b/.changeset/odd-sheep-love.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes an issue detecting the built-in locale when running Starlight in a web container environment on Firefox

--- a/packages/starlight/utils/i18n.ts
+++ b/packages/starlight/utils/i18n.ts
@@ -2,9 +2,6 @@ import type { AstroConfig } from 'astro';
 import { AstroError } from 'astro/errors';
 import type { StarlightConfig } from './user-config';
 
-/** Informations about the built-in default locale used as a fallback when no locales are defined. */
-export const BuiltInDefaultLocale = { ...getLocaleInfo('en'), lang: 'en' };
-
 /**
  * A list of well-known right-to-left languages used as a fallback when determining the text
  * direction of a locale is not supported by the `Intl.Locale` API in the current environment.
@@ -13,6 +10,9 @@ export const BuiltInDefaultLocale = { ...getLocaleInfo('en'), lang: 'en' };
  * @see https://en.wikipedia.org/wiki/IETF_language_tag#List_of_common_primary_language_subtags
  */
 const wellKnownRTL = ['ar', 'fa', 'he', 'prs', 'ps', 'syc', 'ug', 'ur'];
+
+/** Informations about the built-in default locale used as a fallback when no locales are defined. */
+export const BuiltInDefaultLocale = { ...getLocaleInfo('en'), lang: 'en' };
 
 /**
  * Processes the Astro and Starlight i18n configurations to generate/update them accordingly:


### PR DESCRIPTION
#### Description

- Fixes https://github.com/withastro/starlight/issues/1961#issuecomment-2270020341
- We were using `getLocaleInfo()` before defining our well-known RTL locales. This was only used in rare circumstances (environments that support neither [`Intl.Locale#getTextInfo()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTextInfo) nor the non-standard `Intl.Locale#textInfo` accessor), so hadn’t noticed the issue until now. (A StackBlitz or other web container running on Firefox is probably the only place you can really hit this.)


<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
