### PR TITLE
Loosen i18n schema to pass through unknown keys by default

### DIFF
--- a/.changeset/quick-swans-rule.md
+++ b/.changeset/quick-swans-rule.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Loosen Starlight’s i18n schema to pass through unknown keys

--- a/packages/starlight/__tests__/basics/translations.test.ts
+++ b/packages/starlight/__tests__/basics/translations.test.ts
@@ -30,10 +30,6 @@ describe('t()', async () => {
 						'test.nesting1': '$t(test.nesting2) is nested',
 						'test.nesting2': 'this UI string',
 					},
-					// We do not strip unknown translations in this test so that user-defined translations can
-					// override plugin translations like it would in a real- world scenario were the plugin
-					// would have provided a custom schema to extend the translations.
-					{ stripUnknown: false },
 				],
 			],
 		})
@@ -112,7 +108,7 @@ describe('t.all()', async () => {
 	// See the `t()` tests for an explanation of how the user-defined translations are mocked.
 	vi.doMock('astro:content', async () =>
 		(await import('../test-utils')).mockedAstroContent({
-			i18n: [['en', { 'test.foo': 'bar' }, { stripUnknown: false }]],
+			i18n: [['en', { 'test.foo': 'bar' }]],
 		})
 	);
 	vi.resetModules();
@@ -129,7 +125,7 @@ describe('t.exists()', async () => {
 	// See the `t()` tests for an explanation of how the user-defined translations are mocked.
 	vi.doMock('astro:content', async () =>
 		(await import('../test-utils')).mockedAstroContent({
-			i18n: [['en', { 'test.foo': 'bar' }, { stripUnknown: false }]],
+			i18n: [['en', { 'test.foo': 'bar' }]],
 		})
 	);
 	vi.resetModules();

--- a/packages/starlight/__tests__/plugins/translations.test.ts
+++ b/packages/starlight/__tests__/plugins/translations.test.ts
@@ -6,7 +6,7 @@ vi.mock('astro:content', async () =>
 		// We do not strip unknown translations in this test so that user-defined translations can
 		// override plugin translations like it would in a real- world scenario were the plugin would
 		// have provided a custom schema to extend the translations.
-		i18n: [['ar', { 'testPlugin3.doThing': 'افعل الشيء' }, { stripUnknown: false }]],
+		i18n: [['ar', { 'testPlugin3.doThing': 'افعل الشيء' }]],
 	})
 );
 

--- a/packages/starlight/__tests__/test-utils.ts
+++ b/packages/starlight/__tests__/test-utils.ts
@@ -37,16 +37,10 @@ function mockDoc(
 	};
 }
 
-function mockDict(
-	id: string,
-	data: z.input<ReturnType<typeof i18nSchema>>,
-	{ stripUnknown } = { stripUnknown: true }
-) {
+function mockDict(id: string, data: z.input<ReturnType<typeof i18nSchema>>) {
 	return {
 		id,
-		data: stripUnknown
-			? i18nSchema().parse(data)
-			: i18nSchema().and(z.record(z.string())).parse(data),
+		data: i18nSchema().parse(data),
 	};
 }
 

--- a/packages/starlight/schemas/i18n.ts
+++ b/packages/starlight/schemas/i18n.ts
@@ -23,16 +23,26 @@ const defaultI18nSchema = () =>
 /** Type of Starlight’s default i18n schema, including extensions from Pagefind and Expressive Code. */
 type DefaultI18nSchema = ReturnType<typeof defaultI18nSchema>;
 
+/**
+ * Based on the the return type of Zod’s `merge()` method. Merges the type of two `z.object()` schemas.
+ * Also sets them as “passthrough” schemas as that’s how we use them. In practice whether or not the types
+ * are passthrough or not doesn’t matter too much.
+ */
+type MergeSchemas<A extends z.AnyZodObject, B extends z.AnyZodObject> = z.ZodObject<
+	z.objectUtil.extendShape<A['shape'], B['shape']>,
+	'passthrough',
+	B['_def']['catchall']
+>;
 /** Type that extends Starlight’s default i18n schema with an optional, user-defined schema. */
 type ExtendedSchema<T extends z.AnyZodObject> = T extends z.AnyZodObject
-	? z.ZodIntersection<DefaultI18nSchema, T>
+	? MergeSchemas<DefaultI18nSchema, T>
 	: DefaultI18nSchema;
 
 /** Content collection schema for Starlight’s optional `i18n` collection. */
 export function i18nSchema<T extends z.AnyZodObject = z.ZodObject<{}>>({
 	extend = z.object({}) as T,
 }: i18nSchemaOpts<T> = {}): ExtendedSchema<T> {
-	return defaultI18nSchema().merge(extend) as ExtendedSchema<T>;
+	return defaultI18nSchema().merge(extend).passthrough() as ExtendedSchema<T>;
 }
 export type i18nSchemaOutput = z.output<ReturnType<typeof i18nSchema>>;
 

--- a/packages/starlight/schemas/i18n.ts
+++ b/packages/starlight/schemas/i18n.ts
@@ -27,6 +27,8 @@ type DefaultI18nSchema = ReturnType<typeof defaultI18nSchema>;
  * Based on the the return type of Zod’s `merge()` method. Merges the type of two `z.object()` schemas.
  * Also sets them as “passthrough” schemas as that’s how we use them. In practice whether or not the types
  * are passthrough or not doesn’t matter too much.
+ * 
+ * @see https://github.com/colinhacks/zod/blob/3032e240a0c227692bb96eedf240ed493c53f54c/src/types.ts#L2656-L2660
  */
 type MergeSchemas<A extends z.AnyZodObject, B extends z.AnyZodObject> = z.ZodObject<
 	z.objectUtil.extendShape<A['shape'], B['shape']>,


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- This PR calls Zod’s [`.passthrough()`](https://github.com/colinhacks/zod?tab=readme-ov-file#passthrough) method on Starlight’s i18n schema by default.
- This keeps keys not known to the schema in the parsed output instead of stripping them out.
- This improves the DX of custom plugins: these already have types for their i18n strings generated via the `injectTranslations()` hook, but currently users would still need to explicitly extend the i18n schema to provide custom translations.
- With this change, users can skip extending the i18n schema, and just define custom translation data files directly.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
