### PR TITLE
Fix sidebar scroll restoration issue

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -34,6 +34,8 @@ export default defineConfig({
 	trailingSlash: 'always',
 	integrations: [
 		starlight({
+			// TODO(HiDeoo) Remove
+			components: { Sidebar: './src/components/Sidebar.astro' },
 			title: 'Starlight',
 			logo: {
 				light: '/src/assets/logo-light.svg',

--- a/docs/src/components/Sidebar.astro
+++ b/docs/src/components/Sidebar.astro
@@ -1,0 +1,45 @@
+---
+// TODO(HiDeoo) Remove this entire file
+import type { Props } from '@astrojs/starlight/props';
+import Default from '@astrojs/starlight/components/Sidebar.astro';
+---
+
+<Default {...Astro.props}><slot /></Default>
+
+<div class="sl-hidden md:sl-block">
+	<div dir="ltr" lang="en" class="sponsors">
+		<h2 class="sponsors-title">Sponsored by</h2>
+		<a href="https://starlight.astro.build/" aria-label="Starlight"></a>
+		<a href="https://starlight.astro.build/" aria-label="Starlight"></a>
+	</div>
+</div>
+
+<style>
+	.sponsors {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0 1.5rem;
+		padding: 1.5rem 0.5rem 0.75rem;
+	}
+	a {
+		display: flex;
+		align-items: center;
+		min-height: 3rem;
+		opacity: 0.75;
+		background-color: red;
+		width: 96px;
+	}
+	a:hover {
+		opacity: 1;
+	}
+
+	.sponsors-title {
+		width: 100%;
+		color: var(--sl-color-gray-3);
+		font-size: var(--sl-text-xs);
+		font-weight: 400;
+		font-family: var(--__sl-font-mono);
+		line-height: var(--sl-line-height-headings);
+		margin: 0 0 0.5rem;
+	}
+</style>

--- a/packages/starlight/components/Page.astro
+++ b/packages/starlight/components/Page.astro
@@ -79,7 +79,21 @@ const pagefindEnabled =
 		<SkipLink {...Astro.props} />
 		<PageFrame {...Astro.props}>
 			<Header slot="header" {...Astro.props} />
-			{Astro.props.hasSidebar && <Sidebar slot="sidebar" {...Astro.props} />}
+			{
+				Astro.props.hasSidebar && (
+					<Fragment slot="sidebar">
+						<Sidebar {...Astro.props} />
+						<script is:inline>
+							(() => {
+								const scroller = document.getElementById('starlight__sidebar');
+								if (!window._starlightScrollRestore || !scroller) return;
+								scroller.scrollTop = window._starlightScrollRestore;
+								delete window._starlightScrollRestore;
+							})();
+						</script>
+					</Fragment>
+				)
+			}
 			<script src="./SidebarPersistState"></script>
 			<TwoColumnContent {...Astro.props}>
 				<PageSidebar slot="right-sidebar" {...Astro.props} />

--- a/packages/starlight/components/SidebarPersister.astro
+++ b/packages/starlight/components/SidebarPersister.astro
@@ -54,15 +54,6 @@ declare global {
 	</script>
 
 	<slot />
-
-	<script is:inline>
-		(() => {
-			const scroller = document.getElementById('starlight__sidebar');
-			if (!window._starlightScrollRestore || !scroller) return;
-			scroller.scrollTop = window._starlightScrollRestore;
-			delete window._starlightScrollRestore;
-		})();
-	</script>
 </sl-sidebar-state-persist>
 
 <style>


### PR DESCRIPTION
#### Description

This PR fixes a sidebar restoration issue in projects that uses a `<Sidebar>` component override which adds content after the default sidebar, e.g. like the sponsors in the Astro Docs.

Repro:

1. Visit the Astro Docs.
2. Make sure that based on your window height, the sidebar is scrollable.
3. Scroll down to the bottom of the sidebar.
4. Either refresh the page or navigate to another page.

The sidebar scroll position is not properly restored as it should be. The restoration happens after the default sidebar content is rendered but before the entire override content is rendered. Any extra content added after the default sidebar content is not taken into account when restoring the scroll position.

This PR is a draft testing the easiest fix by just moving the restoration script after the `<Sidebar>` component. The goal is to see if this is a viable solution and if it doesn't break anything else.

The preview in this PR includes a reproduction of the issue so that we can easily test the fix.

#### Remaining tasks

- [ ] Remove the `Sidebar` override in `docs/astro.config.mjs`
- [ ] Delete the `docs/src/components/Sidebar.astro` file
- [ ] Based on the final solution, potentially update the frontmatter comment in `packages/starlight/components/SidebarPersister.astro`
- [ ] Add a changeset