### PR TITLE
Fix Expressive Code UI labels

### DIFF
--- a/.changeset/perfect-crews-train.md
+++ b/.changeset/perfect-crews-train.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes an issue with Expressive Code UI labels not displaying correctly.

--- a/packages/starlight/__tests__/i18n/translations-ec.test.ts
+++ b/packages/starlight/__tests__/i18n/translations-ec.test.ts
@@ -97,6 +97,20 @@ test('add translations in a multilingual site with french as default locale', as
 	expect(getExpressiveCodeOverridenLanguages()).toEqual(['fr', 'ru']);
 });
 
+test('does not add translations if the label does not exist', async () => {
+	const [config] = getStarlightConfigAndUseTranslations(undefined);
+
+	addTranslations(config, getUseTranslations(false));
+
+	expect(vi.mocked(pluginFramesTexts.overrideTexts)).not.toHaveBeenCalled();
+});
+
+function getUseTranslations(exists: boolean = true) {
+	const t = () => 'test UI string';
+	t.exists = vi.fn().mockReturnValue(exists);
+	return vi.fn().mockReturnValue(t);
+}
+
 function getStarlightConfigAndUseTranslations(
 	locales: StarlightUserConfig['locales'],
 	defaultLocale?: StarlightUserConfig['defaultLocale']
@@ -107,7 +121,7 @@ function getStarlightConfigAndUseTranslations(
 			locales,
 			defaultLocale,
 		}),
-		vi.fn().mockReturnValue(() => 'test UI string'),
+		getUseTranslations(),
 	] as const;
 }
 

--- a/packages/starlight/integrations/expressive-code/translations.ts
+++ b/packages/starlight/integrations/expressive-code/translations.ts
@@ -29,7 +29,7 @@ function addTranslationsForLocale(
 		'expressiveCode.terminalWindowFallbackTitle',
 	] as const;
 	translationKeys.forEach((key) => {
-		const translation = t(key);
+		const translation = t.exists(key) ? t(key) : undefined;
 		if (!translation) return;
 		const ecId = key.replace(/^expressiveCode\./, '');
 		pluginFramesTexts.overrideTexts(lang, { [ecId]: translation });


### PR DESCRIPTION
#### Description

This PR fixes an issue with Expressive Code UI labels not being displayed correctly in the UI. The issue was caused with the recent change to `i18next` `t` function which returns the key if a translation is not found. This PR fixes the issue by adding a check to see if the translation exists first and if not, it will return `undefined`.

Before:

<img width="374" alt="image" src="https://github.com/user-attachments/assets/e0138989-b54e-4adc-b193-1c77c7900418">

After:

<img width="162" alt="image" src="https://github.com/user-attachments/assets/c164bf94-920f-4cbf-82be-ccd9bb685c91">
