### PR TITLE
fix: apply `scrollbar-gutter: stable` to prevent layout shift with modals

### DIFF
--- a/packages/starlight/style/reset.css
+++ b/packages/starlight/style/reset.css
@@ -11,6 +11,7 @@
 html {
 	color-scheme: dark;
 	accent-color: var(--sl-color-accent);
+	scrollbar-gutter: stable;
 }
 
 html[data-theme='light'] {


### PR DESCRIPTION


#### Description

Closes #2514

Adds `scrollbar-gutter: stable` to html to prevent layout shift when scrollbar appears/disappears, e.g. when opening the search modal.

Before

![2024-10-27 10 51 49](https://github.com/user-attachments/assets/a93cf9d6-34a0-40a5-8e77-85f7f52898f1)

After

![2024-10-27 11 21 28](https://github.com/user-attachments/assets/c64ce0c6-c09d-4a55-afdc-ee3533fbde33)