### PR TITLE
Add WCAG AAA colour contrast option to theme editor

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -17,9 +17,9 @@
     "@astro-community/astro-embed-youtube": "^0.5.2",
     "@astrojs/starlight": "workspace:*",
     "@lunariajs/core": "^0.1.1",
-    "@types/culori": "^2.0.0",
+    "@types/culori": "^2.1.1",
     "astro": "^4.10.2",
-    "culori": "^3.2.0",
+    "culori": "^4.0.1",
     "sharp": "^0.32.5"
   },
   "devDependencies": {

--- a/docs/src/components/theme-designer.astro
+++ b/docs/src/components/theme-designer.astro
@@ -1,12 +1,16 @@
 ---
 import { TabItem, Tabs } from '@astrojs/starlight/components';
 import ColorEditor, { type Props as EditorProps } from './theme-designer/color-editor.astro';
+import ContrastLevel, {
+	type Props as ContrastLevelProps,
+} from './theme-designer/contrast-level.astro';
 import Presets, { type Props as PresetsProps } from './theme-designer/presets.astro';
 import Preview from './theme-designer/preview.astro';
 
 interface Props {
 	labels: {
 		presets: PresetsProps['labels'];
+		contrast: ContrastLevelProps['labels'];
 		editor: EditorProps['labels'] & { accentColor: string; grayColor: string };
 		preview: Record<
 			'darkMode' | 'lightMode' | 'bodyText' | 'linkText' | 'dimText' | 'inlineCode',
@@ -15,11 +19,13 @@ interface Props {
 	};
 }
 const {
-	labels: { presets, editor, preview },
+	labels: { presets, contrast, editor, preview },
 } = Astro.props;
 ---
 
 <Presets labels={presets} />
+
+<ContrastLevel labels={contrast} />
 
 <div>
 	<theme-designer>
@@ -52,7 +58,7 @@ const {
 
 <script>
 	import { getPalettes } from './theme-designer/color-lib';
-	import { store } from './theme-designer/store';
+	import { store, minimumContrast } from './theme-designer/store';
 
 	class ThemeDesigner extends HTMLElement {
 		#stylesheet = new CSSStyleSheet();
@@ -65,10 +71,15 @@ const {
 			const onInput = () => this.#update();
 			store.accent.subscribe(onInput);
 			store.gray.subscribe(onInput);
+			minimumContrast.subscribe(onInput);
 		}
 
 		#update() {
-			const palettes = getPalettes({ accent: store.accent.get(), gray: store.gray.get() });
+			const palettes = getPalettes({
+				accent: store.accent.get(),
+				gray: store.gray.get(),
+				minimumContrast: minimumContrast.get(),
+			});
 			this.#updatePreview(palettes);
 			this.#updateStylesheet(palettes);
 			this.#updateTailwindConfig(palettes);

--- a/docs/src/components/theme-designer/atom.ts
+++ b/docs/src/components/theme-designer/atom.ts
@@ -29,3 +29,7 @@ export function map<T extends Record<string, unknown>>(value: T): MapStore<T> {
 	};
 	return atom;
 }
+
+export function atom<T extends unknown>(value: T): Atom<T> {
+	return new Atom(value);
+}

--- a/docs/src/components/theme-designer/color-lib.ts
+++ b/docs/src/components/theme-designer/color-lib.ts
@@ -42,9 +42,6 @@ const contrastColor = (text: Oklch, bg: Oklch, threshold = 4.5): Oklch => {
 	while (wcagContrast(fgColor, bg) < threshold && fgColor.l < 100 && fgColor.l > 0) {
 		fgColor.l += increment;
 	}
-	if (oklchColorToHex(text) !== oklchColorToHex(fgColor)) {
-		console.log(oklchColorToHex(text), '=>', oklchColorToHex(fgColor));
-	}
 	return fgColor;
 };
 

--- a/docs/src/components/theme-designer/color-lib.ts
+++ b/docs/src/components/theme-designer/color-lib.ts
@@ -49,10 +49,12 @@ const contrastColor = (text: Oklch, bg: Oklch, threshold = 4.5): Oklch => {
 export function getPalettes(config: {
 	accent: { hue: number; chroma: number };
 	gray: { hue: number; chroma: number };
+	minimumContrast?: number;
 }) {
 	const {
 		accent: { hue: ah, chroma: ac },
 		gray: { hue: gh, chroma: gc },
+		minimumContrast: mc,
 	} = config;
 
 	const palettes = {
@@ -93,17 +95,17 @@ export function getPalettes(config: {
 
 	// Dark mode:
 	// `gray-2` is used against `gray-5` in inline code snippets.
-	palettes.dark['gray-2'] = contrastColor(palettes.dark['gray-2'], palettes.dark['gray-5']);
+	palettes.dark['gray-2'] = contrastColor(palettes.dark['gray-2'], palettes.dark['gray-5'], mc);
 	// `gray-3` is used in the table of contents.
-	palettes.dark['gray-3'] = contrastColor(palettes.dark['gray-3'], palettes.dark.black);
+	palettes.dark['gray-3'] = contrastColor(palettes.dark['gray-3'], palettes.dark.black, mc);
 
 	// Light mode:
 	// `accent` is used for links and link buttons and can be slightly under 7:1 for some hues.
-	palettes.light.accent = contrastColor(palettes.light.accent, palettes.light['gray-6']);
+	palettes.light.accent = contrastColor(palettes.light.accent, palettes.light['gray-6'], mc);
 	// `gray-2` is used against `gray-6` in inline code snippets.
-	palettes.light['gray-2'] = contrastColor(palettes.light['gray-2'], palettes.light['gray-6']);
+	palettes.light['gray-2'] = contrastColor(palettes.light['gray-2'], palettes.light['gray-6'], mc);
 	// `gray-3` is used in the table of contents.
-	palettes.light['gray-3'] = contrastColor(palettes.light['gray-3'], palettes.light.black);
+	palettes.light['gray-3'] = contrastColor(palettes.light['gray-3'], palettes.light.black, mc);
 
 	// Convert the palette from OKLCH to RGB hex codes.
 	return {

--- a/docs/src/components/theme-designer/contrast-level.astro
+++ b/docs/src/components/theme-designer/contrast-level.astro
@@ -1,0 +1,86 @@
+---
+export interface Props {
+	labels: {
+		label: string;
+	};
+}
+const { labels = { label: 'WCAG Contrast Level' } } = Astro.props;
+---
+
+<contrast-level-toggle class="sl-flex">
+	<fieldset class="not-content">
+		<legend>{labels.label}</legend>
+		<div class="sl-flex">
+			<label class="sl-flex">
+				<input type="radio" name="contrast-level" value="4.5" checked />
+				AA
+			</label>
+			<label class="sl-flex">
+				<input type="radio" name="contrast-level" value="7" />
+				AAA
+			</label>
+		</div>
+	</fieldset>
+</contrast-level-toggle>
+
+<script>
+	import { minimumContrast } from './store';
+
+	class ContrastLevelToggle extends HTMLElement {
+		#fieldset = this.querySelector('fieldset')!;
+		constructor() {
+			super();
+			this.#fieldset.addEventListener('input', (e) => {
+				if (e.target instanceof HTMLInputElement) {
+					const contrast = parseFloat(e.target.value);
+					minimumContrast.set(contrast);
+				}
+			});
+		}
+	}
+
+	customElements.define('contrast-level-toggle', ContrastLevelToggle);
+</script>
+
+<style>
+	fieldset {
+		border: 0;
+		padding: 0;
+	}
+	fieldset > * {
+		float: left;
+		float: inline-start;
+		vertical-align: middle;
+	}
+	legend {
+		color: var(--sl-color-white);
+		margin-inline-end: 0.75rem;
+	}
+	label {
+		align-items: center;
+		padding: 0.25rem 0.75rem;
+		gap: 0.375rem;
+		background-color: var(--sl-color-gray-6);
+		font-size: var(--sl-text-xs);
+		cursor: pointer;
+	}
+	label:focus-within {
+		outline: 2px solid;
+		outline-offset: -3px;
+	}
+	label:first-child {
+		border-start-start-radius: 99rem;
+		border-end-start-radius: 99rem;
+	}
+	label:last-child {
+		border-start-end-radius: 99rem;
+		border-end-end-radius: 99rem;
+	}
+	label:has(:checked) {
+		color: var(--sl-color-black);
+		background-color: var(--sl-color-text-accent);
+	}
+	input {
+		outline: none;
+	}
+</style>

--- a/docs/src/components/theme-designer/contrast-level.astro
+++ b/docs/src/components/theme-designer/contrast-level.astro
@@ -64,9 +64,9 @@ const { labels = { label: 'WCAG Contrast Level' } } = Astro.props;
 		font-size: var(--sl-text-xs);
 		cursor: pointer;
 	}
-	label:focus-within {
+	label:has(:focus-visible) {
 		outline: 2px solid;
-		outline-offset: -3px;
+		outline-offset: -4px;
 	}
 	label:first-child {
 		border-start-start-radius: 99rem;
@@ -80,7 +80,7 @@ const { labels = { label: 'WCAG Contrast Level' } } = Astro.props;
 		color: var(--sl-color-black);
 		background-color: var(--sl-color-text-accent);
 	}
-	input {
+	input:focus-visible {
 		outline: none;
 	}
 </style>

--- a/docs/src/components/theme-designer/presets.astro
+++ b/docs/src/components/theme-designer/presets.astro
@@ -64,6 +64,10 @@ const resolvedPresets = Object.entries(presets).map(([key, preset]) => {
 		font-size: var(--sl-text-xs);
 		cursor: pointer;
 	}
+	button:focus-visible {
+		outline: 2px solid;
+		outline-offset: -4px;
+	}
 	:global([data-theme='light']) [data-preset] {
 		background-color: var(--light-bg);
 		color: var(--light-text);

--- a/docs/src/components/theme-designer/store.ts
+++ b/docs/src/components/theme-designer/store.ts
@@ -1,4 +1,4 @@
-import { map } from './atom';
+import { atom, map } from './atom';
 
 export const presets = {
 	ocean: {
@@ -27,6 +27,7 @@ export const store = {
 	accent: map(presets.default.accent),
 	gray: map(presets.default.gray),
 };
+export const minimumContrast = atom(4.5);
 
 export const usePreset = (name: string) => {
 	if (name in presets) {

--- a/docs/src/content/docs/guides/css-and-tailwind.mdx
+++ b/docs/src/content/docs/guides/css-and-tailwind.mdx
@@ -251,6 +251,8 @@ These variables are used throughout the UI with a range of gray shades used for 
 Use the sliders below to modify Starlight’s accent and gray color palettes.
 The dark and light preview areas will show the resulting colors, and the whole page will also update to preview your changes.
 
+Use the Contrast Level option to specify which of the Web Content Accessibility Guideline [colour contrast standards](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast) to meet.
+
 When you’re happy with your changes, copy the CSS or Tailwind code below and use it in your project.
 
 import ThemeDesigner from '~/components/theme-designer.astro';
@@ -267,7 +269,7 @@ import ThemeDesigner from '~/components/theme-designer.astro';
 			random: 'Random',
 		},
 		contrast: {
-			label: 'WCAG Contrast Level',
+			label: 'Contrast Level',
 		},
 		editor: {
 			accentColor: 'Accent',

--- a/docs/src/content/docs/guides/css-and-tailwind.mdx
+++ b/docs/src/content/docs/guides/css-and-tailwind.mdx
@@ -266,6 +266,9 @@ import ThemeDesigner from '~/components/theme-designer.astro';
 			default: 'Default',
 			random: 'Random',
 		},
+		contrast: {
+			label: 'WCAG Contrast Level',
+		},
 		editor: {
 			accentColor: 'Accent',
 			grayColor: 'Gray',

--- a/packages/starlight/style/props.css
+++ b/packages/starlight/style/props.css
@@ -3,8 +3,8 @@
 	/* Colors (dark mode) */
 	--sl-color-white: hsl(0, 0%, 100%); /* “white” */
 	--sl-color-gray-1: hsl(224, 20%, 94%);
-	--sl-color-gray-2: hsl(224, 6%, 77%);
-	--sl-color-gray-3: hsl(224, 6%, 56%);
+	--sl-color-gray-2: hsl(224, 6%, 80%);
+	--sl-color-gray-3: hsl(224, 7%, 66%);
 	--sl-color-gray-4: hsl(224, 7%, 36%);
 	--sl-color-gray-5: hsl(224, 10%, 23%);
 	--sl-color-gray-6: hsl(224, 14%, 16%);
@@ -142,7 +142,7 @@
 	--sl-color-red-low: hsl(var(--sl-hue-red), 80%, 90%);
 
 	--sl-color-accent-high: hsl(234, 80%, 30%);
-	--sl-color-accent: hsl(234, 90%, 60%);
+	--sl-color-accent: hsl(236, 86%, 56%);
 	--sl-color-accent-low: hsl(234, 88%, 90%);
 
 	--sl-color-text-accent: var(--sl-color-accent);

--- a/packages/starlight/style/props.css
+++ b/packages/starlight/style/props.css
@@ -3,8 +3,8 @@
 	/* Colors (dark mode) */
 	--sl-color-white: hsl(0, 0%, 100%); /* “white” */
 	--sl-color-gray-1: hsl(224, 20%, 94%);
-	--sl-color-gray-2: hsl(224, 6%, 80%);
-	--sl-color-gray-3: hsl(224, 7%, 66%);
+	--sl-color-gray-2: hsl(224, 6%, 77%);
+	--sl-color-gray-3: hsl(224, 6%, 56%);
 	--sl-color-gray-4: hsl(224, 7%, 36%);
 	--sl-color-gray-5: hsl(224, 10%, 23%);
 	--sl-color-gray-6: hsl(224, 14%, 16%);
@@ -142,7 +142,7 @@
 	--sl-color-red-low: hsl(var(--sl-hue-red), 80%, 90%);
 
 	--sl-color-accent-high: hsl(234, 80%, 30%);
-	--sl-color-accent: hsl(236, 86%, 56%);
+	--sl-color-accent: hsl(234, 90%, 60%);
 	--sl-color-accent-low: hsl(234, 88%, 90%);
 
 	--sl-color-text-accent: var(--sl-color-accent);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,14 +48,14 @@ importers:
         specifier: ^0.1.1
         version: 0.1.1
       '@types/culori':
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^2.1.1
+        version: 2.1.1
       astro:
         specifier: ^4.10.2
         version: 4.10.2(@types/node@18.16.19)(typescript@5.4.5)
       culori:
-        specifier: ^3.2.0
-        version: 3.2.0
+        specifier: ^4.0.1
+        version: 4.0.1
       sharp:
         specifier: ^0.32.5
         version: 0.32.6
@@ -2088,8 +2088,8 @@ packages:
   /@types/cookie@0.6.0:
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
-  /@types/culori@2.0.0:
-    resolution: {integrity: sha512-bKpEra39sQS9UZ+1JoWhuGJEzwKS0dUkNCohVYmn6CAEBkqyIXimKiPDRZWtiOB7sKgkWMaTUpHFimygRoGIlg==}
+  /@types/culori@2.1.1:
+    resolution: {integrity: sha512-NzLYD0vNHLxTdPp8+RlvGbR2NfOZkwxcYGFwxNtm+WH2NuUNV8785zv1h0sulFQ5aFQ9n/jNDUuJeo3Bh7+oFA==}
     dev: false
 
   /@types/debug@4.1.12:
@@ -3093,8 +3093,8 @@ packages:
       stream-transform: 2.1.3
     dev: true
 
-  /culori@3.2.0:
-    resolution: {integrity: sha512-HIEbTSP7vs1mPq/2P9In6QyFE0Tkpevh0k9a+FkjhD+cwsYm9WRSbn4uMdW9O0yXlNYC3ppxL3gWWPOcvEl57w==}
+  /culori@4.0.1:
+    resolution: {integrity: sha512-LSnjA6HuIUOlkfKVbzi2OlToZE8OjFi667JWN9qNymXVXzGDmvuP60SSgC+e92sd7B7158f7Fy3Mb6rXS5EDPw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: false
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Adds a toggle to the Starlight theme editor to allow people to opt in to shades that pass WCAG’S AAA requirements (7:1 contrast ratio for body text).
- Preview: https://deploy-preview-2282--astro-starlight.netlify.app/guides/css-and-tailwind/#color-theme-editor
- The `getPalettes()` function used to generate a colour palette now takes a minimum contrast to enforce and uses it for the shades which are currently marginal (pass AA requirements but not AAA).
- Contrast calculations are done with `culori`’s [`wcagContrast()`](https://culorijs.org/api/#wcagContrast) method. I used that to compute a contrast and then colours without sufficient contrast have their luminance incremented/decremented in 0.5% steps until the contrast requirement is met.


#### Browser testing

Tested on macOS with:

- Chrome 128.0.6613.113
- Firefox 129.0.2 and 130.0
- Safari 17.6

Tested on Android with:

- Firefox

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
