### PR TITLE
Fixes type error with Astro 4.15.x

### DIFF
--- a/.changeset/fifty-gorillas-study.md
+++ b/.changeset/fifty-gorillas-study.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes type error when using Starlight with Astro v4.15

--- a/packages/starlight/__tests__/basics/i18n.test.ts
+++ b/packages/starlight/__tests__/basics/i18n.test.ts
@@ -303,7 +303,7 @@ function getAstroI18nTestConfig(i18nConfig: AstroUserConfig['i18n']): AstroConfi
 		...i18nConfig,
 		routing:
 			typeof i18nConfig?.routing !== 'string'
-				? { prefixDefaultLocale: false, ...i18nConfig?.routing }
+				? { prefixDefaultLocale: false, fallbackType: 'redirect', ...i18nConfig?.routing }
 				: i18nConfig.routing,
 	} as AstroConfig['i18n'];
 }

--- a/packages/starlight/utils/i18n.ts
+++ b/packages/starlight/utils/i18n.ts
@@ -70,6 +70,7 @@ function getAstroI18nConfig(config: StarlightConfig): NonNullable<AstroConfig['i
 				// Sites with a single non-root language different from the built-in default locale.
 				(!config.isMultilingual && config.locales !== undefined),
 			redirectToDefaultLocale: false,
+			fallbackType: 'redirect',
 		},
 	};
 }

--- a/packages/starlight/utils/i18n.ts
+++ b/packages/starlight/utils/i18n.ts
@@ -70,6 +70,8 @@ function getAstroI18nConfig(config: StarlightConfig): NonNullable<AstroConfig['i
 				// Sites with a single non-root language different from the built-in default locale.
 				(!config.isMultilingual && config.locales !== undefined),
 			redirectToDefaultLocale: false,
+			// TODO: remove this ignore comment for Astro v5
+			// @ts-ignore — Only used in Astro >=4.15.0, but Starlight supports ^4.8.6
 			fallbackType: 'redirect',
 		},
 	};


### PR DESCRIPTION
#### Description

- Closes #2271
- Adds handling for the new `i18n.routing.fallbackType` option added in Astro 4.15.0
- Tested locally with both the current version of Astro used in the monorepo and after installing the latest Astro release to ensure type checking still passes

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
