### PR TITLE
Add my two new plugins to Starlight `resources/plugins.mdx` page

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -94,6 +94,11 @@ Extend your site with official plugins supported by the Starlight team and commu
 		description="Add an interactive site graph inside your page's sidebar."
 	/>
 	<LinkCard
+		href="https://github.com/trueberryless-org/starlight-cooler-credit"
+		title="starlight-cooler-credit"
+		description="Add a nice credit to Starlight or Astro at the bottom of Table of Contents."
+	/>
+	<LinkCard
 		href="https://github.com/HiDeoo/starlight-sidebar-topics"
 		title="starlight-sidebar-topics"
 		description="Split your documentation into different sections, each with its own sidebar."
@@ -102,6 +107,11 @@ Extend your site with official plugins supported by the Starlight team and commu
 		href="https://github.com/trueberryless-org/starlight-sidebar-topics-dropdown"
 		title="starlight-sidebar-topics-dropdown"
 		description="Split your docs page into multiple subpages and switch between them with a dropdown menu in the sidebar."
+	/>
+	<LinkCard
+		href="https://github.com/trueberryless-org/starlight-contributor-list"
+		title="starlight-contributor-list"
+		description="Display a list of all contributors to your project."
 	/>
 </CardGrid>
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Add these two plugins:
  - [Starlight Cooler Credit](https://starlight-cooler-credit.trueberryless.org/)
  - [Starlight Contributor List](https://starlight-contributor-list.trueberryless.org/)

I'm NOT adding Cooler Credit at the end of the list for the following reason: 
I think it looks really nice if [Starlight Sidebar Topics](https://starlight-sidebar-topics.netlify.app/) and [Starlight Sidebar Topics Dropdown](https://starlight-sidebar-topics-dropdown.trueberryless.org/) are next to each other (side-by-side) because the Dropdown version is actually a copy of the original...

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
