### PR TITLE
Add SidebarPersister specifier to Starlight package

### DIFF
--- a/.changeset/red-mice-care.md
+++ b/.changeset/red-mice-care.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Exposes `SidebarPersister` component in package exports for use in custom overrides

--- a/packages/starlight/package.json
+++ b/packages/starlight/package.json
@@ -52,6 +52,10 @@
       "types": "./components/MarkdownContent.astro.tsx",
       "import": "./components/MarkdownContent.astro"
     },
+    "./components/SidebarPersister.astro": {
+      "types": "./components/SidebarPersister.astro.tsx",
+      "import": "./components/SidebarPersister.astro"
+    },
     "./components/SidebarSublist.astro": {
       "types": "./components/SidebarSublist.astro.tsx",
       "import": "./components/SidebarSublist.astro"


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

This PR specifies the `SidebarPersister.astro` component, used in `Sidebar.astro`, in the Starlight package's package.json `exports` property.

This change fixes the error `Missing "./components/SidebarPersister.astro" specifier in "@astrojs/starlight" package` that I got when trying to manually override Starlight's sidebar instead of using `import Default from '@astrojs/starlight/components/Sidebar.astro'`. Thanks to @TheOtterlord and @delucis for helping solve my issue in Discord :raised_hands:
