### PR TITLE
i18n(ko): fix Markdown newline in `reference/overrides.md`

### DIFF
--- a/docs/src/content/docs/ko/reference/overrides.md
+++ b/docs/src/content/docs/ko/reference/overrides.md
@@ -194,7 +194,7 @@ Starlight의 구성 옵션을 준수하는 콘텐츠 목차 컴포넌트를 생�
 
 #### `PageFrame`
 
-**기본 컴포넌트:** [`PageFrame.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/PageFrame.astro)
+**기본 컴포넌트:** [`PageFrame.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/PageFrame.astro)  
 **명명된 슬롯:** `header`, `sidebar`
 
 대부분의 페이지 콘텐츠를 감싸는 레이아웃 컴포넌트입니다.
@@ -209,7 +209,7 @@ Starlight의 구성 옵션을 준수하는 콘텐츠 목차 컴포넌트를 생�
 
 #### `TwoColumnContent`
 
-**기본 컴포넌트:** [`TwoColumnContent.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/TwoColumnContent.astro)
+**기본 컴포넌트:** [`TwoColumnContent.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/TwoColumnContent.astro)  
 **명명된 슬롯:** `right-sidebar`
 
 메인 콘텐츠 열과 오른쪽 사이드바 (목차)를 감싸는 레이아웃 컴포넌트입니다.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- there is no newline in the Korean translation from #2629 
- other translations and original have two spaces before the newline to enforce the newline (#2627, #2386)

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->

![Screenshot_20241123-143155.png](https://github.com/user-attachments/assets/9fb9f167-f350-44c6-8746-190ca62a93c3)

