### PR TITLE
Fix synced nested `<Tabs>` restoration issue

### DIFF
--- a/.changeset/beige-knives-visit.md
+++ b/.changeset/beige-knives-visit.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes an issue with synced `<Tabs>` components containing nested `<Tabs>` causing tab panels to not render correctly.

--- a/packages/starlight/__e2e__/fixtures/basics/src/content/docs/tabs-nested.mdx
+++ b/packages/starlight/__e2e__/fixtures/basics/src/content/docs/tabs-nested.mdx
@@ -1,0 +1,47 @@
+---
+title: Tabs
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+A set of tabs using the `pkg` sync key with some nested tabs using an `os` sync key.
+
+<Tabs syncKey="pkg">
+
+    <TabItem label="npm">
+
+    	npm content
+
+    	<Tabs syncKey="os">
+    		<TabItem label="macos">npm macOS</TabItem>
+    		<TabItem label="windows">npm Windows</TabItem>
+    		<TabItem label="linux">npm GNU/Linux</TabItem>
+    	</Tabs>
+
+    </TabItem>
+
+    <TabItem label="pnpm">
+
+    		pnpm content
+
+    		<Tabs syncKey="os">
+    				<TabItem label="macos">pnpm macOS</TabItem>
+    				<TabItem label="windows">pnpm Windows</TabItem>
+    				<TabItem label="linux">pnpm GNU/Linux</TabItem>
+    			</Tabs>
+
+    	</TabItem>
+
+    <TabItem label="yarn">
+
+    		yarn content
+
+    		<Tabs syncKey="os">
+    				<TabItem label="macos">yarn macOS</TabItem>
+    				<TabItem label="windows">yarn Windows</TabItem>
+    				<TabItem label="linux">yarn GNU/Linux</TabItem>
+    			</Tabs>
+
+    	</TabItem>
+
+</Tabs>

--- a/packages/starlight/user-components/Tabs.astro
+++ b/packages/starlight/user-components/Tabs.astro
@@ -54,7 +54,7 @@ if (isSynced) {
 			const tabIndexToRestore = tabs.findIndex(
 				(tab) => tab instanceof HTMLAnchorElement && tab.textContent?.trim() === label
 			);
-			const panels = starlightTabs?.querySelectorAll('[role="tabpanel"]');
+			const panels = starlightTabs?.querySelectorAll(':scope > [role="tabpanel"]');
 			const newTab = tabs[tabIndexToRestore];
 			const newPanel = panels[tabIndexToRestore];
 			if (tabIndexToRestore < 1 || !newTab || !newPanel) return;


### PR DESCRIPTION
#### Description

This pull request fixes an issue reported on Discord regarding synced nested tabs.

Repro steps:

- Visit https://developers.cloudflare.com/d1/get-started/#1-create-a-worker
- Select the _Dashboard_ tab
- Reload the page
- The first tab panel is invisible

This issue is similar to #473 where the panels `hidden` property was not being set correctly due to the query selector matching all nested panels instead of just the direct children. The same issue can happen when restoring synced tabs as this part of the code was not including the same fix.

The restoration code now also uses the [`:scope` CSS pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:scope#direct_children) to only match the direct children.

I've included a test case to cover both the syncing of nested tabs (fixed in #473) and the restoration of synced nested tabs (fixed in this PR).

I also tested the fix locally on the Cloudflare docs and it now works as expected.