### PR TITLE
Add new plugin to Starlight (`resources/plugin.mdx`)

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -94,6 +94,11 @@ Extend your site with official plugins supported by the Starlight team and commu
 		description="Add an interactive site graph inside your page's sidebar."
 	/>
 	<LinkCard
+		href="https://github.com/HiDeoo/starlight-sidebar-topics"
+		title="starlight-sidebar-topics"
+		description="Split your documentation into different sections, each with its own sidebar."
+	/>
+	<LinkCard
 		href="https://github.com/trueberryless-org/starlight-sidebar-topics-dropdown"
 		title="starlight-sidebar-topics-dropdown"
 		description="Split your docs page into multiple subpages and switch between them with a dropdown menu in the sidebar."

--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -93,6 +93,11 @@ Extend your site with official plugins supported by the Starlight team and commu
 		title="starlight-site-graph"
 		description="Add an interactive site graph inside your page's sidebar."
 	/>
+	<LinkCard
+		href="https://github.com/trueberryless-org/starlight-sidebar-topics-dropdown"
+		title="starlight-sidebar-topics-dropdown"
+		description="Split your docs page into multiple subpages and switch between them with a dropdown menu in the sidebar."
+	/>
 </CardGrid>
 
 ### Community themes


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- add new plugin called `starlight-sidebar-plugin-dropdown`
- Starlight plugin to split your docs page into multiple subpages and switch between them with a dropdown menu in the sidebar.

**1000 thanks to @HiDeoo the actual idea for such a plugin was their idea! (I just changed the visuals a bit)**

Try out the plugin [here](https://starlight-sidebar-topics-dropdown.trueberryless.org/).

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
