### PR TITLE
fix: make link relative

### DIFF
--- a/examples/basics/src/content/docs/index.mdx
+++ b/examples/basics/src/content/docs/index.mdx
@@ -8,7 +8,7 @@ hero:
     file: ../../assets/houston.webp
   actions:
     - text: Example Guide
-      link: /guides/example/
+      link: guides/example/
       icon: right-arrow
       variant: primary
     - text: Read the Starlight docs

--- a/examples/tailwind/src/content/docs/index.mdx
+++ b/examples/tailwind/src/content/docs/index.mdx
@@ -18,7 +18,7 @@ hero:
     file: ../../assets/houston.webp
   actions:
     - text: Example Guide
-      link: /guides/example/
+      link: guides/example/
       icon: right-arrow
       variant: primary
     - text: Read the Starlight docs


### PR DESCRIPTION
I used this template and it took me 35 minutes to understand that following the example is a dead end when trying to use the base option. Links need to be relative.

#### Description

- Closes no current issue but is related to #1407 
- What does this PR change? Makes a link in the base example relative to not mislead any other people
- Did you change something visual? Nope
