### PR TITLE
i18n(de): update some files for consistency in German language

### DIFF
--- a/docs/src/content/docs/de/components/asides.mdx
+++ b/docs/src/content/docs/de/components/asides.mdx
@@ -132,7 +132,7 @@ Ein Warnhinweis *mit* einem benutzerdefinierten Titel.
 
 </Preview>
 
-## `<Aside>` Eigenschaften
+## `<Aside>`-Eigenschaften
 
 **Implementation:** [`Aside.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/user-components/Aside.astro)
 
@@ -141,7 +141,7 @@ Die Komponente `<Aside>` akzeptiert die folgenden Eigenschaften:
 ### `type`
 
 **Typ:** `'note' | 'tip' | 'caution' | 'danger'`  
-**Voreinstellung:** `'note'`
+**Standard:** `'note'`
 
 Die Art der Nebenbemerkung, die angezeigt werden soll:
 

--- a/docs/src/content/docs/de/components/badges.mdx
+++ b/docs/src/content/docs/de/components/badges.mdx
@@ -139,7 +139,7 @@ Der Textinhalt, der in dem Abzeichen angezeigt werden soll.
 ### `variant`
 
 **Typ:** `'note' | 'danger' | 'success' | 'caution' | 'tip' | 'default'`  
-**Voreinstellung:** `'default'`
+**Standard:** `'default'`
 
 Die zu verwendende Farbvariante des Abzeichens: `note` (blau), `tip` (lila), `danger` (rot), `caution` (orange), `success` (grün) oder `default` (Akzentfarbe des Aussehens).
 

--- a/docs/src/content/docs/de/components/card-grids.mdx
+++ b/docs/src/content/docs/de/components/card-grids.mdx
@@ -160,7 +160,7 @@ Weitere Informationen, die du weitergeben möchtest.
 
 </Preview>
 
-## `<CardGrid>` Eigenschaften
+## `<CardGrid>`-Eigenschaften
 
 **Implementation:** [`CardGrid.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/user-components/CardGrid.astro)
 

--- a/docs/src/content/docs/de/components/cards.mdx
+++ b/docs/src/content/docs/de/components/cards.mdx
@@ -98,7 +98,7 @@ Die Komponente `<Card>` akzeptiert die folgenden Eigenschaften:
 
 ### `title`
 
-**erforderlich**  
+**Erforderlich**  
 **Typ:** `string`
 
 Der Titel der anzuzeigenden Karte.

--- a/docs/src/content/docs/de/components/file-tree.mdx
+++ b/docs/src/content/docs/de/components/file-tree.mdx
@@ -218,7 +218,7 @@ import { FileTree } from '@astrojs/starlight/components';
 
 </Preview>
 
