### PR TITLE
fix: using wrong field to deconstruct in 'CallToAction' component

### DIFF
--- a/.changeset/wild-phones-pull.md
+++ b/.changeset/wild-phones-pull.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+fix: using wrong field to deconstruct in 'CallToAction' component

--- a/packages/starlight/components/CallToAction.astro
+++ b/packages/starlight/components/CallToAction.astro
@@ -11,7 +11,7 @@ interface Props {
 }
 
 const { link, variant, icon } = Astro.props;
-const { class: customClass, ...attrs } = Astro.props.attrs || {};
+const { class: customClass, ...attrs } = Astro.props || {};
 ---
 
 <a class:list={['sl-flex action', variant, customClass]} href={link} {...attrs}>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
Closes (no issue created)

What does this PR change?
- Fixes what a bug to pass html attribs to the **CallToAction** component.
- This allows to e.g. pass the class attribute `<CallToAction  class="px-1">...</CallToAction>`

Note: I'm actually not sure if the `Prop` interface definition is correct (`attrs?: Omit<HTMLAttributes<'a'>, 'href'> | undefined;`) or what the purpose for this is?!?

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
