### PR TITLE
Fix accessibility CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
 
   pa11y:
     name: Check for accessibility issues
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The `ubuntu-latest` label is currently in the process of [migrating](https://github.blog/changelog/2024-09-25-actions-new-images-and-ubuntu-latest-changes/) to Ubuntu 24 over the course of this month, beginning September 23rd and finishing on October 30th.

The latest [successful run](https://github.com/withastro/starlight/actions/runs/11270268428/job/31340626770) of the accessibility CI workflow was running on `ubuntu-22.04` (which can be seen by expanding the "Set up job" and "Runner Image" sections of the job log). Since then, this job have been failing, e.g. [here](https://github.com/withastro/starlight/actions/runs/11294865497/job/31416309376?pr=2470), which is running on `ubuntu-24.04`.

This PR updates the `runs-on` field of the accessibility CI workflow to `ubuntu-22.04` to ensure that the job continues to work. Note that there is no activity on the `pa11y-ci` issue to migrate from Puppeteer 9 to Puppeteer 22 since November 2023, so it is unclear if we will ever be able to run the accessibility CI workflow on Ubuntu 24+ with `pa11y-ci`.