### PR TITLE
Fix i18n type issue with multiple data content collections

### DIFF
--- a/.changeset/blue-walls-kiss.md
+++ b/.changeset/blue-walls-kiss.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes a UI string type issue in project with multiple data content collections.

--- a/.changeset/blue-walls-kiss.md
+++ b/.changeset/blue-walls-kiss.md
@@ -2,4 +2,4 @@
 '@astrojs/starlight': patch
 ---
 
-Fixes a UI string type issue in project with multiple data content collections.
+Fixes a UI string type issue in projects with multiple data content collections.

--- a/packages/starlight/utils/createTranslationSystem.ts
+++ b/packages/starlight/utils/createTranslationSystem.ts
@@ -121,7 +121,11 @@ function buildResources<T extends Record<string, string | undefined>>(
 	return { [I18nextNamespace]: dictionary as BuiltInStrings & T };
 }
 
-export type I18nKeys = UserI18nKeys | keyof StarlightApp.I18n;
+// `keyof BuiltInStrings` and `UserI18nKeys` may contain some identical keys, e.g. the built-in UI
+// strings. We let TypeScript merge them into a single union type so that plugins with a TypeScript
+// configuration preventing `UserI18nKeys` to be properly inferred can still get auto-completion
+// for built-in UI strings.
+export type I18nKeys = keyof BuiltInStrings | UserI18nKeys | keyof StarlightApp.I18n;
 
 export type I18nT = TFunction<'starlight', undefined> & {
 	all: () => UserI18nSchema;

--- a/packages/starlight/utils/translations.ts
+++ b/packages/starlight/utils/translations.ts
@@ -5,8 +5,13 @@ import type { i18nSchemaOutput } from '../schemas/i18n';
 import { createTranslationSystem } from './createTranslationSystem';
 import type { RemoveIndexSignature } from './types';
 
+// @ts-ignore - This may be a type error in projects without an i18n collection and running
+// `tsc --noEmit` in their project. Note that it is not possible to inline this type in
+// `UserI18nSchema` because this would break types for users having multiple data collections.
+type i18nCollection = CollectionEntry<'i18n'>;
+
 export type UserI18nSchema = 'i18n' extends DataCollectionKey
-	? CollectionEntry<'i18n'> extends { data: infer T }
+	? i18nCollection extends { data: infer T }
 		? i18nSchemaOutput & T
 		: i18nSchemaOutput
 	: i18nSchemaOutput;


### PR DESCRIPTION
#### Description

This PR fixes an issue initially spotted in https://github.com/withastro/docs/pull/9240.

To reproduce the issue:

1. Create a new data content collection by creating an `docs/src/content/nav/en.ts` file with the following content:

   ```ts
   export default {}
   ```
1. Run `pnpm dev` to generate types for the new data content collection.

At this point, all `Astro.locals.t()` calls would indicate a type error and you would get no autocomplete suggestions for it.

On top of extracting the `CollectionEntry<'i18n'>` type outside of the `UserI18nSchema` conditional, I also had to cherry pick a fix I made in #2578 as #2380 made the `i18nSchemaOutput` fallback type too loose.