### PR TITLE
Draft: Pagefind weight frontmatter

### DIFF
--- a/docs/src/content/docs/guides/site-search.mdx
+++ b/docs/src/content/docs/guides/site-search.mdx
@@ -1,6 +1,8 @@
 ---
 title: Site Search
 description: Learn about Starlight’s built-in site search features and how to customize them.
+pagefind:
+  weight: 7.5
 ---
 
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';

--- a/packages/starlight/components/Page.astro
+++ b/packages/starlight/components/Page.astro
@@ -38,7 +38,8 @@ const pagefindEnabled =
 	!Astro.props.entry.slug.endsWith('/404') &&
 	pagefindConfig !== false;
 
-const pagefindWeight = typeof pagefindConfig === 'object' && pagefindConfig.weight;
+const pagefindWeight =
+	pagefindEnabled && typeof pagefindConfig === 'object' && pagefindConfig.weight;
 ---
 
 <html

--- a/packages/starlight/components/Page.astro
+++ b/packages/starlight/components/Page.astro
@@ -31,10 +31,14 @@ import '../style/asides.css';
 // Important that this is the last import so it can override built-in styles.
 import 'virtual:starlight/user-css';
 
+const pagefindConfig = Astro.props.entry.data.pagefind;
+
 const pagefindEnabled =
 	Astro.props.entry.slug !== '404' &&
 	!Astro.props.entry.slug.endsWith('/404') &&
-	Astro.props.entry.data.pagefind !== false;
+	pagefindConfig !== false;
+
+const pagefindWeight = typeof pagefindConfig === 'object' && pagefindConfig.weight;
 ---
 
 <html
@@ -85,6 +89,7 @@ const pagefindEnabled =
 				<PageSidebar slot="right-sidebar" {...Astro.props} />
 				<main
 					data-pagefind-body={pagefindEnabled}
+					data-pagefind-weight={pagefindWeight}
 					lang={Astro.props.entryMeta.lang}
 					dir={Astro.props.entryMeta.dir}
 				>

--- a/packages/starlight/schema.ts
+++ b/packages/starlight/schema.ts
@@ -101,8 +101,14 @@ const StarlightFrontmatterSchema = (context: SchemaContext) =>
 			})
 			.optional(),
 
-		/** Pagefind indexing for this page - set to false to disable. */
-		pagefind: z.boolean().default(true),
+		/**
+		 * Pagefind configuration for this page - set to false to disable indexing or set
+		 * as an object with a "weight" key between 0.0 and 10.0 to adjust the ranking where
+		 * a larger number is a higher ranking.
+		 *
+		 * More information about Pagefind weighting: https://pagefind.app/docs/weighting/
+		 */
+		pagefind: z.union([z.boolean(), z.object({ weight: z.number().min(0).max(10) })]).default(true),
 
 		/**
 		 * Indicates that this page is a draft and will not be included in production builds.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #2348
- This exposes a `pagefind.weight` property for page frontmatter to adjust the search index weight. 

Note: Currently we don't have any tests to verify the pagefind output. I've tested this by adding a weight of `7.5` to the `site-search.mdx` page. Before when searching for "pagefind" this page would be the 3rd on the list, now it is the 1st. This is purely for testing purposes. 

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
