### PR TITLE
i18n(fr): update `reference/plugins`

### DIFF
--- a/docs/src/content/docs/fr/reference/plugins.md
+++ b/docs/src/content/docs/fr/reference/plugins.md
@@ -27,6 +27,7 @@ interface StarlightPlugin {
       command: 'dev' | 'build' | 'preview';
       isRestart: boolean;
       logger: AstroIntegrationLogger;
+      injectTranslations: (Record<string, Record<string, string>>) => void;
     }) => void | Promise<void>;
   };
 }


### PR DESCRIPTION
#### Description

This PR updates the French version of the `reference/plugins` page which is missing `injectTranslations` in the "Quick API Reference" section.