### PR TITLE
Docs - add an example to the i18n custom labels section

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,0 +1,5 @@
+{
+	"_variables": {
+		"lastUpdateCheck": 1725113954442
+	}
+}

--- a/docs/src/content/docs/guides/i18n.mdx
+++ b/docs/src/content/docs/guides/i18n.mdx
@@ -253,26 +253,40 @@ You can provide translations for additional languages you support — or overrid
 
 ### Extend translation schema
 
-Add custom keys to your site’s translation dictionaries by setting `extend` in the `i18nSchema()` options.
-In the following example, a new, optional `custom.label` key is added to the default keys:
+You can add custom keys to your site’s translation dictionaries. In the following example, a new, optional `custom.label` key is added to the default keys:
 
-```diff lang="js"
-// src/content/config.ts
-import { defineCollection, z } from 'astro:content';
-import { docsSchema, i18nSchema } from '@astrojs/starlight/schema';
+<Steps>
 
-export const collections = {
-	docs: defineCollection({ schema: docsSchema() }),
-	i18n: defineCollection({
-		type: 'data',
-		schema: i18nSchema({
-+			extend: z.object({
-+				'custom.label': z.string().optional(),
-+			}),
+1. Set `extend` in the `i18nSchema()` options.
+	```diff lang="js"
+	// src/content/config.ts
+	import { defineCollection, z } from 'astro:content';
+	import { docsSchema, i18nSchema } from '@astrojs/starlight/schema';
+
+	export const collections = {
+		docs: defineCollection({ schema: docsSchema() }),
+		i18n: defineCollection({
+			type: 'data',
+			schema: i18nSchema({
+	+			extend: z.object({
+	+				'custom.label': z.string().optional(),
+	+			}),
+			}),
 		}),
-	}),
-};
-```
+	};
+	```
+
+2. Access this newly-created custom label in your component thanks to the `labels` props.
+	```astro
+	---
+	// src/components/Custom.astro
+
+	const { labels } = Astro.props;
+	---
+	<h2>{labels['custom.label']}</h2>
+	```
+</Steps>
+
 
 Learn more about content collection schemas in [“Defining a collection schema”](https://docs.astro.build/en/guides/content-collections/#defining-a-collection-schema) in the Astro docs.
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "size": "size-limit",
     "version": "pnpm changeset version && pnpm i --no-frozen-lockfile",
     "format": "prettier -w --cache --plugin prettier-plugin-astro .",
-    "typecheck": "astro check --minimumSeverity warning"
+    "typecheck": "astro check --minimumSeverity warning",
+    "dev": "astro dev"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

_- What does this PR change? Give us a brief description._
This PR adds some more detail to the "Extend translation schema" section of the i18n guide by adding an example of how to use the new custom label inside a component. indeed, as i was going through this process on my project, it took me a while to understand that I needed to use the `labels` props. I thought it could be a useful addition to the Starlight docs.

_- Did you change something visual? A before/after screenshot can be helpful._
Yes. I added a `<Steps>` components and a code block. See screenshots.

**Before**
![before](https://github.com/user-attachments/assets/eefa51ba-d4f1-4b06-b974-b43a8c68eb12)

**After**
![after](https://github.com/user-attachments/assets/31a27892-2b23-4992-8290-ebe46a7fd1a9)

I hope it's helpful.
Thank you,
Geoffrey

P.S. Sorry, I don't know why there are updates to `settings.json` and 'package.json`.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
