### PR TITLE
Stop silencing i18n content collection related errors

### DIFF
--- a/.changeset/big-ducks-rhyme.md
+++ b/.changeset/big-ducks-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes an issue where i18n content collection related errors, e.g. malformed JSON or YAML, would not be reported.

--- a/packages/starlight/utils/translations.ts
+++ b/packages/starlight/utils/translations.ts
@@ -14,17 +14,13 @@ export type UserI18nKeys = keyof RemoveIndexSignature<UserI18nSchema>;
 
 /** Get all translation data from the i18n collection, keyed by `id`, which matches locale. */
 async function loadTranslations() {
-	let userTranslations: Record<string, UserI18nSchema> = {};
 	// Briefly override `console.warn()` to silence logging when a project has no i18n collection.
 	const warn = console.warn;
 	console.warn = () => {};
-	try {
-		// Load the user’s i18n collection and ignore the error if it doesn’t exist.
-		userTranslations = Object.fromEntries(
-			// @ts-ignore — may be an error in projects without an i18n collection
-			(await getCollection('i18n')).map(({ id, data }) => [id, data] as const)
-		);
-	} catch {}
+	const userTranslations: Record<string, UserI18nSchema> = Object.fromEntries(
+		// @ts-ignore — may be a type error in projects without an i18n collection
+		(await getCollection('i18n')).map(({ id, data }) => [id, data] as const)
+	);
 	// Restore the original warn implementation.
 	console.warn = warn;
 	return userTranslations;


### PR DESCRIPTION
#### Description

This PR removes the existing behavior of silencing all errors related to the `i18n` content collection when we try to load it.

Initially, the error silencing was introduced in https://github.com/withastro/starlight/pull/1458 to prevent a runtime error when the `i18n` content collection did not exist or was empty.

Since then, this error was [removed](https://github.com/withastro/astro/pull/8382) in Astro and [an empty array is now returned](https://github.com/withastro/astro/pull/10356) when the `i18n` content collection does not exist or is empty.

Both changes are available since Astro v4.4.14 (which is higher than the minimum required version for Starlight (v4.14.0)) and this means that we can now entirely remove the try/catch block entirely.

Note that the warning silencing is still in place.

Screenshot of a possible error that is now visible:

<img width="1220" alt="SCR-20241031-obyr" src="https://github.com/user-attachments/assets/809a8eaa-98ef-47cb-9b3c-6d9c8bf95945">
