### PR TITLE
i18n(fr): update `reference/configuration`

### DIFF
--- a/docs/src/content/docs/fr/reference/configuration.mdx
+++ b/docs/src/content/docs/fr/reference/configuration.mdx
@@ -455,6 +455,8 @@ Définit si le système de recherche du site par défaut de Starlight, [Pagefind
 Utilisez la valeur `false` pour désactiver l'indexation de votre site avec Pagefind.
 Cela désactivera également l'interface de recherche par défaut de Starlight si utilisée.
 
+Pagefind ne peut pas être activé lorsque l'option [`prerender`](#prerender) est définie à `false`.
+
 ### `prerender`
 
 **Type :** `boolean`  


### PR DESCRIPTION
#### Description

Just realized that when updating the French version of the `reference/configuration` page in #2296, I missed one sentence 🙈