### PR TITLE
Fixes import name typo in Customize icons example

### DIFF
--- a/docs/src/content/docs/components/icons.mdx
+++ b/docs/src/content/docs/components/icons.mdx
@@ -64,7 +64,7 @@ The [`class`](#class) attribute can be used to add custom CSS classes to the ico
 <Preview>
 
 ```mdx
-import { Card } from '@astrojs/starlight/components';
+import { Icon } from '@astrojs/starlight/components';
 
 <Icon name="star" color="goldenrod" size="2rem" />
 <Icon name="rocket" color="var(--sl-color-text-accent)" />

--- a/docs/src/content/docs/de/components/icons.mdx
+++ b/docs/src/content/docs/de/components/icons.mdx
@@ -64,7 +64,7 @@ Das Attribut [`class`](#class) kann verwendet werden, um dem Symbol eigene CSS-K
 <Preview>
 
 ```mdx
-import { Card } from '@astrojs/starlight/components';
+import { Icon } from '@astrojs/starlight/components';
 
 <Icon name="star" color="goldenrod" size="2rem" />
 <Icon name="rocket" color="var(--sl-color-text-accent)" />

--- a/docs/src/content/docs/es/components/icons.mdx
+++ b/docs/src/content/docs/es/components/icons.mdx
@@ -64,7 +64,7 @@ El atributo [`class`](#class) se puede usar para agregar clases CSS personalizad
 <Preview>
 
 ```mdx
-import { Card } from '@astrojs/starlight/components';
+import { Icon } from '@astrojs/starlight/components';
 
 <Icon name="star" color="goldenrod" size="2rem" />
 <Icon name="rocket" color="var(--sl-color-text-accent)" />

--- a/docs/src/content/docs/fr/components/icons.mdx
+++ b/docs/src/content/docs/fr/components/icons.mdx
@@ -64,7 +64,7 @@ L'attribut [`class`](#class) peut être utilisé pour ajouter des classes CSS pe
 <Preview>
 
 ```mdx
-import { Card } from '@astrojs/starlight/components';
+import { Icon } from '@astrojs/starlight/components';
 
 <Icon name="star" color="goldenrod" size="2rem" />
 <Icon name="rocket" color="var(--sl-color-text-accent)" />

--- a/docs/src/content/docs/ja/components/icons.mdx
+++ b/docs/src/content/docs/ja/components/icons.mdx
@@ -62,7 +62,7 @@ import { Icon } from '@astrojs/starlight/components';
 <Preview>
 
 ```mdx
-import { Card } from '@astrojs/starlight/components';
+import { Icon } from '@astrojs/starlight/components';
 
 <Icon name="star" color="goldenrod" size="2rem" />
 <Icon name="rocket" color="var(--sl-color-text-accent)" />

--- a/docs/src/content/docs/ko/components/icons.mdx
+++ b/docs/src/content/docs/ko/components/icons.mdx
@@ -64,7 +64,7 @@ CSS 단위와 색상 값을 사용하여 아이콘의 모양을 조정하는 데
 <Preview>
 
 ```mdx
-import { Card } from '@astrojs/starlight/components';
+import { Icon } from '@astrojs/starlight/components';
 
 <Icon name="star" color="goldenrod" size="2rem" />
 <Icon name="rocket" color="var(--sl-color-text-accent)" />

--- a/docs/src/content/docs/ru/components/icons.mdx
+++ b/docs/src/content/docs/ru/components/icons.mdx
@@ -64,7 +64,7 @@ import { Icon } from '@astrojs/starlight/components';
 <Preview>
 
 ```mdx
-import { Card } from '@astrojs/starlight/components';
+import { Icon } from '@astrojs/starlight/components';
 
 <Icon name="star" color="goldenrod" size="2rem" />
 <Icon name="rocket" color="var(--sl-color-text-accent)" />

--- a/docs/src/content/docs/zh-cn/components/icons.mdx
+++ b/docs/src/content/docs/zh-cn/components/icons.mdx
@@ -64,7 +64,7 @@ import { Icon } from '@astrojs/starlight/components';
 <Preview>
 
 ```mdx
-import { Card } from '@astrojs/starlight/components';
+import { Icon } from '@astrojs/starlight/components';
 
 <Icon name="star" color="goldenrod" size="2rem" />
 <Icon name="rocket" color="var(--sl-color-text-accent)" />


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

This PR fixes a typo in the "Customize icons" section of the Icon component docs where `Card` was imported instead of `Icon`.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
