### PR TITLE
chore: remove rel `shortcut` from favicon

### DIFF
--- a/.changeset/lazy-rats-decide.md
+++ b/.changeset/lazy-rats-decide.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Remove 'shortcut' from favicon rel attribute

--- a/packages/starlight/__tests__/basics/head.test.ts
+++ b/packages/starlight/__tests__/basics/head.test.ts
@@ -91,9 +91,10 @@ describe('createHead', () => {
 		const defaultFavicon = {
 			tag: 'link',
 			attrs: {
-				rel: 'shortcut icon',
+				rel: 'icon',
 				href: '/favicon.svg',
 				type: 'image/svg+xml',
+				'data-favicon': 'default',
 			},
 		} as const;
 

--- a/packages/starlight/components/Head.astro
+++ b/packages/starlight/components/Head.astro
@@ -32,9 +32,10 @@ const headDefaults: z.input<ReturnType<typeof HeadConfigSchema>> = [
 	{
 		tag: 'link',
 		attrs: {
-			rel: 'shortcut icon',
+			rel: 'icon',
 			href: fileWithBase(config.favicon.href),
 			type: config.favicon.type,
+			'data-favicon': 'default',
 		},
 	},
 	// OpenGraph Tags

--- a/packages/starlight/utils/head.ts
+++ b/packages/starlight/utils/head.ts
@@ -89,7 +89,12 @@ function getImportance(entry: HeadConfig[number]) {
 		// The default favicon should be below any extra icons that the user may have set
 		// because if several icons are equally appropriate, the last one is used and we
 		// want to use the SVG icon when supported.
-		if (entry.tag === 'link' && 'rel' in entry.attrs && entry.attrs.rel === 'shortcut icon') {
+		if (
+			entry.tag === 'link' &&
+			'rel' in entry.attrs &&
+			entry.attrs.rel === 'icon' &&
+			entry.attrs['data-favicon'] === 'default'
+		) {
 			return 70;
 		}
 		return 80;


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #2112
- What does this PR change? Removes rel `shortcut` from favicon.  As discussed in #2112, 'shortcut' only existed for IE <=8 which Starlight does not support.  While agents should properly parse the rel value even with shortcut, it is non-conforming and should not be used (see [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#icon)).
- Did you change something visual? No.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
