### PR TITLE
Parse `<StarlightPage />` frontmatter asynchronously 

### DIFF
--- a/.changeset/spicy-suns-marry.md
+++ b/.changeset/spicy-suns-marry.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes an issue with frontmatter schemas containing collection references used with the `<StarlightPage />` component and an Astro version greater than `4.14.0`.

--- a/packages/starlight/utils/error-map.ts
+++ b/packages/starlight/utils/error-map.ts
@@ -25,11 +25,31 @@ export function parseWithFriendlyErrors<T extends z.Schema>(
 	input: z.input<T>,
 	message: string
 ): z.output<T> {
-	const parsedConfig = schema.safeParse(input, { errorMap });
-	if (!parsedConfig.success) {
-		throw new AstroError(message, parsedConfig.error.issues.map((i) => i.message).join('\n'));
+	return processParsedData(schema.safeParse(input, { errorMap }), message);
+}
+
+/**
+ * Asynchronously parse data with a Zod schema that contains asynchronous refinements or transforms
+ * and throw a nicely formatted error if it is invalid.
+ *
+ * @param schema The Zod schema to use to parse the input.
+ * @param input Input data that should match the schema.
+ * @param message Error message preamble to use if the input fails to parse.
+ * @returns Validated data parsed by Zod.
+ */
+export async function parseAsyncWithFriendlyErrors<T extends z.Schema>(
+	schema: T,
+	input: z.input<T>,
+	message: string
+): Promise<z.output<T>> {
+	return processParsedData(await schema.safeParseAsync(input, { errorMap }), message);
+}
+
+function processParsedData(parsedData: z.SafeParseReturnType<any, any>, message: string) {
+	if (!parsedData.success) {
+		throw new AstroError(message, parsedData.error.issues.map((i) => i.message).join('\n'));
 	}
-	return parsedConfig.data;
+	return parsedData.data;
 }
 
 const errorMap: z.ZodErrorMap = (baseError, ctx) => {

--- a/packages/starlight/utils/starlight-page.ts
+++ b/packages/starlight/utils/starlight-page.ts
@@ -1,7 +1,7 @@
 import { z } from 'astro/zod';
 import { type ContentConfig, type SchemaContext } from 'astro:content';
 import config from 'virtual:starlight/user-config';
-import { parseWithFriendlyErrors } from './error-map';
+import { parseWithFriendlyErrors, parseAsyncWithFriendlyErrors } from './error-map';
 import { stripLeadingAndTrailingSlashes } from './path';
 import {
 	getSiteTitle,
@@ -198,7 +198,9 @@ async function getStarlightPageFrontmatter(frontmatter: StarlightPageFrontmatter
 			}),
 	});
 
-	return parseWithFriendlyErrors(
+	// Starting with Astro 4.14.0, a frontmatter schema that contains collection references will
+	// contain an async transform.
+	return parseAsyncWithFriendlyErrors(
 		schema,
 		frontmatter,
 		'Invalid frontmatter props passed to the `<StarlightPage/>` component.'


### PR DESCRIPTION
#### Description

- Closes #2270

This PR updates how the frontmatter data passed down to the `<StarlightPage />` component is parsed. Starting with Astro 4.14.0, schemas containing collection references contains an [async transform](https://github.com/withastro/astro/blame/a79a8b0230b06ed32ce1802f2a5f84a6cf92dbe7/packages/astro/src/content/runtime.ts#L585-L592) which would failed to be parsed due to our usage of Zod `safeParse()` instead of `safeParseAsync()`.

I decided to create a new `parseAsyncWithFriendlyErrors()` instead of always parsing schemas asynchrounously as `parseWithFriendlyErrors()` is used in the plugin `setup` hook `updateConfig` option and I did not want to change that behavior. The new function is now only used in this specific case.

Regarding testing, I decided to not add a test as we cannot really easily have a unit test with a custom schema using `extend` and having an E2E test for this would require using a different Astro version. Creating a unit test simply calling `parseAsyncWithFriendlyErrors()` with a schema containing an async refinement or transform doesn't provide much value imo. Let me know if you think otherwise.

Altho, I used the reproduction in #2270 and tested the fix using Astro `4.13.4` and the latest version and both are now working as expected.