-## `<FileTree>` Eigenschaften
+## `<FileTree>`-Eigenschaften
 
 **Implementation:** [`FileTree.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/user-components/FileTree.astro)
 

--- a/docs/src/content/docs/de/components/icons.mdx
+++ b/docs/src/content/docs/de/components/icons.mdx
@@ -94,7 +94,7 @@ Die Komponente `<Icon>` akzeptiert die folgenden Eigenschaften:
 
 ### `name`
 
-**erforderlich**  
+**Erforderlich**  
 **Typ:** `string`
 
 Der Name des anzuzeigenden Symbols wird auf [eines der in Starlight integrierten Symbole](/de/reference/icons/#alle-symbole) gesetzt.

--- a/docs/src/content/docs/de/components/link-buttons.mdx
+++ b/docs/src/content/docs/de/components/link-buttons.mdx
@@ -118,7 +118,7 @@ Die `<LinkButton>`-Komponente akzeptiert die folgenden Eigenschaften und auch al
 
 ### `href`
 
-**erforderlich**  
+**Erforderlich**  
 **Typ:** `string`
 
 Die URL, auf die der Link-Button zeigt.
@@ -126,7 +126,7 @@ Die URL, auf die der Link-Button zeigt.
 ### `variant`
 
 **Typ:** `'primary' | 'secondary' | 'minimal'`  
-**Voreinstellung:** `'primary'`
+**Standard:** `'primary'`
 
 Das Aussehen des Link-Button.
 Setze auf `primary` für einen auffälligen Call-to-Action-Link mit der Akzentfarbe des Themas, auf `secondary` für einen weniger auffälligen Link oder auf `minimal` für einen Link mit minimalem Styling.
@@ -140,6 +140,6 @@ Ein Link-Button kann ein `icon`-Attribut enthalten, das auf den Namen [eines von
 ### `iconPlacement`
 
 **Typ:** `'start' | 'end'`  
-**Voreinstellung:** `'end'`
+**Standard:** `'end'`
 
 Bestimmt die Platzierung des Symbols im Verhältnis zum Text des Link-Buttons.

--- a/docs/src/content/docs/de/components/link-cards.mdx
+++ b/docs/src/content/docs/de/components/link-cards.mdx
@@ -101,7 +101,7 @@ import { LinkCard } from '@astrojs/starlight/components';
 Zeige mehrere Link-Karten nebeneinander an, wenn genügend Platz vorhanden ist, indem du sie mit der Komponente [`<CardGrid>`](/de/components/card-grids/) gruppierst.
 Ein Beispiel findest du im Handbuch [“Gruppiere Link-Karten”](/de/components/card-grids/#link-karten-gruppieren).
 
-## `<LinkCard>` Eigenschaften
+## `<LinkCard>`-Eigenschaften
 
 **Implementation:** [`LinkCard.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/user-components/LinkCard.astro)
 

