### PR TITLE
Support passing more options to the DocSearch component

### DIFF
--- a/.changeset/small-trainers-learn.md
+++ b/.changeset/small-trainers-learn.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight-docsearch': minor
+---
+
+Adds support for some more of the DocSearch component’s configuration options

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -26,6 +26,9 @@ i18n:
 '🌟 tailwind':
   - packages/tailwind/**
 
+'🌟 docsearch':
+  - packages/docsearch/**
+
 '🌟 markdoc':
   - packages/markdoc/**
 

--- a/docs/src/content/docs/guides/site-search.mdx
+++ b/docs/src/content/docs/guides/site-search.mdx
@@ -108,6 +108,15 @@ If you have access to [Algolia’s DocSearch program](https://docsearch.algolia.
 
 With this updated configuration, the search bar on your site will now open an Algolia modal instead of the default search modal.
 
+#### DocSearch configuration
+
+The Starlight DocSearch plugin also supports customizing the DocSearch component with the following additional options:
+
+- `maxResultsPerGroup`: Limit the number of results displayed for each search group. Default is `5`.
+- `disableUserPersonalization`: Prevent DocSearch from saving a user’s recent searches and favorites to local storage. Default is `false`.
+- `insights`: Enable the Algolia Insights plugin and send search events to your DocSearch index. Default is `false`.
+- `searchParameters`: An object customizing the [Algolia Search Parameters](https://www.algolia.com/doc/api-reference/search-api-parameters/).
+
 #### Translating the DocSearch UI
 
 DocSearch only provides English UI strings by default.

--- a/packages/docsearch/DocSearch.astro
+++ b/packages/docsearch/DocSearch.astro
@@ -131,7 +131,8 @@ const docsearchTranslations: DocSearchTranslationProps = {
 			super();
 			window.addEventListener('DOMContentLoaded', async () => {
 				const { default: docsearch } = await import('@docsearch/js');
-				const options: Parameters<typeof docsearch>[0] = { ...config, container: 'sl-doc-search' };
+				type DocSearchOptions = Parameters<typeof docsearch>[0];
+				const options = { ...config, container: 'sl-doc-search' } as DocSearchOptions;
 				try {
 					const translations = JSON.parse(this.dataset.translations || '{}');
 					Object.assign(options, translations);

--- a/packages/docsearch/README.md
+++ b/packages/docsearch/README.md
@@ -1,0 +1,18 @@
+# <img src="https://github.com/withastro/starlight/assets/357379/494fcd83-42aa-4891-87e0-87402fa0b6f3" alt="" align="left" width="40" height="40"> @astrojs/starlight-docsearch
+
+Algolia DocSearch plugin for the [Starlight][starlight] documentation theme for [Astro][astro].
+
+## Documentation
+
+See the [Starlight site search guide][docs] for how to use this plugin.
+
+## License
+
+MIT
+
+Copyright (c) 2023–present [Starlight contributors][contributors]
+
+[starlight]: https://starlight.astro.build/
+[astro]: https://astro.build/
+[docs]: https://starlight.astro.build/guides/site-search/#algolia-docsearch
+[contributors]: https://github.com/withastro/starlight/graphs/contributors

--- a/packages/docsearch/index.ts
+++ b/packages/docsearch/index.ts
@@ -1,17 +1,37 @@
 import type { StarlightPlugin } from '@astrojs/starlight/types';
+import type docsearch from '@docsearch/js';
 import type { AstroUserConfig, ViteUserConfig } from 'astro';
 import { z } from 'astro/zod';
 
-/** Config options users must provide for DocSearch to work. */
-const DocSearchConfigSchema = z.object({
-	appId: z.string(),
-	apiKey: z.string(),
-	indexName: z.string(),
-});
-export type DocSearchConfig = z.input<typeof DocSearchConfigSchema>;
+type SearchOptions = Parameters<typeof docsearch>[0]['searchParameters'];
+
+/** DocSearch configuration options. */
+const DocSearchConfigSchema = z
+	.object({
+		// Required config without which DocSearch won’t work.
+		/** Your Algolia application ID. */
+		appId: z.string(),
+		/** Your Algolia Search API key. */
+		apiKey: z.string(),
+		/** Your Algolia index name. */
+		indexName: z.string(),
+		// Optional DocSearch component config (only the serializable properties can be included here)
+		/** The maximum number of results to display per search group. Default is `5`. */
+		maxResultsPerGroup: z.number().optional(),
+		/** Disable saving recent searches and favorites to the local storage. Default is `false`. */
+		disableUserPersonalization: z.boolean().optional(),
+		/** Whether to enable the Algolia Insights plugin and send search events to your DocSearch index. Default is `false`. */
+		insights: z.boolean().optional(),
+		/** The Algolia Search Parameters. See https://www.algolia.com/doc/api-reference/search-api-parameters/ */
+		searchParameters: z.custom<SearchOptions>(),
+	})
+	.strict();
+
+type DocSearchUserConfig = z.input<typeof DocSearchConfigSchema>;
+export type DocSearchConfig = z.output<typeof DocSearchConfigSchema>;
 
 /** Starlight DocSearch plugin. */
-export default function starlightDocSearch(userConfig: DocSearchConfig): StarlightPlugin {
+export default function starlightDocSearch(userConfig: DocSearchUserConfig): StarlightPlugin {
 	const opts = DocSearchConfigSchema.parse(userConfig);
 	return {
 		name: 'starlight-docsearch',

--- a/packages/docsearch/index.ts
+++ b/packages/docsearch/index.ts
@@ -16,13 +16,25 @@ const DocSearchConfigSchema = z
 		/** Your Algolia index name. */
 		indexName: z.string(),
 		// Optional DocSearch component config (only the serializable properties can be included here)
-		/** The maximum number of results to display per search group. Default is `5`. */
+		/**
+		 * The maximum number of results to display per search group.
+		 * @default 5
+		 */
 		maxResultsPerGroup: z.number().optional(),
-		/** Disable saving recent searches and favorites to the local storage. Default is `false`. */
+		/**
+		 * Disable saving recent searches and favorites to the local storage.
+		 * @default false
+		 */
 		disableUserPersonalization: z.boolean().optional(),
-		/** Whether to enable the Algolia Insights plugin and send search events to your DocSearch index. Default is `false`. */
+		/**
+		 * Whether to enable the Algolia Insights plugin and send search events to your DocSearch index.
+		 * @default false
+		 */
 		insights: z.boolean().optional(),
-		/** The Algolia Search Parameters. See https://www.algolia.com/doc/api-reference/search-api-parameters/ */
+		/**
+		 * The Algolia Search Parameters.
+		 * @see https://www.algolia.com/doc/api-reference/search-api-parameters/
+		 */
 		searchParameters: z.custom<SearchOptions>(),
 	})
 	.strict();


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- This PR exposes a few more of the DocSearch component’s options in the Starlight DocSearch Plugin’s config.
- We’re still limited to serializable options here, so it’s a subset of DocSearch’s full set of options (which includes stuff like callback methods for transforming results and providing custom UI components).
- This PR also adds a README to the package which was missing and updates our GitHub labeler action config to apply a `🌟 docsearch` label to PRs like this one.
- I also omitted the `initialQuery` option for now because it feels like that would perhaps be a mistake to control from a global location like the plugin config. If anything, perhaps it should go through i18n APIs or something else. Seemed safest to omit for now and we can revisit if someone has a specific use case and requests it.
- We don’t have tests set up for the DocSearch plugin given it’s pretty simple. I tested this by adding the plugin to a local example and testing out the different config options, which worked successfully.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
