### PR TITLE
i18n(fr): update `resources/plugins`

### DIFF
--- a/docs/src/content/docs/fr/resources/plugins.mdx
+++ b/docs/src/content/docs/fr/resources/plugins.mdx
@@ -91,17 +91,27 @@ Les [modules d'extension](/fr/reference/plugins/) peuvent personnaliser la confi
 	<LinkCard
 		href="https://github.com/Fevol/starlight-site-graph"
 		title="starlight-site-graph"
-		description="Ajoutez un graphe interactif de votre site dans la barre latérale de votre page."
+		description="Ajouter un graphe interactif de votre site dans la barre latérale de votre page."
 	/>
 	<LinkCard
 		href="https://github.com/HiDeoo/starlight-sidebar-topics"
 		title="starlight-sidebar-topics"
-		description="Divisez votre documentation en différentes sections, chacune ayant sa propre barre latérale."
+		description="Diviser votre documentation en différentes sections, chacune ayant sa propre barre latérale."
 	/>
 	<LinkCard
 		href="https://github.com/trueberryless-org/starlight-sidebar-topics-dropdown"
 		title="starlight-sidebar-topics-dropdown"
-		description="Divisez vos pages de documentation en plusieurs sous-pages et passez de l'une à l'autre à l'aide d'un menu déroulant dans la barre latérale."
+		description="Diviser vos pages de documentation en plusieurs sous-pages et passez de l'une à l'autre à l'aide d'un menu déroulant dans la barre latérale."
+	/>
+	<LinkCard
+		href="https://github.com/trueberryless-org/starlight-cooler-credit"
+		title="starlight-cooler-credit"
+		description="Ajouter de jolis crédits pour Starlight ou Astro en bas de la table des matières."
+	/>
+	<LinkCard
+		href="https://github.com/trueberryless-org/starlight-contributor-list"
+		title="starlight-contributor-list"
+		description="Afficher une liste de tous les contributeurs à votre projet."
 	/>
 </CardGrid>
 


### PR DESCRIPTION
#### Description

This PR updates the French version of the `resources/plugins` page with the changes from #2595 and also tweaks some tense for consistency.