### PR TITLE
docs: fix link buttons incorrect heading name

### DIFF
--- a/docs/src/content/docs/components/link-buttons.mdx
+++ b/docs/src/content/docs/components/link-buttons.mdx
@@ -63,7 +63,7 @@ Configuration Reference
 
 </Preview>
 
-### Add icons to cards
+### Add icons to link buttons
 
 Include an icon in a link button using the [`icon`](#icon) attribute set to the name of [one of Starlight’s built-in icons](/reference/icons/#all-icons).
 


### PR DESCRIPTION
#### Description

This PR fixes the heading of a section of the `<LinkButton>` component documentation that was incorrectly named.