### PR TITLE
Fixes ToC highlighting after window resize

### DIFF
--- a/.changeset/silent-fireants-retire.md
+++ b/.changeset/silent-fireants-retire.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes a table of contents highlighting issue after resizing the window.

--- a/packages/starlight/components/TableOfContents/starlight-toc.ts
+++ b/packages/starlight/components/TableOfContents/starlight-toc.ts
@@ -88,7 +88,10 @@ export class StarlightTOC extends HTMLElement {
 		let timeout: NodeJS.Timeout;
 		window.addEventListener('resize', () => {
 			// Disable intersection observer while window is resizing.
-			if (observer) observer.disconnect();
+			if (observer) {
+				observer.disconnect();
+				observer = undefined;
+			}
 			clearTimeout(timeout);
 			timeout = setTimeout(() => this.onIdle(observe), 200);
 		});

--- a/packages/starlight/vitest.config.ts
+++ b/packages/starlight/vitest.config.ts
@@ -21,10 +21,10 @@ export default defineConfig({
 			],
 			thresholds: {
 				autoUpdate: true,
-				lines: 89.28,
+				lines: 89.26,
 				functions: 92.78,
 				branches: 92.83,
-				statements: 89.28,
+				statements: 89.26,
 			},
 		},
 	},


### PR DESCRIPTION
#### Description

- Closes #2506

This PR fixes a table of contents highlighting issue after the window is resized.

When resizing the window, the current code disconnect the `IntersectionObserver` and re-runs the `observe` function after a small amount of time. Altho, this function starts by checking if the variable containing the `IntersectionObserver` is defined, which is still the case after a disconnect, and if it is, it doesn't re-run the logic to observe the elements.

This PR fixes the issue by setting the observer variable to `undefined` after disconnecting it so that the observer is re-created with the new `rootMargin` after the window is resized.