### PR TITLE
Fix broken restoration of remark directives.

### DIFF
--- a/.changeset/gold-coats-destroy.md
+++ b/.changeset/gold-coats-destroy.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fixes restoration of remark directives for nodes with custom data attached.

--- a/packages/starlight/integrations/asides.ts
+++ b/packages/starlight/integrations/asides.ts
@@ -227,7 +227,8 @@ export function remarkDirectivesRestoration() {
 			if (
 				index !== undefined &&
 				parent &&
-				(node.type === 'textDirective' || node.type === 'leafDirective')
+				(node.type === 'textDirective' || node.type === 'leafDirective') &&
+				node.data === undefined
 			) {
 				transformUnhandledDirective(node, index, parent);
 				return;


### PR DESCRIPTION
#### Description

This fixes the logic in `remarkDirectivesRestoration` so it only restores remark directives that do not have node data.

If the node has a defined data, this means it was set explicitly and should be allowed to continue to be processed later on by `remark-rehype`.