### PR TITLE
docs: i18n improvements

### DIFF
--- a/docs/src/components/icons-list.astro
+++ b/docs/src/components/icons-list.astro
@@ -2,10 +2,18 @@
 import { Icon } from '@astrojs/starlight/components';
 import { Icons } from '../../../packages/starlight/components/Icons';
 
+interface Props {
+	labels?: {
+		copied?: string;
+	};
+}
+
+const { copied = 'Copied!' } = Astro.props.labels ?? {};
+
 const icons = Object.keys(Icons) as (keyof typeof Icons)[];
 ---
 
-<div class="icons-grid">
+<div class="icons-grid" data-label-copied={copied}>
 	{
 		icons.map((icon) => {
 			return (
@@ -19,6 +27,7 @@ const icons = Object.keys(Icons) as (keyof typeof Icons)[];
 </div>
 
 <script>
+	const copiedLabel = document.querySelector<HTMLDivElement>('.icons-grid')?.dataset.labelCopied!;
 	const icons = document.querySelectorAll<HTMLButtonElement>('.icon-preview');
 	icons.forEach((icon) => {
 		icon.addEventListener('click', () => {
@@ -27,7 +36,7 @@ const icons = Object.keys(Icons) as (keyof typeof Icons)[];
 
 			const iconLabel = icon.querySelector('[aria-live]');
 			if (iconLabel) {
-				iconLabel.textContent = 'Copied!';
+				iconLabel.textContent = copiedLabel;
 				setTimeout(() => {
 					iconLabel.textContent = iconName;
 				}, 1000);

--- a/docs/src/components/languages-list.astro
+++ b/docs/src/components/languages-list.astro
@@ -1,7 +1,6 @@
 ---
 import { getEntry } from 'astro:content';
 import translations from '../../../packages/starlight/translations';
-import { slugToLocaleData } from '../../../packages/starlight/utils/slugs';
 
 interface Props {
 	startsSentence?: boolean;
@@ -12,7 +11,7 @@ const slug = Astro.url.pathname.replace(/^\//, '').replace(/\/$/, '');
 // The docs entry for the current page, or `undefined` if the page is using fallback content.
 const entry = await getEntry('docs', slug);
 // The BCP-47 tag for the current page or fallback content's language.
-const pageLang = entry ? slugToLocaleData(slug).lang : 'en';
+const pageLang = entry && Astro.currentLocale ? Astro.currentLocale : 'en';
 // The BCP-47 tags for all supported languages in Starlight.
 const supportedLangs = Object.keys(translations);
 // An i18n helper that returns the language name for a given BCP-47 tag configured for the current page's language.

--- a/docs/src/content/docs/fr/reference/icons.mdx
+++ b/docs/src/content/docs/fr/reference/icons.mdx
@@ -16,4 +16,4 @@ Une liste de toutes les icônes disponibles est affichée ci-dessous avec leurs 
 
 import IconsList from '~/components/icons-list.astro';
 
-<IconsList />
+<IconsList labels={{ copied: 'Copié !' }} />

--- a/docs/src/content/docs/reference/icons.mdx
+++ b/docs/src/content/docs/reference/icons.mdx
@@ -16,4 +16,4 @@ A list of all available icons is shown below with their associated names. Click 
 
 import IconsList from '~/components/icons-list.astro';
 
-<IconsList />
+<IconsList labels={{ copied: 'Copied!' }} />


### PR DESCRIPTION
#### Description

This PR implements tiny i18n related improvements for the documentation:

- Removes the `slugToLocaleData()` internal dependency in the languages list component in favor of using `Astro.currentLocale`.
- Adds a translatable "copied" label to the icons list as discussed in https://github.com/withastro/starlight/pull/2343#pullrequestreview-2313253701