### PR TITLE
Stop publishing E2E tests

### DIFF
--- a/.changeset/slimy-beers-report.md
+++ b/.changeset/slimy-beers-report.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Removes internal E2E tests from the package published to the npm registry.

--- a/packages/starlight/.npmignore
+++ b/packages/starlight/.npmignore
@@ -1,6 +1,8 @@
 # Vitest
 __coverage__/
 __tests__/
+__e2e__/
 vitest.*
+playwright.config.ts
 # Astro generates this during tests, but we want to ignore it.
 src/env.d.ts


### PR DESCRIPTION
#### Description

This PR adds E2E tests and their configuration to the `.npmignore` file to avoid publishing them:

<img width="353" alt="image" src="https://github.com/user-attachments/assets/fa28c655-b266-4513-9941-3274e920b387">

I tested the change before and after with `pnpm publish --dry-run --no-git-checks` in the `packages/starlight/` directory and confirmed that the E2E tests are no longer included after this change.