### PR TITLE
Add YAML support to the FS translation system

### DIFF
--- a/.changeset/thick-houses-pull.md
+++ b/.changeset/thick-houses-pull.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes an issue with custom UI strings defined in YAML files not being loaded in some contexts.

--- a/packages/starlight/__tests__/i18n/malformed-yaml-src/content/i18n/en.yml
+++ b/packages/starlight/__tests__/i18n/malformed-yaml-src/content/i18n/en.yml
@@ -1,0 +1,1 @@
+test: 'Malformed YAML file with dangling trailing comma',

--- a/packages/starlight/__tests__/i18n/src/content/i18n/fr.yml
+++ b/packages/starlight/__tests__/i18n/src/content/i18n/fr.yml
@@ -1,0 +1,1 @@
+page.editLink: Rendre cette page différente

--- a/packages/starlight/package.json
+++ b/packages/starlight/package.json
@@ -177,6 +177,7 @@
   "devDependencies": {
     "@astrojs/markdown-remark": "^5.1.0",
     "@playwright/test": "^1.45.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^18.16.19",
     "@vitest/coverage-v8": "^1.6.0",
     "astro": "^4.15.3",
@@ -196,6 +197,7 @@
     "hast-util-to-string": "^3.0.0",
     "hastscript": "^9.0.0",
     "i18next": "^23.11.5",
+    "js-yaml": "^4.1.0",
     "mdast-util-directive": "^3.0.0",
     "mdast-util-to-markdown": "^2.1.0",
     "mdast-util-to-string": "^4.0.0",

--- a/packages/starlight/utils/translations-fs.ts
+++ b/packages/starlight/utils/translations-fs.ts
@@ -1,8 +1,13 @@
 import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
 import type { i18nSchemaOutput } from '../schemas/i18n';
 import { createTranslationSystem } from './createTranslationSystem';
 import type { StarlightConfig } from './user-config';
 import type { AstroConfig } from 'astro';
+
+const contentCollectionFileExtensions = ['.json', '.yaml', '.yml'];
 
 /**
  * Loads and creates a translation system from the file system.
@@ -23,15 +28,18 @@ export function createTranslationSystemFromFs<T extends i18nSchemaOutput>(
 		// Load the user’s i18n directory
 		const files = fs.readdirSync(i18nDir, 'utf-8');
 		// Load the user’s i18n collection and ignore the error if it doesn’t exist.
-		userTranslations = Object.fromEntries(
-			files
-				.filter((file) => file.endsWith('.json'))
-				.map((file) => {
-					const id = file.slice(0, -5);
-					const data = JSON.parse(fs.readFileSync(new URL(file, i18nDir), 'utf-8'));
-					return [id, data] as const;
-				})
-		);
+		for (const file of files) {
+			const filePath = path.parse(file);
+			if (!contentCollectionFileExtensions.includes(filePath.ext)) continue;
+			const id = filePath.name;
+			const url = new URL(filePath.base, i18nDir);
+			const content = fs.readFileSync(new URL(file, i18nDir), 'utf-8');
+			const data =
+				filePath.ext === '.json'
+					? JSON.parse(content)
+					: yaml.load(content, { filename: fileURLToPath(url) });
+			userTranslations[id] = data as i18nSchemaOutput;
+		}
 	} catch (e: unknown) {
 		if (e instanceof Error && 'code' in e && e.code === 'ENOENT') {
 			// i18nDir doesn’t exist, so we ignore the error.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       i18next:
         specifier: ^23.11.5
         version: 23.11.5
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
       mdast-util-directive:
         specifier: ^3.0.0
         version: 3.0.0
@@ -234,6 +237,9 @@ importers:
       '@playwright/test':
         specifier: ^1.45.0
         version: 1.45.0
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: ^18.16.19
         version: 18.16.19
@@ -1996,6 +2002,10 @@ packages:
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
     dependencies:
       '@types/unist': 3.0.0
+
+  /@types/js-yaml@4.0.9:
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+    dev: true
 
   /@types/linkify-it@5.0.0:
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}


### PR DESCRIPTION
#### Description

This PR fixes an issue where the FS translation system (only used with some internal integrations or remark plugins at the moment) was not handling YAML files even though Astro Content Collections support YAML files.