### PR TITLE
Enlarge header icons

### DIFF
--- a/.changeset/rich-toys-drive.md
+++ b/.changeset/rich-toys-drive.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': minor
+---
+
+Enlarge header icons

--- a/packages/starlight/components/MobileMenuFooter.astro
+++ b/packages/starlight/components/MobileMenuFooter.astro
@@ -18,7 +18,6 @@ import type { Props } from '../props';
 		margin-inline-end: auto;
 		gap: 1rem;
 		align-items: center;
-		padding-block: 1rem;
 	}
 	.social-icons:empty {
 		display: none;

--- a/packages/starlight/components/Select.astro
+++ b/packages/starlight/components/Select.astro
@@ -29,7 +29,7 @@ interface Props {
 
 <style>
 	label {
-		--sl-label-icon-size: 0.875rem;
+		--sl-label-icon-size: 1.2rem;
 		--sl-caret-size: 1.25rem;
 		--sl-inline-padding: 0.5rem;
 		position: relative;
@@ -63,7 +63,7 @@ interface Props {
 	select {
 		border: 0;
 		padding-block: 0.625rem;
-		padding-inline: calc(var(--sl-label-icon-size) + var(--sl-inline-padding) + 0.25rem)
+		padding-inline: calc(var(--sl-label-icon-size) + var(--sl-inline-padding) + 0.5rem)
 			calc(var(--sl-caret-size) + var(--sl-inline-padding) + 0.25rem);
 		margin-inline: calc(var(--sl-inline-padding) * -1);
 		width: calc(var(--sl-select-width) + var(--sl-inline-padding) * 2);

--- a/packages/starlight/components/SocialIcons.astro
+++ b/packages/starlight/components/SocialIcons.astro
@@ -14,7 +14,7 @@ const links = Object.entries(config.social || {}) as [Platform, SocialConfig][];
 			{links.map(([platform, { label, url }]) => (
 				<a href={url} rel="me" class="sl-flex">
 					<span class="sr-only">{label}</span>
-					<Icon name={platform} />
+					<Icon name={platform} size="1.2em" />
 				</a>
 			))}
 		</>
@@ -24,9 +24,16 @@ const links = Object.entries(config.social || {}) as [Platform, SocialConfig][];
 <style>
 	a {
 		color: var(--sl-color-text-accent);
-		padding: 0.5em;
+		padding: 0.9em;
 		margin: -0.5em;
 	}
+
+	@media (min-width: 50rem) {
+		a {
+			padding: 0.8em;
+		}
+	}
+
 	a:hover {
 		opacity: 0.66;
 	}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Related to https://github.com/withastro/starlight/discussions/1701, but not explicitly proposed there. The original proposal suggests to increase the space between the social icons, but I believe the icons themselves should be larger too.

This PR changes the appearance of social icons and the icons in language/theme selects to be larger. It also increases the touch area of the social icons to align it with the touch area of selects (~44.5px on desktop, ~48px on mobile). Finally, it marginally increases the space between the icon and the label, just something that's been bugging me visually a little bit.

<details><summary>Screenshots</summary>

**Desktop (light)**

<table><tr><th>Before</th><th>After</th></tr><tr><td>
<img width="715" alt="Scherm­afbeelding 2024-12-07 om 19 22 40" src="https://github.com/user-attachments/assets/e7d27c81-31c4-4709-b6f4-bb1ef058600d">

</td><td>
<img width="715" alt="Scherm­afbeelding 2024-12-07 om 19 23 17" src="https://github.com/user-attachments/assets/86f7612e-ef97-4b22-a800-6886d2a65ab6">


</td></tr></table>

**Desktop (dark)**

<table><tr><th>Before</th><th>After</th></tr><tr><td>
<img width="715" alt="Scherm­afbeelding 2024-12-07 om 19 22 46" src="https://github.com/user-attachments/assets/b30b7b8c-899e-427c-b931-129e8582f01a">

</td><td>
<img width="715" alt="Scherm­afbeelding 2024-12-07 om 19 23 23" src="https://github.com/user-attachments/assets/21d12d63-be93-49f7-8d56-b2283cc7d319">


</td></tr></table>


**Mobile (light)**

<table><tr><th>Before</th><th>After</th></tr><tr><td>
<img width="430" alt="Scherm­afbeelding 2024-12-07 om 19 21 17" src="https://github.com/user-attachments/assets/394f171b-0635-4270-833f-e39bdce10f8f">
</td><td>
<img width="430" alt="Scherm­afbeelding 2024-12-07 om 19 16 59" src="https://github.com/user-attachments/assets/7dfeeb95-8fc7-4e0a-bf29-d3e7d05b5f2a">
</td></tr></table>


**Mobile (dark)**

<table><tr><th>Before</th><th>After</th></tr><tr><td>
<img width="430" alt="Scherm­afbeelding 2024-12-07 om 19 21 22" src="https://github.com/user-attachments/assets/80dba966-9e63-4f67-bd61-25281df9bdaa">
</td><td>
<img width="430" alt="Scherm­afbeelding 2024-12-07 om 19 17 12" src="https://github.com/user-attachments/assets/6e7c5455-1021-4a91-a8d5-5836a9bb0fd5">
</td></tr></table>


</details>

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
