### PR TITLE
Make asides less prominent

### DIFF
--- a/packages/starlight/style/asides.css
+++ b/packages/starlight/style/asides.css
@@ -1,23 +1,27 @@
 .starlight-aside {
 	padding: 1rem;
-	border-inline-start: 0.25rem solid var(--sl-color-asides-border);
+	border: 1px solid var(--sl-color-asides-border);
 	color: var(--sl-color-white);
 }
+
 .starlight-aside--note {
 	--sl-color-asides-text-accent: var(--sl-color-blue-high);
 	--sl-color-asides-border: var(--sl-color-blue);
 	background-color: var(--sl-color-blue-low);
 }
+
 .starlight-aside--tip {
 	--sl-color-asides-text-accent: var(--sl-color-purple-high);
 	--sl-color-asides-border: var(--sl-color-purple);
 	background-color: var(--sl-color-purple-low);
 }
+
 .starlight-aside--caution {
 	--sl-color-asides-text-accent: var(--sl-color-orange-high);
 	--sl-color-asides-border: var(--sl-color-orange);
 	background-color: var(--sl-color-orange-low);
 }
+
 .starlight-aside--danger {
 	--sl-color-asides-text-accent: var(--sl-color-red-high);
 	--sl-color-asides-border: var(--sl-color-red);
@@ -28,7 +32,6 @@
 	display: flex;
 	gap: 0.5rem;
 	align-items: center;
-	font-size: var(--sl-text-h5);
 	font-weight: 600;
 	line-height: var(--sl-line-height-headings);
 	color: var(--sl-color-asides-text-accent);

--- a/packages/starlight/style/props.css
+++ b/packages/starlight/style/props.css
@@ -11,23 +11,23 @@
 	--sl-color-black: hsl(224, 10%, 10%);
 
 	--sl-hue-orange: 41;
-	--sl-color-orange-low: hsl(var(--sl-hue-orange), 39%, 22%);
+	--sl-color-orange-low: hsl(var(--sl-hue-orange), 39%, 15%);
 	--sl-color-orange: hsl(var(--sl-hue-orange), 82%, 63%);
 	--sl-color-orange-high: hsl(var(--sl-hue-orange), 82%, 87%);
 	--sl-hue-green: 101;
-	--sl-color-green-low: hsl(var(--sl-hue-green), 39%, 22%);
+	--sl-color-green-low: hsl(var(--sl-hue-green), 39%, 15%);
 	--sl-color-green: hsl(var(--sl-hue-green), 82%, 63%);
 	--sl-color-green-high: hsl(var(--sl-hue-green), 82%, 80%);
 	--sl-hue-blue: 234;
-	--sl-color-blue-low: hsl(var(--sl-hue-blue), 54%, 20%);
+	--sl-color-blue-low: hsl(var(--sl-hue-blue), 54%, 18%);
 	--sl-color-blue: hsl(var(--sl-hue-blue), 100%, 60%);
 	--sl-color-blue-high: hsl(var(--sl-hue-blue), 100%, 87%);
 	--sl-hue-purple: 281;
-	--sl-color-purple-low: hsl(var(--sl-hue-purple), 39%, 22%);
+	--sl-color-purple-low: hsl(var(--sl-hue-purple), 39%, 15%);
 	--sl-color-purple: hsl(var(--sl-hue-purple), 82%, 63%);
 	--sl-color-purple-high: hsl(var(--sl-hue-purple), 82%, 89%);
 	--sl-hue-red: 339;
-	--sl-color-red-low: hsl(var(--sl-hue-red), 39%, 22%);
+	--sl-color-red-low: hsl(var(--sl-hue-red), 39%, 15%);
 	--sl-color-red: hsl(var(--sl-hue-red), 82%, 63%);
 	--sl-color-red-high: hsl(var(--sl-hue-red), 82%, 87%);
 
@@ -127,19 +127,19 @@
 
 	--sl-color-orange-high: hsl(var(--sl-hue-orange), 80%, 25%);
 	--sl-color-orange: hsl(var(--sl-hue-orange), 90%, 60%);
-	--sl-color-orange-low: hsl(var(--sl-hue-orange), 90%, 88%);
+	--sl-color-orange-low: hsl(var(--sl-hue-orange), 90%, 90%);
 	--sl-color-green-high: hsl(var(--sl-hue-green), 80%, 22%);
 	--sl-color-green: hsl(var(--sl-hue-green), 90%, 46%);
-	--sl-color-green-low: hsl(var(--sl-hue-green), 85%, 90%);
+	--sl-color-green-low: hsl(var(--sl-hue-green), 85%, 92%);
 	--sl-color-blue-high: hsl(var(--sl-hue-blue), 80%, 30%);
 	--sl-color-blue: hsl(var(--sl-hue-blue), 90%, 60%);
-	--sl-color-blue-low: hsl(var(--sl-hue-blue), 88%, 90%);
+	--sl-color-blue-low: hsl(var(--sl-hue-blue), 88%, 94%);
 	--sl-color-purple-high: hsl(var(--sl-hue-purple), 90%, 30%);
 	--sl-color-purple: hsl(var(--sl-hue-purple), 90%, 60%);
-	--sl-color-purple-low: hsl(var(--sl-hue-purple), 80%, 90%);
+	--sl-color-purple-low: hsl(var(--sl-hue-purple), 80%, 94%);
 	--sl-color-red-high: hsl(var(--sl-hue-red), 80%, 30%);
 	--sl-color-red: hsl(var(--sl-hue-red), 90%, 60%);
-	--sl-color-red-low: hsl(var(--sl-hue-red), 80%, 90%);
+	--sl-color-red-low: hsl(var(--sl-hue-red), 80%, 94%);
 
 	--sl-color-accent-high: hsl(234, 80%, 30%);
 	--sl-color-accent: hsl(234, 90%, 60%);


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Related to https://github.com/withastro/starlight/discussions/1701

This PR changes the appearance of aside blocks to make them stand out less. This was done by changing the `-low` version of the color palette to be less prominent. This change also affected the Card component.

I based my changes off of HiDeoo's WIP branch, but left off some changes:
- decided not to round the corners of asides, since this is something that should be done separately and consistently
- decided not to reduce the icon size because it didn't seem necessary
- instead of using `color-mix` to add transparency to existing `-low` colors, I decided to change the low colors to keep consistency

<details><summary>Screenshots of the before/after for asides and cards in dark/light mode</summary>
<table><tr><th/><th>Before</th><th>After</th></tr>

<tr><td>Asides (dark)</td><td><img width="705" alt="image" src="https://github.com/user-attachments/assets/0c094195-0f0f-403e-a9d9-d02746d97615"></td><td><img width="704" alt="image" src="https://github.com/user-attachments/assets/5ff83f99-3722-412f-9673-11412ddc6ed2"></td></tr>

<tr><td>Asides (light)</td><td><img width="712" alt="image" src="https://github.com/user-attachments/assets/d979add6-d99f-44b2-8984-458df4fc5eda"></td><td>
<img width="708" alt="image" src="https://github.com/user-attachments/assets/b47654da-b888-452f-afef-5026069764a7">
</td></tr>

<tr><td>Cards (dark)</td><td>
<img width="704" alt="image" src="https://github.com/user-attachments/assets/089cd863-eadc-48a0-b54d-498b5c73bbda">
</td><td>
<img width="705" alt="image" src="https://github.com/user-attachments/assets/710daf99-1b87-4a40-b955-80ce39c6409d">
</td></tr>

<tr><td>Cards (light)</td><td>
<img width="705" alt="image" src="https://github.com/user-attachments/assets/82366fae-e70a-4454-9a67-1a4c88fb626f">
</td><td>
<img width="704" alt="image" src="https://github.com/user-attachments/assets/a64101a6-1125-499a-ba2e-56f460991918">
</td></tr>
</table>

</details>


<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
