### PR TITLE
[i18nIgnore] docs: fix a few links with inconsistent locale

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "pa11y-ci": "^3.0.1",
-    "starlight-links-validator": "^0.9.0",
+    "starlight-links-validator": "^0.11.0",
     "start-server-and-test": "^2.0.4"
   }
 }

--- a/docs/src/content/docs/ja/resources/plugins.mdx
+++ b/docs/src/content/docs/ja/resources/plugins.mdx
@@ -17,7 +17,7 @@ Starlight向けのプラグインやツールを作成しましたか？この�
 
 <CardGrid>
 	<LinkCard
-		href="/guides/site-search/#algolia-docsearch"
+		href="/ja/guides/site-search/#algolia-docsearch"
 		title="Algolia DocSearch"
 		description="デフォルトの検索プロバイダーであるPagefindを、Algolia DocSearchに置き換えます。"
 	/>

--- a/docs/src/content/docs/pt-pt/resources/plugins.mdx
+++ b/docs/src/content/docs/pt-pt/resources/plugins.mdx
@@ -19,7 +19,7 @@ Estenda o seu site com os plugins oficiais suportados pela equipa Starlight e co
 
 <CardGrid>
 	<LinkCard
-		href="/pt-br/guides/site-search/#algolia-docsearch"
+		href="/pt-pt/guides/site-search/#algolia-docsearch"
 		title="Algolia DocSearch"
 		description="Substitua o fornecedor de pesquisa Pagefind pelo Algolia DocSearch."
 	/>

--- a/docs/src/content/docs/zh-cn/guides/components.mdx
+++ b/docs/src/content/docs/zh-cn/guides/components.mdx
@@ -237,9 +237,9 @@ import { LinkCard } from '@astrojs/starlight/components';
 
 import { LinkButton } from '@astrojs/starlight/components';
 
-<LinkButton href="/zh-cn/getting-started/">Get started</LinkButton>
+<LinkButton href="/zh-cn/getting-started/">开始使用</LinkButton>
 <LinkButton href="https://docs.astro.build" variant="secondary" icon="external">
-	Related: Astro
+	相关内容：Astro
 </LinkButton>
 ```
 
@@ -247,9 +247,9 @@ import { LinkButton } from '@astrojs/starlight/components';
 
 import { LinkButton } from '@astrojs/starlight/components';
 
-<LinkButton href="/zh-cn/getting-started/">Get started</LinkButton>
+<LinkButton href="/zh-cn/getting-started/">开始使用</LinkButton>
 <LinkButton href="https://docs.astro.build" variant="secondary" icon="external">
-	Related: Astro
+	相关内容：Astro
 </LinkButton>
 
 ### 旁白

--- a/docs/src/content/docs/zh-cn/guides/components.mdx
+++ b/docs/src/content/docs/zh-cn/guides/components.mdx
@@ -237,7 +237,7 @@ import { LinkCard } from '@astrojs/starlight/components';
 
 import { LinkButton } from '@astrojs/starlight/components';
 
-<LinkButton href="/getting-started/">Get started</LinkButton>
+<LinkButton href="/zh-cn/getting-started/">Get started</LinkButton>
 <LinkButton href="https://docs.astro.build" variant="secondary" icon="external">
 	Related: Astro
 </LinkButton>
@@ -247,7 +247,7 @@ import { LinkButton } from '@astrojs/starlight/components';
 
 import { LinkButton } from '@astrojs/starlight/components';
 
-<LinkButton href="/getting-started/">Get started</LinkButton>
+<LinkButton href="/zh-cn/getting-started/">Get started</LinkButton>
 <LinkButton href="https://docs.astro.build" variant="secondary" icon="external">
 	Related: Astro
 </LinkButton>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       starlight-links-validator:
-        specifier: ^0.9.0
-        version: 0.9.0(@astrojs/starlight@packages+starlight)(astro@4.10.2)
+        specifier: ^0.11.0
+        version: 0.11.0(@astrojs/starlight@packages+starlight)(astro@4.10.2)
       start-server-and-test:
         specifier: ^2.0.4
         version: 2.0.4
@@ -6818,8 +6818,8 @@ packages:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
 
-  /starlight-links-validator@0.9.0(@astrojs/starlight@packages+starlight)(astro@4.10.2):
-    resolution: {integrity: sha512-DJQDncEJBuuguPHJKP/SMmYdToWCFeEpZuRV5z9Qqgif3njJiF7dBRDAFdNIM2TCNADAZdseMOcR0iUpnvvjLQ==}
+  /starlight-links-validator@0.11.0(@astrojs/starlight@packages+starlight)(astro@4.10.2):
+    resolution: {integrity: sha512-7mKiP0xAS8ItKy8QAIkmeNYbzI4w0WD0pOYoTPa1xMNbz+qYr/QWT+a40QO/Z2XYJLzzQn47yomupUfI89wheg==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       '@astrojs/starlight': '>=0.15.0'


### PR DESCRIPTION
#### Description

This PR updates `starlight-links-validator` to the version `0.11.0` which now validates links in `<LinkCard>` and `<LinkButton>` components.

Following this update, the PR also fixes a few links in such components that were using inconsistent locales.