### PR TITLE
Throw an error if a showcase image does not have the required dimensions

### DIFF
--- a/docs/src/components/showcase-card.astro
+++ b/docs/src/components/showcase-card.astro
@@ -2,6 +2,7 @@
 import type { ImageMetadata } from 'astro';
 import { Image } from 'astro:assets';
 import MediaCard from './media-card.astro';
+import { AstroError } from 'astro/errors';
 
 interface Props {
 	href: string;
@@ -18,6 +19,22 @@ if (!thumbnail) {
 	throw new Error(`Could not resolve showcase thumbnail: ${Astro.props.thumbnail}`);
 }
 const src = (await thumbnail()).default;
+
+if (src.width !== 800 || src.height !== 450) {
+	let fileName = src.src.split('/').pop();
+	const queryIndex = fileName?.indexOf('?');
+	if (queryIndex !== undefined && queryIndex > -1) {
+		fileName = fileName?.slice(0, queryIndex);
+	}
+	throw new AstroError(
+		'Showcase images must be **800×450px**',
+		`Dimensions of **${src.width}×${src.height}px** found for showcase image \`${fileName || src.src}\`\n\n` +
+			`For best results:\n\n` +
+			`1. Take a screenshot of the site using a browser resized to **1280×720px**. The responsive view in dev tools can be helpful for this.\n\n` +
+			`2. Resize the screenshot to **800×450px** and make sure it is saved as a PNG. An online tool like [Squoosh](https://squoosh.app/) can help here.\n\n` +
+			`See more details in the [Starlight contributing guide](https://github.com/withastro/starlight/blob/main/CONTRIBUTING.md#showcase)\n`
+	);
+}
 ---
 
 <MediaCard {href}>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- This PR adds a validation to our showcase card component to ensure passed images have the expected dimensions.
- We often get images submitted that do not have the required dimensions and contributors don’t get any feedback about this until we review the PR. The aim here is that they will get local dev errors if previewing the site, or failing that, CI failures when they open the PR. It will also help PR reviewers spot the issue more easily.
- There is currently one image that has the wrong dimensions. Will resize it in a subsequent commit so we can see this fail once in this PR.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
