### PR TITLE
i18n(de): Make translation of 'theme' consistent in German language: 'Theme' (i18nIgnore)

### DIFF
--- a/docs/src/content/docs/de/components/badges.mdx
+++ b/docs/src/content/docs/de/components/badges.mdx
@@ -25,7 +25,7 @@ import { Badge } from '@astrojs/starlight/components';
 
 Zeige ein Abzeichen mit der Komponente `<Badge>` an und übergib den Inhalt, den du anzeigen möchtest, an das Attribut [`text`](#text) der Komponente `<Badge>`.
 
-Standardmäßig wird für das Abzeichen die Akzentfarbe des Aussehens deiner Website verwendet.
+Standardmäßig wird für das Abzeichen die Akzentfarbe des Themes deiner Website verwendet.
 Um eine eingebaute Abzeichen-Farbe zu verwenden, setze das Attribut [`variant`](#variant) auf einen der unterstützten Werte.
 
 <Preview>
@@ -141,7 +141,7 @@ Der Textinhalt, der in dem Abzeichen angezeigt werden soll.
 **Typ:** `'note' | 'danger' | 'success' | 'caution' | 'tip' | 'default'`  
 **Standard:** `'default'`
 
-Die zu verwendende Farbvariante des Abzeichens: `note` (blau), `tip` (lila), `danger` (rot), `caution` (orange), `success` (grün) oder `default` (Akzentfarbe des Aussehens).
+Die zu verwendende Farbvariante des Abzeichens: `note` (blau), `tip` (lila), `danger` (rot), `caution` (orange), `success` (grün) oder `default` (Akzentfarbe des Themes).
 
 ### `size`
 

--- a/docs/src/content/docs/de/resources/plugins.mdx
+++ b/docs/src/content/docs/de/resources/plugins.mdx
@@ -97,7 +97,7 @@ Erweitere deine Seite mit offiziellen Plugins, die vom Starlight-Team unterstüt
 
 ### Community-Themes
 
-Eine Ansicht ist ein Starlight-Plugin, das das visuelle Erscheinungsbild einer Website mit Komponentenüberschreibungen, benutzerdefiniertem CSS oder anderen neuen Funktionen verändert.
+Ein Theme ist ein Starlight-Plugin, das das visuelle Erscheinungsbild einer Website mit Komponentenüberschreibungen, benutzerdefiniertem CSS oder anderen neuen Funktionen verändert.
 
 <CardGrid>
 	<LinkCard


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

There was a little controversy on how to translated the English word "theme" into the German language. But this PR resolves this issue and fixes all mistakes in all pages of Starlight so the German word "Theme" is used consistent.

- discussion started in #2541 

<!-- TAKING PART IN HACKTOBERFEST? LET US KNOW! -->
<!-- See https://contribute.docs.astro.build/guides/hacktoberfest/ for more details. -->

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
