### PR TITLE
Add `grid-template-columns` to`<CardGrid>`

### DIFF
--- a/.changeset/few-dogs-grab.md
+++ b/.changeset/few-dogs-grab.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Makes `<CardGrid>` more resilient to complex child content on smaller viewports

--- a/packages/starlight/user-components/CardGrid.astro
+++ b/packages/starlight/user-components/CardGrid.astro
@@ -11,6 +11,7 @@ const { stagger = false } = Astro.props;
 <style>
 	.card-grid {
 		display: grid;
+		grid-template-columns: 100%;
 		gap: 1rem;
 	}
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- This PR adds a base `grid-template-columns` rule to the `<CardGrid>` component to apply on smaller screens as one `100%` wide column.

- This helps avoid overflow when there is complex content inside the grid children. We already [apply this rule as an override in Astro Docs](https://github.com/withastro/docs/blob/a9065e9f5bf616abd8b769b5250ed2535f8762d7/src/styles/custom.css#L3-L11) to avoid overflow, but I only just remembered to upstream this.

- **Why can this be an issue?** Without an explicit column width, the grid uses an implicit width based on context. For example, without this rule, cards on the Astro Docs homepage would overflow due to the code block in the “Start a new project” card:

  <img width="351" alt="narrow viewport screenshot of Astro Docs without this change. A card featuring a code example overflows the viewport" src="https://github.com/user-attachments/assets/49e8bee0-00cd-4a43-a0af-0bb8ba480f47">

- Adding an explicit column width avoids that and ensures children are constrained as expected:

  <img width="344" alt="A similar screenshot of Astro Docs but now the cards all fit inside the viewport instead of overflowing" src="https://github.com/user-attachments/assets/2dd0a601-c4f5-40b8-9e65-a00680ef6a18">



<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
