### PR TITLE
Make themes a little bit more visible

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -151,7 +151,6 @@ export default defineConfig({
 				},
 				{
 					label: 'Resources',
-					badge: 'New',
 					translations: {
 						'zh-CN': '资源',
 						fr: 'Ressources',

--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -78,6 +78,13 @@ Extend your site with official plugins supported by the Starlight team and commu
 		title="starlight-versions"
 		description="Version your Starlight documentation pages."
 	/>
+</CardGrid>
+
+### Community themes
+
+A theme is a Starlight plugin that changes the visual appearance of a site with component overrides, custom CSS, or other new features.
+
+<CardGrid>
 	<LinkCard
 		href="https://github.com/HiDeoo/starlight-theme-rapide"
 		title="starlight-theme-rapide"


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Tiny tweak to make themes slightly more visible in our plugins catalogue. I also considered if there are other quick wins for theme docs, but the plugin reference does say “Starlight plugins can customize Starlight configuration, UI, and behavior” and a theme is just a plugin so not sure we have much more to add just yet (short of a full “how to build a theme” guide, which would take a bit more time).

While there I’ve also removed the badge from the Resources menu group as it’s been there a while now.