### PR TITLE
fix bottom padding in search dialog

### DIFF
--- a/.changeset/thin-guests-listen.md
+++ b/.changeset/thin-guests-listen.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes CSS issue where bottom padding is not applied in the search dialog.

--- a/packages/starlight/components/Search.astro
+++ b/packages/starlight/components/Search.astro
@@ -231,6 +231,8 @@ const pagefindTranslations = {
 	}
 
 	.dialog-frame {
+		position: relative;
+		overflow: auto;
 		flex-direction: column;
 		flex-grow: 1;
 		gap: 1rem;


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Fixes CSS issue where bottom padding is not applied in the search dialog. 

| Before                                                                                                               | After                                                                                                                |
|----------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
| <img width="1512" alt="image" src="https://github.com/user-attachments/assets/c0f3ca01-bced-4cfc-a8a9-1a368d10c0f6"> | <img width="1508" alt="image" src="https://github.com/user-attachments/assets/1b58fcbf-1957-4394-9345-3fe3cb4c17c2"> |

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
