### PR TITLE
Add `starlight-heading-badges` & `@hideoo/generator-starlight-plugin` to the plugin showcase

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -83,6 +83,11 @@ Extend your site with official plugins supported by the Starlight team and commu
 		title="star-warp"
 		description="Warp-drive through search results in your documentation."
 	/>
+	<LinkCard
+		href="https://github.com/HiDeoo/starlight-heading-badges"
+		title="starlight-heading-badges"
+		description="Add badges to your Markdown and MDX headings."
+	/>
 </CardGrid>
 
 ### Community themes
@@ -133,5 +138,10 @@ These community tools and integrations can be used to add features to your Starl
 		href="https://github.com/HiDeoo/starlight-showcases"
 		title="starlight-showcases"
 		description="Set of Starlight components to author showcase pages."
+	/>
+	<LinkCard
+		href="https://github.com/HiDeoo/generator-starlight-plugin"
+		title="@hideoo/starlight-plugin"
+		description="A generator to quickly scaffold Starlight plugins."
 	/>
 </CardGrid>


### PR DESCRIPTION
#### Description

This PR adds the following resources to the plugin showcase:

- [`starlight-heading-badges`](https://github.com/HiDeoo/starlight-heading-badges): plugin to add badges to Markdown headings
- [`@hideoo/starlight-plugin`](https://github.com/HiDeoo/generator-starlight-plugin): Yeoman generator to quickly scaffold a new Starlight plugin