### PR TITLE
Fix Safari VoiceOver issue

### DIFF
--- a/.changeset/strange-icons-explode.md
+++ b/.changeset/strange-icons-explode.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes a VoiceOver issue with Safari where the content of a `<script>` element could be read before the sidebar content.

--- a/packages/starlight/components/SidebarPersister.astro
+++ b/packages/starlight/components/SidebarPersister.astro
@@ -13,10 +13,10 @@
   - The state is parsed from session storage and restored.
   - This is a progressive enhancement, so any errors are swallowed silently.
 
-	The `aria-hidden` attribute on script tags is used to prevent a Safari/VoiceOver bug where the
-	script is read out loud due to them being inside a container with `display: contents`.
-	@see https://bugs.webkit.org/show_bug.cgi?id=283645
-	@see https://github.com/withastro/starlight/pull/2633
+  The `aria-hidden` attribute on script tags is used to prevent a Safari/VoiceOver bug where the
+  script is read out loud due to them being inside a container with `display: contents`.
+  @see https://bugs.webkit.org/show_bug.cgi?id=283645
+  @see https://github.com/withastro/starlight/pull/2633
 */
 
 import type { Props } from '../props';

--- a/packages/starlight/components/SidebarPersister.astro
+++ b/packages/starlight/components/SidebarPersister.astro
@@ -12,6 +12,11 @@
   - On smaller viewports, restoring state is skipped as the sidebar is collapsed inside a menu.
   - The state is parsed from session storage and restored.
   - This is a progressive enhancement, so any errors are swallowed silently.
+
+	The `aria-hidden` attribute on script tags is used to prevent a Safari/VoiceOver bug where the
+	script is read out loud due to them being inside a container with `display: contents`.
+	@see https://bugs.webkit.org/show_bug.cgi?id=283645
+	@see https://github.com/withastro/starlight/pull/2633
 */
 
 import type { Props } from '../props';

--- a/packages/starlight/components/SidebarPersister.astro
+++ b/packages/starlight/components/SidebarPersister.astro
@@ -28,7 +28,7 @@ declare global {
 ---
 
 <sl-sidebar-state-persist data-hash={hash}>
-	<script is:inline>
+	<script is:inline aria-hidden="true">
 		(() => {
 			try {
 				if (!matchMedia('(min-width: 50em)').matches) return;
@@ -55,7 +55,7 @@ declare global {
 
 	<slot />
 
-	<script is:inline>
+	<script is:inline aria-hidden="true">
 		(() => {
 			const scroller = document.getElementById('starlight__sidebar');
 			if (!window._starlightScrollRestore || !scroller) return;


### PR DESCRIPTION
#### Description

The change may look a bit weird at first but it looks like the number of Safari/VoiceOver issue with `display: contents;` is growing. A new "fun" one I just discovered seems to be related to a web component having `display: contents;` and a `<script>` element as a direct child which seems to make VoiceOver read the content of the `<script>` element.

This reproduces at least on macOS Sequoia 15.1 with Safari 18.1.

Here is a video before the fix…

https://github.com/user-attachments/assets/0d6beffb-5051-42b2-9882-9236bf687770

Here is a video after the fix:

https://github.com/user-attachments/assets/c0208683-2376-43c8-8f90-05cbb50b2976

If this is accepted, maybe we could add a comment in the file frontmatter explaining why we have this attribute on a `script` element with a link to this PR and the videos?