### PR TITLE
Fix `sidebar` frontmatter use in internal links

### DIFF
--- a/.changeset/wild-donkeys-join.md
+++ b/.changeset/wild-donkeys-join.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes support for `sidebar` frontmatter options in sidebar entries using `slug` or the string shorthand for internal links

--- a/packages/starlight/__tests__/i18n-sidebar/i18n-sidebar.test.ts
+++ b/packages/starlight/__tests__/i18n-sidebar/i18n-sidebar.test.ts
@@ -12,7 +12,13 @@ vi.mock('astro:content', async () =>
 			['fr/manual-setup.mdx', { title: 'Installation manuelle' }],
 			['environmental-impact.md', { title: 'Eco-friendly docs' }],
 			['fr/environmental-impact.md', { title: 'Documents écologiques' }],
-			['guides/pages.mdx', { title: 'Pages' }],
+			[
+				'guides/pages.mdx',
+				{
+					title: 'Pages',
+					sidebar: { label: 'Pages Guide', badge: 'Test', attrs: { class: 'test' } },
+				},
+			],
 			['fr/guides/pages.mdx', { title: 'Pages' }],
 			['guides/authoring-content.mdx', { title: 'Authoring Content in Markdown' }],
 			['fr/guides/authoring-content.mdx', { title: 'Création de contenu en Markdown' }],
@@ -69,11 +75,16 @@ describe('getSidebar', () => {
 			    "collapsed": false,
 			    "entries": [
 			      {
-			        "attrs": {},
-			        "badge": undefined,
+			        "attrs": {
+			          "class": "test",
+			        },
+			        "badge": {
+			          "text": "Test",
+			          "variant": "default",
+			        },
 			        "href": "/guides/pages",
 			        "isCurrent": false,
-			        "label": "Pages",
+			        "label": "Pages Guide",
 			        "type": "link",
 			      },
 			      {

--- a/packages/starlight/utils/navigation.ts
+++ b/packages/starlight/utils/navigation.ts
@@ -13,7 +13,7 @@ import { createPathFormatter } from './createPathFormatter';
 import { formatPath } from './format-path';
 import { BuiltInDefaultLocale, pickLang } from './i18n';
 import { ensureLeadingSlash, ensureTrailingSlash, stripLeadingAndTrailingSlashes } from './path';
-import { getLocaleRoutes, routes, type Route } from './routing';
+import { getLocaleRoutes, routes, type Route, type StarlightDocsEntry } from './routing';
 import { localeToLang, slugToPathname } from './slugs';
 import type { StarlightConfig } from './user-config';
 
@@ -142,8 +142,8 @@ function linkFromInternalSidebarLinkItem(
 	// Astro passes root `index.[md|mdx]` entries with a slug of `index`
 	const slug = item.slug === 'index' ? '' : item.slug;
 	const localizedSlug = locale ? (slug ? locale + '/' + slug : locale) : slug;
-	const entry = routes.find((entry) => localizedSlug === entry.slug);
-	if (!entry) {
+	const route = routes.find((entry) => localizedSlug === entry.slug);
+	if (!route) {
 		const hasExternalSlashes = item.slug.at(0) === '/' || item.slug.at(-1) === '/';
 		if (hasExternalSlashes) {
 			throw new AstroError(
@@ -158,9 +158,15 @@ function linkFromInternalSidebarLinkItem(
 			);
 		}
 	}
+	const frontmatter = route.entry.data;
 	const label =
-		pickLang(item.translations, localeToLang(locale)) || item.label || entry.entry.data.title;
-	return makeSidebarLink(entry.slug, label, getSidebarBadge(item.badge, locale, label), item.attrs);
+		pickLang(item.translations, localeToLang(locale)) ||
+		item.label ||
+		frontmatter.sidebar?.label ||
+		frontmatter.title;
+	const badge = item.badge ?? frontmatter.sidebar?.badge;
+	const attrs = { ...frontmatter.sidebar?.attrs, ...item.attrs };
+	return makeSidebarLink(route.slug, label, getSidebarBadge(badge, locale, label), attrs);
 }
 
 /** Process sidebar link options to create a link entry. */


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Fixes use of the `sidebar` frontmatter options to control appearance of a sidebar link when included using the “internal” link syntax, i.e. `{ slug: 'page/name' }` or the shorthand of `'page/name'`
- Currently `sidebar.label`, `sidebar.badge`, and `sidebar.attrs` in frontmatter are ignored with only `title` from frontmatter being used when an explicit label is not set.
- This PR fixes that and updates a sidebar test to match

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
