### PR TITLE
i18n(fr): update `guides/overriding-components` & `reference/overrides`

### DIFF
--- a/docs/src/content/docs/fr/guides/overriding-components.mdx
+++ b/docs/src/content/docs/fr/guides/overriding-components.mdx
@@ -86,6 +86,23 @@ Lorsque vous affichez un composant intégré dans un composant personnalisé :
 - Décomposez `Astro.props` dans celui-ci. Cela permet de s'assurer qu'il reçoit toutes les données dont il a besoin pour être affiché.
 - Ajoutez un élément [`<slot />`](https://docs.astro.build/fr/core-concepts/astro-components/#les-emplacements-slots) à l'intérieur du composant par défaut. Cela permet de s'assurer que si le composant reçoit des éléments enfants, Astro sait où les afficher.
 
+Si vous réutilisez les composants [`PageFrame`](/fr/reference/overrides/#pageframe) ou [`TwoColumnContent`](/fr/reference/overrides/#twocolumncontent) qui contiennent des [emplacements (slots) nommés](https://docs.astro.build/fr/basics/astro-components/#les-emplacements-slots-nomm%C3%A9s), vous devez également [transférer](https://docs.astro.build/fr/basics/astro-components/#transf%C3%A9rer-les-emplacements) ces emplacements.
+
+L'exemple ci-dessous montre un composant personnalisé qui réutilise le composant `TwoColumnContent` qui contient un emplacement supplémentaire nommé `right-sidebar` qui doit être transféré :
+
+```astro {9}
+---
+// src/components/CustomContent.astro
+import type { Props } from '@astrojs/starlight/props';
+import Default from '@astrojs/starlight/components/TwoColumnContent.astro';
+---
+
+<Default {...Astro.props}>
+	<slot />
+	<slot name="right-sidebar" slot="right-sidebar" />
+</Default>
+```
+
 ## Utiliser les données de la page
 
 Lorsque vous redéfinissez un composant de Starlight, votre implémentation personnalisée reçoit un objet `Astro.props` standard contenant toutes les données de la page courante.

--- a/docs/src/content/docs/fr/reference/overrides.md
+++ b/docs/src/content/docs/fr/reference/overrides.md
@@ -195,7 +195,8 @@ Lorsque cela est possible, préférez redéfinir un composant de plus bas niveau
 
 #### `PageFrame`
 
-**Composant par défaut :** [`PageFrame.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/PageFrame.astro)
+**Composant par défaut :** [`PageFrame.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/PageFrame.astro)  
+**Emplacements (slots) nommés :** `header`, `sidebar`
 
 Composant de mise en page contenant la plupart du contenu de la page.
 L'implémentation par défaut configure la mise en page de l'en-tête, de la barre latérale et du contenu principal et inclut des emplacements (slots) nommés `header` et `sidebar` en plus de l'emplacement par défaut pour le contenu principal.
@@ -209,7 +210,8 @@ Composant utilisé à l'intérieur de [`<PageFrame>`](#pageframe) qui est respon
 
 #### `TwoColumnContent`
 
-**Composant par défaut :** [`TwoColumnContent.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/TwoColumnContent.astro)
+**Composant par défaut :** [`TwoColumnContent.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/TwoColumnContent.astro)  
+**Emplacement (slot) nommé :** `right-sidebar`
 
 Composant de mise en page enveloppant le contenu principal de la page et la barre latérale de droite (table des matières).
 L'implémentation par défaut prend en charge le changement entre une mise en page à une seule colonne pour petits écrans et une mise en page à deux colonnes pour écrans plus larges.


### PR DESCRIPTION
#### Description

This PR updates the French version of the `guides/overriding-components` & `reference/overrides` pages with the changes from #2386.