### PR TITLE
Publish provenance for public packages

### DIFF
--- a/.changeset/sweet-poems-smoke.md
+++ b/.changeset/sweet-poems-smoke.md
@@ -1,0 +1,8 @@
+---
+'@astrojs/starlight-docsearch': patch
+'@astrojs/starlight': patch
+'@astrojs/starlight-tailwind': patch
+'@astrojs/starlight-markdoc': patch
+---
+
+Publishes provenance containing verifiable data to link a package back to its source repository and the specific build instructions used to publish it.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
     name: Release
     if: ${{ github.repository_owner == 'withastro' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/packages/docsearch/package.json
+++ b/packages/docsearch/package.json
@@ -33,5 +33,8 @@
   },
   "devDependencies": {
     "@astrojs/starlight": "workspace:*"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/markdoc/package.json
+++ b/packages/markdoc/package.json
@@ -24,5 +24,8 @@
   "peerDependencies": {
     "@astrojs/markdoc": "^0.11.4",
     "@astrojs/starlight": ">=0.23.0"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/starlight/package.json
+++ b/packages/starlight/package.json
@@ -212,5 +212,8 @@
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0",
     "vfile": "^6.0.2"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -32,5 +32,8 @@
     "@astrojs/starlight": ">=0.9.0",
     "@astrojs/tailwind": "^5.0.0",
     "tailwindcss": "^3.3.3"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }


### PR DESCRIPTION
#### Description

While working in a workflow that involves strict security requirements, I noticed that Starlight public packages do not include any [provenance](https://github.blog/security/supply-chain-security/introducing-npm-package-provenance/). This PR fixes that by adding a `publishConfig` block to public packages.

- [Astro PR](https://github.com/withastro/astro/pull/8737) doing the same 
- [Astro PR](https://github.com/withastro/astro/pull/8749) fixing permissions forgotten in the first PR

