### PR TITLE
i18n(fr): add missing `syncKey` to various pages

### DIFF
--- a/docs/src/content/docs/fr/guides/customization.mdx
+++ b/docs/src/content/docs/fr/guides/customization.mdx
@@ -385,7 +385,7 @@ Il fournit des modules npm que vous pouvez installer pour les polices que vous s
 2.  Installez le package pour la police choisie.
     Vous pouvez trouver le nom du package en cliquant sur "Installer" sur la page de police Fontsource.
 
-        <Tabs>
+        <Tabs syncKey="pkg">
 
     <TabItem label="npm">
 

--- a/docs/src/content/docs/fr/guides/site-search.mdx
+++ b/docs/src/content/docs/fr/guides/site-search.mdx
@@ -52,7 +52,7 @@ Si vous avez accès au [programme DocSearch d'Algolia](https://docsearch.algolia
 
 1. Installez `@astrojs/starlight-docsearch` :
 
-   <Tabs>
+   <Tabs syncKey="pkg">
 
    <TabItem label="npm">
 

--- a/docs/src/content/docs/fr/manual-setup.mdx
+++ b/docs/src/content/docs/fr/manual-setup.mdx
@@ -16,7 +16,7 @@ Pour suivre ce guide, vous aurez besoin d'un projet Astro existant.
 
 Starlight est une [intégration Astro](https://docs.astro.build/fr/guides/integrations-guide/). Ajoutez-la à votre site en exécutant la commande `astro add` dans le répertoire racine de votre projet :
 
-<Tabs>
+<Tabs syncKey="pkg">
     <TabItem label="npm">
         ```sh
         npx astro add starlight


### PR DESCRIPTION
#### Description

This PR updates the French version of the `manual-setup`, `guides/customization`, and `guides/site-search` pages with the changes from #2087.