### PR TITLE
Fix the favicon schema so it doesn't accept absolute URL. Closes #2647

### DIFF
--- a/packages/starlight/schemas/favicon.ts
+++ b/packages/starlight/schemas/favicon.ts
@@ -38,10 +38,6 @@ export const FaviconSchema = () =>
                 });
                 return z.NEVER;
             }
-			// If it is a relative link but with different format, reformat it.
-			if (!favicon.startsWith('/')) {
-                favicon = `/${favicon}`;
-            }
 
 			// Return the relative path (correctly formatted)
 			return {

--- a/packages/starlight/schemas/favicon.ts
+++ b/packages/starlight/schemas/favicon.ts
@@ -1,4 +1,4 @@
-import { extname } from 'node:path';
+import { extname,  } from 'node:path';
 import { z } from 'astro/zod';
 
 const faviconTypeMap = {
@@ -10,13 +10,17 @@ const faviconTypeMap = {
 	'.svg': 'image/svg+xml',
 };
 
+function isFaviconExt(ext: string): ext is keyof typeof faviconTypeMap {
+	return ext in faviconTypeMap;
+}
+
 export const FaviconSchema = () =>
 	z
 		.string()
 		.default('/favicon.svg')
 		.transform((favicon, ctx) => {
 			const ext = extname(favicon).toLowerCase();
-
+			// Return error when favicon isn't the file type accepted
 			if (!isFaviconExt(ext)) {
 				ctx.addIssue({
 					code: z.ZodIssueCode.custom,
@@ -25,7 +29,21 @@ export const FaviconSchema = () =>
 
 				return z.NEVER;
 			}
+			// check for both http and https
+			if (/^https?:\/\//.test(favicon)) {
+                ctx.addIssue({
+					// Show error message
+                    code: z.ZodIssueCode.custom,
+                    message: 'Favicons must be a relative URL with a .ico, .gif, .jpg, .png, or .svg file.',
+                });
+                return z.NEVER;
+            }
+			// If it is a relative link but with different format, reformat it.
+			if (!favicon.startsWith('/')) {
+                favicon = `/${favicon}`;
+            }
 
+			// Return the relative path (correctly formatted)
 			return {
 				href: favicon,
 				type: faviconTypeMap[ext],
@@ -35,6 +53,3 @@ export const FaviconSchema = () =>
 			'The default favicon for your site which should be a path to an image in the `public/` directory.'
 		);
 
-function isFaviconExt(ext: string): ext is keyof typeof faviconTypeMap {
-	return ext in faviconTypeMap;
-}


### PR DESCRIPTION
#### Description
- Closes #2647  <!-- Add an issue number if this PR will close it. -->
- This PR adds several lines of codes so that the Astro Starlight doesn't accept any absolute URL(i.g https://starlight.astro.build/favicon.svg) and throws an error when a user tries to. 

<img width="742" alt="スクリーンショット 2024-12-02 20 41 54" src="https://github.com/user-attachments/assets/65765d3d-8aaf-48f9-bf21-8c25db250862">

