### PR TITLE
Disable update check in E2E tests

### DIFF
--- a/packages/starlight/__e2e__/test-utils.ts
+++ b/packages/starlight/__e2e__/test-utils.ts
@@ -5,6 +5,7 @@ import { build, preview } from 'astro';
 export { expect, type Locator } from '@playwright/test';
 
 process.env.ASTRO_TELEMETRY_DISABLED = 'true';
+process.env.ASTRO_DISABLE_UPDATE_CHECK = 'true';
 
 // Setup a test environment that will build and start a preview server for a given fixture path and
 // provide a Starlight Playwright fixture accessible from within all tests.


### PR DESCRIPTION
#### Description

While debugging some E2E tests with maximum verbosity, I noticed that update checks can happen in some of our E2E tests locally, specifically the ones where we need to start a dev server (e.g. in the SSR tests where we want to verify the output of the dev server for git related output (`lastUpdated`)). This is not a huge deal, but something useless that is not even visible or can be acted upon so I think it's better to disable it. This change also brings the local version closer to the CI environment.

- [Reference](https://github.com/withastro/astro/blob/main/packages/astro/src/core/dev/update-check.ts#L46) for the check
- This can only happens locally as the code [checks](https://github.com/withastro/astro/blob/main/packages/astro/src/core/dev/update-check.ts#L37-L39) if we are in a CI environment.