### PR TITLE
docs: fix broken Markdown content related links

### DIFF
--- a/docs/src/content/docs/components/using-components.mdx
+++ b/docs/src/content/docs/components/using-components.mdx
@@ -31,7 +31,7 @@ import CustomCard from '../../components/CustomCard.astro';
 ```
 
 Because Starlight is powered by Astro, you can add support for components built with any [supported UI framework (React, Preact, Svelte, Vue, Solid, and Alpine)](https://docs.astro.build/en/core-concepts/framework-components/) in your MDX files.
-Learn more about [using components in MDX](https://docs.astro.build/en/guides/markdown-content/#using-components-in-mdx) in the Astro docs.
+Learn more about [using components in MDX](https://docs.astro.build/en/guides/integrations-guide/mdx/#using-components-in-mdx) in the Astro docs.
 
 ## Using a component in Markdoc
 

--- a/docs/src/content/docs/guides/authoring-content.mdx
+++ b/docs/src/content/docs/guides/authoring-content.mdx
@@ -392,7 +392,7 @@ Starlight supports all other Markdown authoring syntax, such as lists and tables
 
 ## Advanced Markdown and MDX configuration
 
-Starlight uses Astro’s Markdown and MDX renderer built on remark and rehype. You can add support for custom syntax and behavior by adding `remarkPlugins` or `rehypePlugins` in your Astro config file. See [“Configuring Markdown and MDX”](https://docs.astro.build/en/guides/markdown-content/#configuring-markdown-and-mdx) in the Astro docs to learn more.
+Starlight uses Astro’s Markdown and MDX renderer built on remark and rehype. You can add support for custom syntax and behavior by adding `remarkPlugins` or `rehypePlugins` in your Astro config file. See [“Markdown Plugins”](https://docs.astro.build/en/guides/markdown-content/#markdown-plugins) in the Astro docs to learn more.
 
 ## Markdoc
 


### PR DESCRIPTION
#### Description

Following the Astro Docs https://github.com/withastro/docs/pull/9337 & https://github.com/withastro/docs/pull/9344 pull requests, this PR fixes a few broken links related to Markdown content.