### PR TITLE
Fix file icons generator

### DIFF
--- a/packages/file-icons-generator/index.ts
+++ b/packages/file-icons-generator/index.ts
@@ -1,24 +1,28 @@
 import { writeDefinitionsAndSVGs } from './utils/file';
 import { getIconSvgPaths } from './utils/font';
-import { fetchFont, fetchMapping, parseMapping } from './utils/seti';
+import { deleteRepo, parseMapping, setupRepo } from './utils/seti';
 
 /**
  * Script generating definitions used by the Starlight `<FileTree>` component and associated SVGs.
  *
- * To do so, it fetches the Seti UI icon mapping file and font from GitHub, parses the mapping to
- * generate the definitions and a list of icons to extract as SVGs, and finally extracts the SVGs
- * from the font and writes the definitions and SVGs to the Starlight package in a file ready to be
- * consumed by Starlight.
+ * To do so, it clones the Seti UI repository, installs dependencies, generates icons, parses the
+ * mapping to generate the definitions and a list of icons to extract as SVGs, and finally extracts
+ * the SVGs from the font and writes the definitions and SVGs to the Starlight package in a file
+ * ready to be consumed by Starlight.
  *
  * @see {@link file://./config.ts} for the configuration used by this script.
  * @see {@link file://../starlight/user-components/file-tree-icons.ts} for the generated file.
  * @see {@link https://opentype.js.org/glyph-inspector.html} for a font glyph inspector.
  */
 
-const mapping = await fetchMapping();
-const { definitions, icons } = parseMapping(mapping);
+const repoPath = await setupRepo();
 
-const font = await fetchFont();
-const svgPaths = getIconSvgPaths(icons, definitions, font);
+try {
+	const { definitions, icons } = await parseMapping(repoPath);
 
-await writeDefinitionsAndSVGs(definitions, svgPaths);
+	const svgPaths = await getIconSvgPaths(repoPath, icons, definitions);
+
+	await writeDefinitionsAndSVGs(definitions, svgPaths);
+} finally {
+	await deleteRepo(repoPath);
+}

--- a/packages/file-icons-generator/utils/font.ts
+++ b/packages/file-icons-generator/utils/font.ts
@@ -1,17 +1,15 @@
 import opentype, { type Font, Glyph } from 'opentype.js';
 import { seti, starlight } from '../config';
 import type { Definitions } from '../../starlight/user-components/rehype-file-tree';
-import { getSetiIconName } from './seti';
+import { getFont, getSetiIconName } from './seti';
 
 // This matches the default precision used by the SVGO default preset.
 const pathDecimalPrecision = 3;
 
 /** Extract SVG paths from the Seti UI icon font from a list of icon names matching font glyphs. */
-export function getIconSvgPaths(
-	icons: string[],
-	definitions: Definitions,
-	fontBuffer: ArrayBuffer
-) {
+export async function getIconSvgPaths(repoPath: string, icons: string[], definitions: Definitions) {
+	const fontBuffer = await getFont(repoPath);
+
 	const iconSvgs: Record<string, string> = {};
 
 	let font: Font;


### PR DESCRIPTION
#### Description

I noticed the [last file icons generator run](https://github.com/withastro/starlight/actions/runs/12100560042/job/33739317068) failed.

The issue is related to the fact that when icons are added (or modified) to the Seti UI theme in https://github.com/jesseweed/seti-ui, the font is not automatically updated in their repository and they basically let consumers do it (e.g. that's what Visual Studio Code does).

This PR updates the file icons generator to no longer download files from their GitHub repository, but instead clone the repository, install dependencies, and build the font locally which is then used to generate the icons.

Note that this PR only includes the changes necessary to fix the file icons generator. The icons themselves are not updated in this PR. With these changes, the following icon changes are expected once the script is triggered:

- New Vite icon + its definitions (https://github.com/jesseweed/seti-ui/pull/709)
- Updated Java icon (https://github.com/jesseweed/seti-ui/pull/651)
- Updated Terraform icon (https://github.com/jesseweed/seti-ui/pull/657)