### PR TITLE
Move import statement in `resources/plugins.mdx` after Aside (because it's already used before it's imported...)

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -10,6 +10,8 @@ Have you built a plugin or a tool for Starlight?
 Open a PR adding a link to this page!
 :::
 
+import { CardGrid, LinkCard } from '@astrojs/starlight/components';
+
 ## Plugins
 
 [Plugins](/reference/plugins/) can customize Starlight configuration, UI, and behavior, while also being easy to share and reuse.
@@ -128,8 +130,6 @@ A theme is a Starlight plugin that changes the visual appearance of a site with 
 </CardGrid>
 
 ## Community tools and integrations
-
-import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 These community tools and integrations can be used to add features to your Starlight site.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- I don't know if this is a bug, but I'm not sure why it actually works, but I think that:
- import statement is misplaced and therefore moved to the top of the page (after the Aside)

Reason: The components imported are already used before being imported, or am I blind?

(already mentioned shortly in #2580)

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
