### PR TITLE
Reduce the prominence of the selected sidebar item

### DIFF
--- a/.changeset/hot-geese-crash.md
+++ b/.changeset/hot-geese-crash.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': minor
+---
+
+Reduce the prominence of the selected sidebar item

--- a/packages/starlight/components/SidebarSublist.astro
+++ b/packages/starlight/components/SidebarSublist.astro
@@ -128,7 +128,17 @@ const { sublist, nested } = Astro.props;
 	[aria-current='page']:hover,
 	[aria-current='page']:focus {
 		font-weight: 600;
-		color: var(--sl-color-text-invert);
+		color: var(--sl-color-text-accent);
+		position: relative;
+	}
+
+	[aria-current='page']::before {
+		content: '';
+		position: absolute;
+		width: 0.15rem;
+		height: 100%;
+		top: 0;
+		left: calc(-1 * var(--sl-sidebar-item-padding-inline));
 		background-color: var(--sl-color-text-accent);
 	}
 

--- a/packages/starlight/user-components/Badge.astro
+++ b/packages/starlight/user-components/Badge.astro
@@ -61,6 +61,7 @@ const {
 		border: 1px solid var(--sl-color-border-badge);
 		border-radius: 0.25rem;
 		font-family: var(--sl-font-system-mono);
+		font-weight: normal;
 		line-height: normal;
 		color: var(--sl-color-text-badge);
 		background-color: var(--sl-color-bg-badge);
@@ -72,13 +73,6 @@ const {
 		line-height: 1;
 		font-size: var(--sl-text-xs);
 		padding: 0.125rem 0.375rem;
-	}
-
-	/* outline variant */
-	:global(.sidebar-content a[aria-current='page']) > .sl-badge {
-		--sl-color-bg-badge: transparent;
-		--sl-color-border-badge: currentColor;
-		color: inherit;
 	}
 
 	/* Color variants */


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Related to https://github.com/withastro/starlight/discussions/1701. There has been a comment expressing a concern about the accessibility of this redesign, but I'm not sure what exactly was the problem. However, I did find it helpful to increase the thickness of the highlight to make it visually stand out more. I tested without colors and still found it pretty easy to tell which entry is selected. However, I do not have any visual impairments, so my word should not be the last here.

This PR removes the bright background of a selected item in the left sidebar and replaces it with an accent text color and an accent line on the left.

<details><summary>Screenshots</summary>

Before, desktop:

<table>
<tr><th>Light</th><th>Dark</th><th>Dark without sidebar BG</th></tr>

<tr><td>
<img width="468" alt="Scherm­afbeelding 2024-12-07 om 22 53 06" src="https://github.com/user-attachments/assets/9260210b-510d-4ad2-b4f3-3c9aa623c462">
</td><td>
<img width="468" alt="Scherm­afbeelding 2024-12-07 om 22 53 22" src="https://github.com/user-attachments/assets/0ab1c3b4-2c84-4907-9095-992673aba02d">
</td><td>
<img width="468" alt="Scherm­afbeelding 2024-12-07 om 22 53 31" src="https://github.com/user-attachments/assets/7cbac768-5480-4769-bc82-9ad79330810f">
</td></tr>

<tr><td>
<img width="468" alt="Scherm­afbeelding 2024-12-07 om 22 53 39" src="https://github.com/user-attachments/assets/e5bf9f6c-0236-432b-855c-989be7eb23c6">
</td><td>
<img width="468" alt="Scherm­afbeelding 2024-12-07 om 22 54 09" src="https://github.com/user-attachments/assets/936b12f5-6ade-42d4-8dfe-9aa84792633a">
</td><td>
<img width="468" alt="Scherm­afbeelding 2024-12-07 om 22 53 58" src="https://github.com/user-attachments/assets/aa465407-ce83-4f67-8390-dc3c80c3a192">
</td></tr>
</table>

After, desktop:

<table>
<tr><th>Light</th><th>Dark</th><th>Dark without sidebar BG</th></tr>
<tr><td>
<img width="468" alt="Scherm­afbeelding 2024-12-07 om 22 50 13" src="https://github.com/user-attachments/assets/40be7e38-425a-4af9-a66f-5155b4417229">
</td><td>
<img width="468" alt="Scherm­afbeelding 2024-12-07 om 22 50 25" src="https://github.com/user-attachments/assets/76378fb5-f6fc-48d3-9357-fe099768a393">
</td><td>
<img width="468" alt="Scherm­afbeelding 2024-12-07 om 22 50 55" src="https://github.com/user-attachments/assets/f012e2bc-54b8-4144-9189-d1bd1fc90a9c">
</td></tr>

<tr><td>
<img width="468" alt="Scherm­afbeelding 2024-12-07 om 22 51 13" src="https://github.com/user-attachments/assets/9ddd87bf-8123-40ec-abfb-b12bf80a1ce5">
</td><td>
<img width="468" alt="Scherm­afbeelding 2024-12-07 om 22 51 34" src="https://github.com/user-attachments/assets/63983e6f-7310-4e6c-a9a5-0c79b609e765">
</td><td>
<img width="468" alt="Scherm­afbeelding 2024-12-07 om 22 51 42" src="https://github.com/user-attachments/assets/20e1fa78-0bb9-4177-8468-99eb50105764">
</td></tr>
</table>

Mobile (dark version is identical to desktop):

<table>
<tr><td>
<img width="429" alt="Scherm­afbeelding 2024-12-07 om 22 55 02" src="https://github.com/user-attachments/assets/dba57344-9dd6-4248-a0e4-ce58f222248c">
</td><td>
<img width="429" alt="Scherm­afbeelding 2024-12-07 om 22 55 25" src="https://github.com/user-attachments/assets/00a70785-1151-44e7-841a-fa7a6ba48f36">
</td></tr></table>

</details>

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
