### PR TITLE
Add tests and functionality for handling double quotes in file names in FileTree

### DIFF
--- a/docs/src/content/docs/components/file-tree.mdx
+++ b/docs/src/content/docs/components/file-tree.mdx
@@ -218,6 +218,46 @@ import { FileTree } from '@astrojs/starlight/components';
 
 </Preview>
 
+### Escape white-space in file names
+
+To include white-space in a file or directory name, escape it with double quotes.
+
+<Preview>
+
+```mdx {5,6}
+import { FileTree } from '@astrojs/starlight/components';
+
+<FileTree>
+
+- "main folder/"
+  - "The Header.astro"
+  - …
+
+</FileTree>
+```
+
+<Fragment slot="markdoc">
+
+```markdoc {2,3}
+{% filetree %}
+- "main folder/"
+  - "The Header.astro"
+  - …
+{% /filetree %}
+```
+
+</Fragment>
+
+<FileTree slot="preview">
+
+- "main folder/"
+  - "The Header.astro"
+  - …
+
+</FileTree>
+
+</Preview>
+
 ## `<FileTree>` Props
 
 **Implementation:** [`FileTree.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/user-components/FileTree.astro)

--- a/docs/src/content/docs/components/file-tree.mdx
+++ b/docs/src/content/docs/components/file-tree.mdx
@@ -229,8 +229,9 @@ import { FileTree } from '@astrojs/starlight/components';
 
 <FileTree>
 
-- "main folder/"
-  - "The Header.astro"
+- "main folder/" file <strong>container</strong>
+- "main folder/" file container
+  - "The Header.astro" main file
   - …
 
 </FileTree>
@@ -240,8 +241,9 @@ import { FileTree } from '@astrojs/starlight/components';
 
 ```markdoc {2,3}
 {% filetree %}
-- "main folder/"
-  - "The Header.astro"
+- "main folder/" file <strong>container</strong>
+- "main folder/" file container
+  - "The Header.astro" main file
   - …
 {% /filetree %}
 ```
@@ -250,8 +252,9 @@ import { FileTree } from '@astrojs/starlight/components';
 
 <FileTree slot="preview">
 
-- "main folder/"
-  - "The Header.astro"
+- "main folder/" file <strong>container</strong>
+- "main folder/" file container
+  - "The Header.astro" main file
   - …
 
 </FileTree>

--- a/packages/starlight/__tests__/remark-rehype/rehype-file-tree.test.ts
+++ b/packages/starlight/__tests__/remark-rehype/rehype-file-tree.test.ts
@@ -120,6 +120,42 @@ describe('processor', () => {
 		expect(extractFileTree(html)).toMatchFileSnapshot('./snapshots/file-tree-double-quotes-folder-node.html');
 	});
 
+	test('special quotes allows to add white-space to file names', () => {
+		const html = processTestFileTree(`<ul><li>“file name”</li></ul>`);
+
+		expect(extractFileTree(html)).toMatchFileSnapshot('./snapshots/file-tree-double-quotes-file.html');
+	});
+
+	test('special quotes file name with text comments', () => {
+		const html = processTestFileTree(`<ul><li>“file name” with some comments</li></ul>`);
+
+		expect(extractFileTree(html)).toMatchFileSnapshot('./snapshots/file-tree-double-quotes-file-text.html');
+	});
+
+	test('special quotes file name with node comments', () => {
+		const html = processTestFileTree(`<ul><li>“file name” with <strong>important</strong> comments</li></ul>`);
+
+		expect(extractFileTree(html)).toMatchFileSnapshot('./snapshots/file-tree-double-quotes-file-node.html');
+	});
+
+	test('special quotes allows to add white-space to folder names', () => {
+		const html = processTestFileTree(`<ul><li>“folder name/”</li></ul>`);
+
+		expect(extractFileTree(html)).toMatchFileSnapshot('./snapshots/file-tree-double-quotes-folder.html');
+	});
+
+	test('special quotes folder name with text comments', () => {
+		const html = processTestFileTree(`<ul><li>“folder name/” with some comments</li></ul>`);
+
+		expect(extractFileTree(html)).toMatchFileSnapshot('./snapshots/file-tree-double-quotes-folder-text.html');
+	});
+
+	test('special quotes folder name with node comments', () => {
+		const html = processTestFileTree(`<ul><li>“folder name/” with <strong>important</strong> comments</li></ul>`);
+
+		expect(extractFileTree(html)).toMatchFileSnapshot('./snapshots/file-tree-double-quotes-folder-node.html');
+	});
+
 	test('identifies directory with either a file name ending with a slash or a nested list', () => {
 		const html = processTestFileTree(`<ul>
   <li>directory/</li>

--- a/packages/starlight/__tests__/remark-rehype/rehype-file-tree.test.ts
+++ b/packages/starlight/__tests__/remark-rehype/rehype-file-tree.test.ts
@@ -84,6 +84,42 @@ describe('processor', () => {
 		expect(extractFileTree(html)).toMatchFileSnapshot('./snapshots/file-tree-comment-nodes.html');
 	});
 
+	test('double quotes allows to add white-space to file names', () => {
+		const html = processTestFileTree(`<ul><li>"file name"</li></ul>`);
+
+		expect(extractFileTree(html)).toMatchFileSnapshot('./snapshots/file-tree-double-quotes-file.html');
+	});
+
+	test('double quotes file name with text comments', () => {
+		const html = processTestFileTree(`<ul><li>"file name" with some comments</li></ul>`);
+
+		expect(extractFileTree(html)).toMatchFileSnapshot('./snapshots/file-tree-double-quotes-file-text.html');
+	});
+
+	test('double quotes file name with node comments', () => {
+		const html = processTestFileTree(`<ul><li>"file name" with <strong>important</strong> comments</li></ul>`);
+
+		expect(extractFileTree(html)).toMatchFileSnapshot('./snapshots/file-tree-double-quotes-file-node.html');
+	});
+
+	test('double quotes allows to add white-space to folder names', () => {
+		const html = processTestFileTree(`<ul><li>"folder name/"</li></ul>`);
+
+		expect(extractFileTree(html)).toMatchFileSnapshot('./snapshots/file-tree-double-quotes-folder.html');
+	});
+
+	test('double quotes folder name with text comments', () => {
+		const html = processTestFileTree(`<ul><li>"folder name/" with some comments</li></ul>`);
+
+		expect(extractFileTree(html)).toMatchFileSnapshot('./snapshots/file-tree-double-quotes-folder-text.html');
+	});
+
+	test('double quotes folder name with node comments', () => {
+		const html = processTestFileTree(`<ul><li>"folder name/" with <strong>important</strong> comments</li></ul>`);
+
+		expect(extractFileTree(html)).toMatchFileSnapshot('./snapshots/file-tree-double-quotes-folder-node.html');
+	});
+
 	test('identifies directory with either a file name ending with a slash or a nested list', () => {
 		const html = processTestFileTree(`<ul>
   <li>directory/</li>

--- a/packages/starlight/__tests__/remark-rehype/snapshots/file-tree-double-quotes-file-node.html
+++ b/packages/starlight/__tests__/remark-rehype/snapshots/file-tree-double-quotes-file-node.html
@@ -1,0 +1,1 @@
+<ul><li class="file"><span class="tree-entry"><span class=""><span><svg></svg></span>file name</span> <span class="comment">with <strong>important</strong> comments</span></span></li></ul>

--- a/packages/starlight/__tests__/remark-rehype/snapshots/file-tree-double-quotes-file-text.html
+++ b/packages/starlight/__tests__/remark-rehype/snapshots/file-tree-double-quotes-file-text.html
@@ -1,0 +1,1 @@
+<ul><li class="file"><span class="tree-entry"><span class=""><span><svg></svg></span>file name</span> <span class="comment">with some comments</span></span></li></ul>

--- a/packages/starlight/__tests__/remark-rehype/snapshots/file-tree-double-quotes-file.html
+++ b/packages/starlight/__tests__/remark-rehype/snapshots/file-tree-double-quotes-file.html
@@ -1,0 +1,1 @@
+<ul><li class="file"><span class="tree-entry"><span class=""><span><svg></svg></span>file name</span></span></li></ul>

--- a/packages/starlight/__tests__/remark-rehype/snapshots/file-tree-double-quotes-folder-node.html
+++ b/packages/starlight/__tests__/remark-rehype/snapshots/file-tree-double-quotes-folder-node.html
@@ -1,0 +1,1 @@
+<ul><li class="directory"><details><summary><span class="tree-entry"><span class=""><span><span class="sr-only">Directory</span><svg></svg></span>folder name/</span> <span class="comment">with <strong>important</strong> comments</span></span></summary><ul><li class="file empty"><span class="tree-entry"><span class="">…</span></span></li></ul></details></li></ul>

--- a/packages/starlight/__tests__/remark-rehype/snapshots/file-tree-double-quotes-folder-text.html
+++ b/packages/starlight/__tests__/remark-rehype/snapshots/file-tree-double-quotes-folder-text.html
@@ -1,0 +1,1 @@
+<ul><li class="directory"><details><summary><span class="tree-entry"><span class=""><span><span class="sr-only">Directory</span><svg></svg></span>folder name/</span> <span class="comment">with some comments</span></span></summary><ul><li class="file empty"><span class="tree-entry"><span class="">…</span></span></li></ul></details></li></ul>

--- a/packages/starlight/__tests__/remark-rehype/snapshots/file-tree-double-quotes-folder.html
+++ b/packages/starlight/__tests__/remark-rehype/snapshots/file-tree-double-quotes-folder.html
@@ -1,0 +1,1 @@
+<ul><li class="directory"><details><summary><span class="tree-entry"><span class=""><span><span class="sr-only">Directory</span><svg></svg></span>folder name/</span></span></summary><ul><li class="file empty"><span class="tree-entry"><span class="">…</span></span></li></ul></details></li></ul>

--- a/packages/starlight/user-components/rehype-file-tree.ts
+++ b/packages/starlight/user-components/rehype-file-tree.ts
@@ -252,6 +252,11 @@ function splitFileNameAndTextComments(value: string): [string, string] {
 		if (match) return [match[1]!, match[2]!];
 	}
 
+	if (value.startsWith('“')) {
+		const match = value.match(/^“([^”]+)”\s*(.*)$/);
+		if (match) return [match[1]!, match[2]!];
+	}
+
 	const [filename, ...fragments] = value.split(' ');
 	const textComments = fragments.join(' ');
 	return [filename!, textComments];

--- a/packages/starlight/user-components/rehype-file-tree.ts
+++ b/packages/starlight/user-components/rehype-file-tree.ts
@@ -56,11 +56,10 @@ const fileTreeProcessor = rehype()
 
 				// Extract text comment that follows the file name, e.g. `README.md This is a comment`
 				if (firstChild?.type === 'text') {
-					const [filename, ...fragments] = firstChild.value.split(' ');
-					firstChild.value = filename || '';
-					const textComment = fragments.join(' ').trim();
-					if (textComment.length > 0) {
-						comment.push(fragments.join(' '));
+					const [filename, textComment] = splitFileNameAndTextComments(firstChild.value);
+					firstChild.value = filename;
+					if (textComment.trim().length > 0) {
+						comment.push(textComment);
 					}
 				}
 
@@ -242,6 +241,20 @@ function throwFileTreeValidationError(message: string): never {
 		message,
 		'To learn more about the `<FileTree>` component, see https://starlight.astro.build/components/file-tree/'
 	);
+}
+
+function splitFileNameAndTextComments(value: string): [string, string] {
+	if (!value || value.trim() === '') return ['', ''];
+
+	// Handles the case where the file name is wrapped in double quotes, e.g. `"READ ME.md" This is a comment`.
+	if (value.startsWith('"')) {
+		const match = value.match(/^"([^"]+)"\s*(.*)$/);
+		if (match) return [match[1]!, match[2]!];
+	}
+
+	const [filename, ...fragments] = value.split(' ');
+	const textComments = fragments.join(' ');
+	return [filename!, textComments];
 }
 
 export interface Definitions {


### PR DESCRIPTION
#### Description

- Closes #2608
- What does this PR change?
  Allows to use double quotes in `FileTree` component to indicate the full file name in cases where the file name contains white space. Like: `- "my file name" this is the comment`
- Did you change something visual?
  Yes, but I don't know how to test the visuals from this project. I just added some tests for this case and change the code parsing the content of the list.
  I would still need to update the docs
<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
