### PR TITLE
Improve error message with invalid configuration

### DIFF
--- a/.changeset/hip-roses-brush.md
+++ b/.changeset/hip-roses-brush.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Improves error message when an invalid configuration or no configuration is provided to the Starlight integration.

--- a/packages/starlight/index.ts
+++ b/packages/starlight/index.ts
@@ -9,6 +9,7 @@
 
 import mdx from '@astrojs/mdx';
 import type { AstroIntegration } from 'astro';
+import { AstroError } from 'astro/errors';
 import { spawn } from 'node:child_process';
 import { dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -27,10 +28,16 @@ import {
 import { processI18nConfig } from './utils/i18n';
 import type { StarlightConfig } from './types';
 
-export default function StarlightIntegration({
-	plugins,
-	...opts
-}: StarlightUserConfigWithPlugins): AstroIntegration {
+export default function StarlightIntegration(
+	userOpts: StarlightUserConfigWithPlugins
+): AstroIntegration {
+	if (typeof userOpts !== 'object' || userOpts === null || Array.isArray(userOpts))
+		throw new AstroError(
+			'Invalid config passed to starlight integration',
+			`The Starlight integration expects a configuration object with at least a \`title\` property.\n\n` +
+				`See more details in the [Starlight configuration reference](https://starlight.astro.build/reference/configuration/)\n`
+		);
+	const { plugins, ...opts } = userOpts;
 	let userConfig: StarlightConfig;
 	let pluginTranslations: PluginTranslations = {};
 	return {


### PR DESCRIPTION
#### Description

- Closes #2655

The integration expects an object for its configuration and we assume that this user input is always an object and we [unpack](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#unpacking_properties_from_objects_passed_as_a_function_parameter) it into variables from the integration parameters.

This can lead to confusing error messages when the user inputs an invalid configuration or even no configuration at all, e.g. after running `npx astro add starlight`.

This PR adds an extra check to ensure that the configuration is an object and throws a more helpful error message if it is not.

<img width="820" alt="image" src="https://github.com/user-attachments/assets/0ca14053-0ca4-4f8b-8eac-c4d4c49ac4af">
