### PR TITLE
i18n(fr): add `reference/icons`

### DIFF
--- a/docs/src/content/docs/fr/reference/icons.mdx
+++ b/docs/src/content/docs/fr/reference/icons.mdx
@@ -1,0 +1,19 @@
+---
+title: Référence des icônes
+description: Une vue d'ensemble de tous les icônes disponibles dans Starlight.
+---
+
+Starlight fournit un ensemble d'icônes intégrées que vous pouvez afficher dans votre contenu en utilisant le composant `<Icon>`.
+
+## Utiliser les icônes
+
+Les icônes peuvent être affichées en utilisant le composant [`<Icon>`](/fr/components/icons/).
+Elles sont également souvent utilisées dans d'autres composants, comme les [cartes](/fr/components/cards/) ou des paramètres comme les [actions de la section d'en-tête](/fr/reference/frontmatter/#hero).
+
+## Toutes les icônes
+
+Une liste de toutes les icônes disponibles est affichée ci-dessous avec leurs noms associés. Cliquez sur une icône pour copier son nom dans votre presse-papiers.
+
+import IconsList from '~/components/icons-list.astro';
+
+<IconsList />


### PR DESCRIPTION
#### Description

This PR adds the French version of the `reference/icons` page with the changes from #2121.