### PR TITLE
Fix a sidebar persistence issue when navigating between pages with different sidebars

### DIFF
--- a/.changeset/lemon-ants-bow.md
+++ b/.changeset/lemon-ants-bow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes a sidebar persistence issue when navigating between pages with different sidebar content.

--- a/packages/starlight/components/SidebarPersistState.ts
+++ b/packages/starlight/components/SidebarPersistState.ts
@@ -16,17 +16,19 @@ interface SidebarState {
 /**
  * Get the current sidebar state.
  *
- * The `open` state is loaded from session storage, while `scroll` and `hash` are read from the current page.
+ * The `open` state is loaded from session storage when the sidebar hashes match, while `scroll`
+ * and `hash` are read from the current page.
  */
 const getState = (): SidebarState => {
 	let open = [];
+	const hash = target?.dataset.hash || '';
 	try {
 		const rawStoredState = sessionStorage.getItem(storageKey);
 		const storedState = JSON.parse(rawStoredState || '{}');
-		if (Array.isArray(storedState.open)) open = storedState.open;
+		if (Array.isArray(storedState.open) && storedState.hash === hash) open = storedState.open;
 	} catch {}
 	return {
-		hash: target?.dataset.hash || '',
+		hash,
 		open,
 		scroll: scroller?.scrollTop || 0,
 	};


### PR DESCRIPTION
#### Description

Fixes the sidebar persistence issue spotted by Chris.

The repro is:

- Go to https://starlight.astro.build/getting-started/
- Collapse some groups
- Navigate to the homepage
- Click “getting started”
- The groups are reset as expected
- Navigate to another page
- The stale collapse state is restored

If I'm not wrong, the `open` state is always loaded from session storage even when the stored hash and current hash don't match. This PR fixes this issue by only loading the `open` state from session storage when the stored hash and current hash match.