### PR TITLE
Remove the header color

### DIFF
--- a/packages/starlight/style/props.css
+++ b/packages/starlight/style/props.css
@@ -45,7 +45,7 @@
 	--sl-color-bg-accent: var(--sl-color-accent-high);
 	--sl-color-hairline-light: var(--sl-color-gray-5);
 	--sl-color-hairline: var(--sl-color-gray-6);
-	--sl-color-hairline-shade: var(--sl-color-black);
+	--sl-color-hairline-shade: var(--sl-color-gray-6);
 
 	--sl-color-backdrop-overlay: hsla(223, 13%, 10%, 0.66);
 

--- a/packages/starlight/style/props.css
+++ b/packages/starlight/style/props.css
@@ -39,8 +39,8 @@
 	--sl-color-text-accent: var(--sl-color-accent-high);
 	--sl-color-text-invert: var(--sl-color-accent-low);
 	--sl-color-bg: var(--sl-color-black);
-	--sl-color-bg-nav: var(--sl-color-gray-6);
-	--sl-color-bg-sidebar: var(--sl-color-gray-6);
+	--sl-color-bg-nav: var(--sl-color-bg);
+	--sl-color-bg-sidebar: var(--sl-color-bg);
 	--sl-color-bg-inline-code: var(--sl-color-gray-5);
 	--sl-color-bg-accent: var(--sl-color-accent-high);
 	--sl-color-hairline-light: var(--sl-color-gray-5);
@@ -147,7 +147,7 @@
 
 	--sl-color-text-accent: var(--sl-color-accent);
 	--sl-color-text-invert: var(--sl-color-black);
-	--sl-color-bg-nav: var(--sl-color-gray-7);
+	--sl-color-bg-nav: var(--sl-color-bg);
 	--sl-color-bg-sidebar: var(--sl-color-bg);
 	--sl-color-bg-inline-code: var(--sl-color-gray-6);
 	--sl-color-bg-accent: var(--sl-color-accent);


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Related to https://github.com/withastro/starlight/discussions/1701

Again, building on HiDeoo's experience from the prototype, I made the header the same color as the background and then did the same for the sidebar in dark mode.

<details><summary>Screenshots</summary>

**Desktop (light)**

![image](https://github.com/user-attachments/assets/830177cb-db05-4848-b52b-c4163f97b2d7)

**Desktop (dark)**

![image](https://github.com/user-attachments/assets/a7d61de2-1fde-4bad-8661-80cab4ec4b6c)

**Mobile (light)**

<table><tr><td>

![image](https://github.com/user-attachments/assets/e93912f6-33db-4aa9-875d-00bca3b0e7b8)

</td><td>

![image](https://github.com/user-attachments/assets/688d0001-a9fe-44d6-afce-fc27e4c3b126)

</td><td>

![image](https://github.com/user-attachments/assets/4e322e81-2714-4662-9e6d-0770ad07f4a0)

</td></tr></table>

**Mobile (dark)**

<table><tr><td>

![image](https://github.com/user-attachments/assets/a7f0cef4-01db-4664-be97-7efa9dafef48)

</td><td>

![image](https://github.com/user-attachments/assets/0a6c874c-3586-42c7-bea5-3d122af6e6be)

</td><td>

![image](https://github.com/user-attachments/assets/54d066d7-12c2-495b-ac1c-31ccc8cf3be7)

</td></tr></table>

</details>

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
