### PR TITLE
i18n(fr): update `guides/authoring-content`

### DIFF
--- a/docs/src/content/docs/fr/guides/authoring-content.mdx
+++ b/docs/src/content/docs/fr/guides/authoring-content.mdx
@@ -391,7 +391,7 @@ Starlight prend en charge toutes les autres syntaxes de rédaction Markdown, tel
 
 ## Configuration avancée de Markdown et MDX
 
-Starlight utilise le moteur de rendu Markdown et MDX d'Astro basé sur remark et rehype. Vous pouvez ajouter la prise en charge de syntaxe et comportement personnalisés en ajoutant `remarkPlugins` ou `rehypePlugins` dans votre fichier de configuration Astro. Pour en savoir plus, consultez [« Configuration de Markdown et MDX »](https://docs.astro.build/fr/guides/markdown-content/#configuration-de-markdown-et-mdx) dans la documentation d'Astro.
+Starlight utilise le moteur de rendu Markdown et MDX d'Astro basé sur remark et rehype. Vous pouvez ajouter la prise en charge de syntaxe et comportement personnalisés en ajoutant `remarkPlugins` ou `rehypePlugins` dans votre fichier de configuration Astro. Pour en savoir plus, consultez [« Plugins Markdown »](https://docs.astro.build/fr/guides/markdown-content/#plugins-markdown) dans la documentation d'Astro.
 
 ## Markdoc
 


### PR DESCRIPTION
#### Description

This PR updates the French version of the `guides/authoring-content` page with the changes from #2344.