### PR TITLE
feat(link): add target="_blank" for external social links

### DIFF
--- a/packages/starlight/components/SocialIcons.astro
+++ b/packages/starlight/components/SocialIcons.astro
@@ -12,7 +12,7 @@ const links = Object.entries(config.social || {}) as [Platform, SocialConfig][];
 	links.length > 0 && (
 		<>
 			{links.map(([platform, { label, url }]) => (
-				<a href={url} rel="me" class="sl-flex">
+				<a href={url} rel="me" class="sl-flex" target="_blank">
 					<span class="sr-only">{label}</span>
 					<Icon name={platform} />
 				</a>


### PR DESCRIPTION
## Add target="_blank" to Social Media Links

### Description

This PR enhances the user experience of social media links by making them open in new tabs, allowing users to maintain their current browsing session while accessing external social platforms.

#### Changes Made
- Added `target="_blank"` attribute to social media anchor tags
- Maintains the main site navigation context for users
- Follows web accessibility best practices

#### Before
Social media links would navigate away from the current page, disrupting the user's browsing experience.

#### After
Social media links now open in new tabs, preserving the user's current session on the main site.

#### Technical Details
Modified the social media link component:
html
<!-- Before -->
<a href={url} rel="me" class="sl-flex">
<!-- After -->
<a href={url} rel="me" target="blank" class="sl-flex">