--- a/docs/src/content/docs/de/guides/pages.mdx
+++ b/docs/src/content/docs/de/guides/pages.mdx
@@ -113,7 +113,7 @@ Die folgenden Eigenschaften unterscheiden sich von Markdown frontmatter:
 ##### `sidebar`
 
 **Typ:** [`SidebarItem[]`](/de/reference/configuration/#sidebaritem)  
-**Voreinstellung:** die Seitenleiste, die auf der Grundlage der [globalen `Sidebar`-Konfiguration](/de/reference/configuration/#sidebar) erzeugt wird
+**Standard:** die Seitenleiste, die auf der Grundlage der [globalen `Sidebar`-Konfiguration](/de/reference/configuration/#sidebar) erzeugt wird
 
 Legt eine benutzerdefinierte Navigationsleiste für diese Seite fest.
 Wenn sie nicht gesetzt wird, verwendet die Seite die globale Standard-Seitenleiste.
@@ -144,14 +144,14 @@ In der Anleitung [„Seitenleisten-Navigation“](/de/guides/sidebar/) erfährst
 ##### `hasSidebar`
 
 **Typ:** `boolean`  
-**Voreinstellung:** `false` wenn [`frontmatter.template`](/de/reference/frontmatter/#template) `'splash'` ist, sonst `true`
+**Standard:** `false` wenn [`frontmatter.template`](/de/reference/frontmatter/#template) `'splash'` ist, sonst `true`
 
 Legt fest, ob die Seitenleiste auf dieser Seite angezeigt werden soll oder nicht.
 
 ##### `headings`
 
 **Typ:** `{ depth: number; slug: string; text: string }[]`  
-**Voreinstellung:** `[]`
+**Standard:** `[]`
 
 Gib ein Array mit allen Überschriften auf dieser Seite an.
 Starlight wird das Inhaltsverzeichnis der Seite aus diesen Überschriften generieren, wenn sie angegeben sind.
@@ -159,20 +159,20 @@ Starlight wird das Inhaltsverzeichnis der Seite aus diesen Überschriften generi
 ##### `dir`
 
 **Typ:** `'ltr' | 'rtl'`  
-**Voreinstellung:** die Schreibrichtung für das aktuelle Gebietsschema
+**Standard:** die Schreibrichtung für das aktuelle Gebietsschema
 
 Legt die Schreibrichtung für den Inhalt dieser Seite fest.
 
 ##### `lang`
 
 **Typ:** `String`  
-**Voreinstellung:** die Sprache des aktuellen Gebietsschemas
+**Standard:** die Sprache des aktuellen Gebietsschemas
 
 Setzt das BCP-47 Sprach-Tag für den Inhalt dieser Seite, z.B. `en`, `zh-CN` oder `pt-BR`.
 
 ##### `isFallback`
 
 **Typ:** `boolean`  
-**Voreinstellung:** `false`
+**Standard:** `false`
 
 Gibt an, ob diese Seite [Fallback-Inhalt](/de/guides/i18n/#fallback-inhalt) verwendet, weil es für die aktuelle Sprache keine Übersetzung gibt.

--- a/docs/src/content/docs/de/reference/configuration.mdx
+++ b/docs/src/content/docs/de/reference/configuration.mdx
@@ -75,7 +75,7 @@ type LogoConfig = { alt?: string; replacesTitle?: boolean } & (
 ### `tableOfContents`
 
 **Typ:** `false | { minHeadingLevel?: number; maxHeadingLevel?: number; }`  
-**Voreinstellung:** `{ minHeadingLevel: 2; maxHeadingLevel: 3; }`
+**Standard:** `{ minHeadingLevel: 2; maxHeadingLevel: 3; }`
 
 Konfiguriere das Inhaltsverzeichnis, das rechts auf jeder Seite angezeigt wird. Standardmäßig werden `<h2>` und `<h3>` Überschriften in dieses Inhaltsverzeichnis aufgenommen.
 
@@ -384,7 +384,7 @@ starlight({
 ### `expressiveCode`
 
 **Typ:** `StarlightExpressiveCodeOptions | boolean`  
-**Voreinstellung:** `true`
+**Standard:** `true`
 
 Starlight verwendet [Expressive Code](https://github.com/expressive-code/expressive-code/tree/main/packages/astro-expressive-code), um Codeblöcke zu rendern und Unterstützung für das Hervorheben von Teilen von Codebeispielen, das Hinzufügen von Dateinamen zu Codeblöcken und mehr hinzuzufügen.
 Im [Handbuch „Codeblöcke“](/de/guides/authoring-content/#codeblöcke) erfährst du, wie du die Expressive Code-Syntax in deinen Markdown- und MDX-Inhalten verwendest.
@@ -413,7 +413,7 @@ Zusätzlich zu den standardmäßigen Expressive Code-Optionen kannst du in deine
 #### `themes`
 
 **Typ:** `Array<string | ThemeObject | ExpressiveCodeTheme>`  
-**Voreinstellung:** `['starlight-dark', 'starlight-light']`
+**Standard:** `['starlight-dark', 'starlight-light']`
 
 Lege die Designs fest, die zum Stylen von Codeblöcken verwendet werden.
 Weitere Informationen zu den unterstützten Designformaten findest du in der [Expressive Code-Dokumentation zu Designs](https://github.com/expressive-code/expressive-code/blob/main/packages/astro-expressive-code/README.md#themes).
@@ -426,7 +426,7 @@ Konfiguriere dieses Verhalten mit der Option [`useStarlightDarkModeSwitch`](#use
 #### `useStarlightDarkModeSwitch`
 
 **Typ:** `boolean`  
-**Voreinstellung:** `true`
+**Standard:** `true`
 
 Falls `true`, wechseln Codeblöcke automatisch zwischen hellen und dunklen Designs, wenn sich das Site-Design ändert.
 Falls `false`, müssen Sie manuell CSS hinzufügen, um das Wechseln zwischen mehreren Designs zu handhaben.
@@ -438,7 +438,7 @@ Beim Festlegen von `themes` musst du mindestens ein dunkles und ein helles Desig
 #### `useStarlightUiThemeColors`
 
 **Typ:** `boolean`  
-**Voreinstellung:** `true` wenn `themes` nicht gesetzt ist, andernfalls `false`
+**Standard:** `true` wenn `themes` nicht gesetzt ist, andernfalls `false`
 
 Falls `true`, werden Starlights CSS-Variablen für die Farben von Codeblock-UI-Elementen (Hintergründe, Schaltflächen, Schatten usw.) verwendet, die dem [Site-Farbdesign](/de/guides/css-and-tailwind/#themes) entsprechen.
 Falls `false`, werden für diese Elemente die vom aktiven Syntaxhervorhebungsdesign bereitgestellten Farben verwendet.
@@ -450,7 +450,7 @@ Wenn du benutzerdefinierte Themes verwendest und dies auf `true` setzt, musst du
 ### `pagefind`
 
 **Typ:** `boolean`  
-**Voreinstellung:** `true`
+**Standard:** `true`
 
 Lege fest, ob Starlight's Standard-Site-Search-Anbieter [Pagefind](https://pagefind.app/) aktiviert ist.
 
@@ -462,7 +462,7 @@ Pagefind kann nicht aktiviert werden, wenn die Option [`prerender`](#prerender) 
 ### `prerender`
 
 **Typ:** `boolean`  
-**Voreinstellung:** `true`
+**Standard:** `true`
 
 Lege fest, ob Starlight-Seiten vorgerendert zu statischem HTML oder bei Bedarf von einem [SSR-Adapter](https://docs.astro.build/de/guides/server-side-rendering/) gerendert werden sollen.
 
@@ -508,7 +508,7 @@ interface HeadConfig {
 ### `lastUpdated`
 
 **Typ:** `boolean`  
-**Voreinstellung:** `false`
+**Standard:** `false`
 
 Legt fest, ob in der Fußzeile angezeigt werden soll, wann die Seite zuletzt aktualisiert wurde.
 
@@ -517,7 +517,7 @@ Standardmäßig verwendet diese Funktion die Git-Historie deines Repositorys und
 ### `pagination`
 
 **Typ:** `boolean`  
-**Voreinstellung:** `true`
+**Standard:** `true`
 
 Legt fest, ob die Fußzeile Links zur vorherigen und nächsten Seite enthalten soll.
 
@@ -526,7 +526,7 @@ Eine Seite kann diese Einstellung oder den Linktext und/oder die URL mit Hilfe d
 ### `favicon`
 
 **Typ:** `string`  
-**Voreinstellung:** `'/favicon.svg'`
+**Standard:** `'/favicon.svg'`
 
 Legt den Pfad des Standard-Favicons für deine Website fest. Dieses sollte sich im Verzeichnis `public/` befinden und eine gültige Icon-Datei (`.ico`, `.gif`, `.jpg`, `.png` oder `.svg`) sein.
 
@@ -558,7 +558,7 @@ starlight({
 ### `titleDelimiter`
 
 **Typ:** `string`  
-**Voreinstellung:** `'|'`
+**Standard:** `'|'`
 
 Legt das Trennzeichen zwischen Seitentitel und dem Titel der Website im `<title>`-Tag der Website fest, welches in den Browser-Tabs angezeigt wird.
 
@@ -568,7 +568,7 @@ Zum Beispiel heißt diese Seite „Konfigurationsreferenz“ und diese Website h
 ### `disable404Route`
 
 **Typ:** `Boolean`  
-**Voreinstellung:** `false`
+**Standard:** `false`
 
 Deaktiviert die Einspeisung von Starlights Standard [404 Seite](https://docs.astro.build/en/core-concepts/astro-pages/#custom-404-error-page). Um eine eigene `src/pages/404.astro`-Route in deinem Projekt zu verwenden, setze diese Option auf `true`.
 

--- a/docs/src/content/docs/de/reference/frontmatter.md
+++ b/docs/src/content/docs/de/reference/frontmatter.md
@@ -88,7 +88,7 @@ tableOfContents: false
 ### `template`
 
 **Typ:** `'doc' | 'splash'`  
-**Voreinstellung:** `'doc'`
+**Standard:** `'doc'`
 
 Legt die Layoutvorlage für diese Seite fest.
 Seiten verwenden standardmäßig das `'doc'`-Layout.
@@ -258,7 +258,7 @@ next: false
 ### `pagefind`
 
 **Typ:** `boolean`  
-**Voreinstellung:** `true`
+**Standard:** `true`
 
 Legt fest, ob diese Seite in den [Pagefind](https://pagefind.app/)-Suchindex aufgenommen werden soll. Setze das Feld auf `false`, um eine Seite von den Suchergebnissen auszuschließen:
 
@@ -273,7 +273,7 @@ pagefind: false
 ### `draft`
 
 **Typ:** `boolean`  
-**Voreinstellung:** `false`
+**Standard:** `false`
 
 Legt fest, ob diese Seite als Entwurf betrachtet werden soll und nicht in [Produktions-Builds](https://docs.astro.build/de/reference/cli-reference/#astro-build) und [Autogenerierte Link-Gruppen](/de/guides/sidebar/#automatisch-erzeugte-gruppen) aufgenommen werden soll. Setze die Eigenschaft auf `true`, um eine Seite als Entwurf zu markieren und sie nur während der Entwicklung sichtbar zu machen.
 
@@ -306,7 +306,7 @@ interface SidebarConfig {
 #### `label`
 
 **Typ:** `string`  
-**Voreinstellung:** der Seitentitel ([`title`](#title-erforderlich))
+**Standard:** der Seitentitel ([`title`](#title-erforderlich))
 
 Legt die Bezeichnung für diese Seite in der Seitenleiste fest, wenn sie in einer automatisch erzeugten Linkgruppe angezeigt wird.
 
@@ -338,7 +338,7 @@ sidebar:
 #### `hidden`
 
 **Typ:** `boolean`  
-**Voreinstellung:** `false`
+**Standard:** `false`
 
 Verhindert, dass diese Seite in eine automatisch generierte Seitenleistengruppe aufgenommen wird.
 
@@ -418,7 +418,7 @@ Mehr über Schemata für Inhaltssammlungen erfährst du in [„Definieren eines 
 ### `extend`
 
 **Typ:** Zod-Schema oder Funktion, die ein Zod-Schema zurückgibt  
-**Voreinstellung:** `z.object({})`
+**Standard:** `z.object({})`
 
 Erweitere das Schema von Starlight um zusätzliche Felder, indem du `extend` in den `docsSchema()` Optionen setzt.
 Der Wert sollte ein [Zod-Schema](https://docs.astro.build/de/guides/content-collections/#datentypen-mit-zod-definieren) sein.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- update `components/asides.mdx`
- update `components/badges.mdx`
- update `components/card-grids.mdx`
- update `components/cards.mdx`
- update `components/file-tree.mdx`
- update `components/icons.mdx`
- update `components/link-buttons.mdx`
- update `components/link-cards.mdx`
- update `guides/pages.mdx`
- update `reference/configuration.mdx`
- update `reference/frontmatter.mdx`

Changes described:

- add hyphen (`-`) to all props headings in the component pages

  Example in English and German with new Version:
  
  ```
  // components/code.mdx
  ## `<Code>` Props
  
  **Implementation:** [`Code.astro`](https://github.com/expressive-code/expressive-code/blob/main/packages/astro-expressive-code/components/Code.astro)
  ```
  
  ```
  // de/components/code.mdx
  ## `<Code>`-Eigenschaften
  
  **Implementation:** [`Code.astro`](https://github.com/expressive-code/expressive-code/blob/main/packages/astro-expressive-code/components/Code.astro)
  ```

- rename `Voreinstellung` to `Standard` (for the default value)

  Example in English and German with new Version:
  
  ```
  // components/asides.mdx
  ### `type`
  
  **type:** `'note' | 'tip' | 'caution' | 'danger'`  
  **default:** `'note'`
  
  The type of aside to display:
  ```
  
  ```
  // de/components/asides.mdx
  ### `type`
  
  **Typ:** `'note' | 'tip' | 'caution' | 'danger'`  
  **Standard:** `'note'`
  
  Die Art der Nebenbemerkung, die angezeigt werden soll:
  ```

- make all `Erforderlich` (`required` in English) CAPITALIZED (first letter)

  Example in English and German with new Version:
  
  ```
  // components/badges.mdx
  ### `text`
  
  **required**  
  **type:** `string`
  
  The text content to display in the badge.
  ```
  
  ```
  // de/components/badges.mdx
  ### `text`
  
  **Erforderlich**  
  **Typ:** `string`
  
  Der Textinhalt, der in dem Abzeichen angezeigt werden soll.
  ```

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
