### PR TITLE
[i18nIgnore] Update `starlight-links-validator` and fix link

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -27,6 +27,6 @@
     "@playwright/test": "^1.45.0",
     "axe-playwright": "^2.0.3",
     "sitemapper": "^3.2.12",
-    "starlight-links-validator": "^0.12.1"
+    "starlight-links-validator": "^0.13.1"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -27,6 +27,6 @@
     "@playwright/test": "^1.45.0",
     "axe-playwright": "^2.0.3",
     "sitemapper": "^3.2.12",
-    "starlight-links-validator": "^0.13.1"
+    "starlight-links-validator": "^0.13.2"
   }
 }

--- a/docs/src/content/docs/pt-br/reference/configuration.mdx
+++ b/docs/src/content/docs/pt-br/reference/configuration.mdx
@@ -351,7 +351,7 @@ starlight({
 **padrão:**: `true`
 
 Starlight usa [`Expressive Code`](https://github.com/expressive-code/expressive-code/tree/main/packages/astro-expressive-code) para renderizar blocos de código e adicionar suporte para destacar partes de códigos de exemplo, adicionar nomes de arquivos aos blocos de código, e mais.
-Veja o [guia para “Blocos de Código”](http://localhost:4321/guides/authoring-content/#code-blocks) para aprender como usar a sintaxe do Expressive Code dentro de seu conteúdo Markdown e MDX.
+Veja o [guia para “Blocos de Código”](/pt-br/guides/authoring-content/#blocos-de-código) para aprender como usar a sintaxe do Expressive Code dentro de seu conteúdo Markdown e MDX.
 
 Você pode utilizar qualquer uma das [opções de configuração do Expressive Code](https://github.com/expressive-code/expressive-code/blob/main/packages/astro-expressive-code/README.md#configuration) padrões, assim como alguma propriedades específicas do Starlight, configurando a opção `expressiveCode` do Starlight.
 Por exemplo, defina um valor para `styleOverrides` do Expressive Code para sobrescrever o CSS padrão. Isso permite customizações como adicionar cantos arredondados aos seus blocos de código:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: ^3.2.12
         version: 3.2.12
       starlight-links-validator:
-        specifier: ^0.12.1
-        version: 0.12.1(@astrojs/starlight@packages+starlight)(astro@4.16.10)
+        specifier: ^0.13.1
+        version: 0.13.1(@astrojs/starlight@packages+starlight)(astro@4.16.10)
 
   examples/basics:
     dependencies:
@@ -5820,8 +5820,8 @@ packages:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
 
-  /starlight-links-validator@0.12.1(@astrojs/starlight@packages+starlight)(astro@4.16.10):
-    resolution: {integrity: sha512-LhRuGaI9Rp7c7ltwcG0BfCZuAN1d15oYbDB4jXblJ6zsiFcrSGHNlDnKXJHEJZ6XhJ+eOpd1IsHLFLh5Sq6uHg==}
+  /starlight-links-validator@0.13.1(@astrojs/starlight@packages+starlight)(astro@4.16.10):
+    resolution: {integrity: sha512-1qt04vxO7rsu//JoaRP2TNU9/cj8Wfx6FYK3VXIvkkN9HoIpQ/zgq43dy3h7+6fcuyksg7+Eu17dgDQaOUbQVw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       '@astrojs/starlight': '>=0.15.0'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: ^3.2.12
         version: 3.2.12
       starlight-links-validator:
-        specifier: ^0.13.1
-        version: 0.13.1(@astrojs/starlight@packages+starlight)(astro@4.16.10)
+        specifier: ^0.13.2
+        version: 0.13.2(@astrojs/starlight@packages+starlight)(astro@4.16.10)
 
   examples/basics:
     dependencies:
@@ -5820,8 +5820,8 @@ packages:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
 
-  /starlight-links-validator@0.13.1(@astrojs/starlight@packages+starlight)(astro@4.16.10):
-    resolution: {integrity: sha512-1qt04vxO7rsu//JoaRP2TNU9/cj8Wfx6FYK3VXIvkkN9HoIpQ/zgq43dy3h7+6fcuyksg7+Eu17dgDQaOUbQVw==}
+  /starlight-links-validator@0.13.2(@astrojs/starlight@packages+starlight)(astro@4.16.10):
+    resolution: {integrity: sha512-BP6vf+fj91LnQXPnggWVhZXhcSF1x6SHof0GRg+IGgY0idSbIU7OHE2SvLggs2fRZ5SflVqpCTpK0pQcOmYcDg==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       '@astrojs/starlight': '>=0.15.0'


### PR DESCRIPTION
#### Description

While working on #2578, I made a patch update to `starlight-links-validator` to simplify some legacy internal types and avoid future type errors. While testing it, I noticed a link issue.

This PR updates the `starlight-links-validator` package to the latest version and looks like the new [`errorOnLocalLinks`](https://starlight-links-validator.vercel.app/configuration/#erroronlocallinks) option I added mostly for myself found an issue in one of our documentation pages.