### PR TITLE
Re-enable skipped navigation test

### DIFF
--- a/packages/starlight/__tests__/build-format-file/navigation.test.ts
+++ b/packages/starlight/__tests__/build-format-file/navigation.test.ts
@@ -17,13 +17,13 @@ vi.mock('astro:content', async () =>
 
 describe('getSidebar with build.format = "file"', () => {
 	test('returns an array of sidebar entries with its file extension', () => {
-		expect(getSidebar('/', undefined)).toMatchInlineSnapshot(`
+		expect(getSidebar('/index.html', undefined)).toMatchInlineSnapshot(`
 			[
 			  {
 			    "attrs": {},
 			    "badge": undefined,
 			    "href": "/index.html",
-			    "isCurrent": false,
+			    "isCurrent": true,
 			    "label": "Home",
 			    "type": "link",
 			  },

--- a/packages/starlight/__tests__/build-format-file/navigation.test.ts
+++ b/packages/starlight/__tests__/build-format-file/navigation.test.ts
@@ -23,7 +23,7 @@ describe('getSidebar with build.format = "file"', () => {
 			    "attrs": {},
 			    "badge": undefined,
 			    "href": "/index.html",
-			    "isCurrent": true,
+			    "isCurrent": false,
 			    "label": "Home",
 			    "type": "link",
 			  },


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- @HiDeoo noticed this test file had been accidentally skipped when added in #1023
- This PR re-enables it, by adding `.test` to the filename, and fixes a test it contains to pass

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
