### PR TITLE
Prevent Zod errors from crashing build

### DIFF
--- a/.changeset/famous-glasses-clean.md
+++ b/.changeset/famous-glasses-clean.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/starlight': patch
+---
+
+Safely handle Zod errors 
+
+Prevents bugs where errors without the `.received` props would through and cause builds to fail unnecessarily.

--- a/packages/starlight/utils/error-map.ts
+++ b/packages/starlight/utils/error-map.ts
@@ -143,7 +143,8 @@ const errorMap: z.ZodErrorMap = (baseError, ctx) => {
 };
 
 const getTypeOrLiteralMsg = (error: TypeOrLiteralErrByPathEntry): string => {
-	if (typeof error.received === 'undefined') return 'Required';
+	// received could be `undefined` or the string `'undefined'`
+	if (typeof error.received === 'undefined' || error.received === 'undefined') return 'Required';
 	const expectedDeduped = new Set(error.expected);
 	switch (error.code) {
 		case 'invalid_type':

--- a/packages/starlight/utils/error-map.ts
+++ b/packages/starlight/utils/error-map.ts
@@ -143,7 +143,7 @@ const errorMap: z.ZodErrorMap = (baseError, ctx) => {
 };
 
 const getTypeOrLiteralMsg = (error: TypeOrLiteralErrByPathEntry): string => {
-	if (error.received === 'undefined') return 'Required';
+	if (typeof error.received === 'undefined') return 'Required';
 	const expectedDeduped = new Set(error.expected);
 	switch (error.code) {
 		case 'invalid_type':


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Errors are weakly typed and some `undefined`s were escaping due to a missing `typeof`, which this fixes.
