### PR TITLE
feat(header): enhance frosted glass effect on landing page #2686

### DIFF
--- a/docs/src/assets/landing.css
+++ b/docs/src/assets/landing.css
@@ -18,8 +18,14 @@
 [data-has-hero] header {
 	border-bottom: 1px solid transparent;
 	background-color: transparent;
-	-webkit-backdrop-filter: blur(16px);
+}
+
+[data-has-hero] .header-backdrop {
 	backdrop-filter: blur(16px);
+	-webkit-backdrop-filter: blur(16px);
+	mask-image: linear-gradient(to bottom, black 0% 50%, transparent 50% 100%);
+	-webkit-mask-image: linear-gradient(to bottom, black 0% 50%, transparent 50% 100%);
+	z-index: -1;
 }
 
 [data-has-hero] .hero > img {

--- a/packages/starlight/components/Header.astro
+++ b/packages/starlight/components/Header.astro
@@ -29,6 +29,7 @@ const shouldRenderSearch =
 		<ThemeSelect {...Astro.props} />
 		<LanguageSelect {...Astro.props} />
 	</div>
+	<div class="header-backdrop"></div>
 </div>
 
 <style>
@@ -37,6 +38,13 @@ const shouldRenderSearch =
 		justify-content: space-between;
 		align-items: center;
 		height: 100%;
+	}
+
+	.header-backdrop {
+		position: absolute;
+		inset: 0;
+		block-size: 200%;
+		inline-size: 100%;
 	}
 
 	.title-wrapper {


### PR DESCRIPTION
Add gradient mask to header backdrop for a more realistic frosted glass effect that fades towards the bottom.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #2686 (discussion)
- Enhances the frosted glass effect on the landing page header by:
-- Adding a gradient mask to the backdrop
-- Making the effect fade out towards the bottom
-- Keeping the effect scoped to landing page only
-- Based on and credits to: https://www.joshwcomeau.com/css/backdrop-filter/

This creates a more natural and modern look while maintaining good performance.

Before:
<img width="812" alt="Scherm­afbeelding 2024-12-14 om 10 19 32" src="https://github.com/user-attachments/assets/fed103ff-f5bb-4c60-8806-39476d268174" />

After:
<img width="812" alt="Scherm­afbeelding 2024-12-14 om 10 19 38" src="https://github.com/user-attachments/assets/d561da4f-411f-4569-8f7f-62db1548ec1a" />

Before:
<img width="812" alt="Scherm­afbeelding 2024-12-14 om 10 20 42" src="https://github.com/user-attachments/assets/d90e21af-3111-43fd-9cda-2e12248392e4" />

After:
<img width="812" alt="Scherm­afbeelding 2024-12-14 om 10 20 58" src="https://github.com/user-attachments/assets/284fec40-ce05-4e5d-b768-92639577e088" />

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
