### PR TITLE
Fix site title focus ring

### DIFF
--- a/.changeset/wicked-insects-refuse.md
+++ b/.changeset/wicked-insects-refuse.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes display of focus indicator around site title

--- a/packages/starlight/components/Header.astro
+++ b/packages/starlight/components/Header.astro
@@ -41,7 +41,10 @@ const shouldRenderSearch =
 
 	.title-wrapper {
 		/* Prevent long titles overflowing and covering the search and menu buttons on narrow viewports. */
-		overflow: hidden;
+		overflow: clip;
+		/* Avoid clipping focus ring around link inside title wrapper. */
+		padding: 0.25rem;
+		margin: -0.25rem;
 	}
 
 	.right-group,


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #2696 
- Adds space inside the title wrapper element to avoid clipping the site title focus indicator

Example in Firefox (macOS):

| Before | After |
|---|---|
| ![Starlight site title with only one edge of the focus ring visible](https://github.com/user-attachments/assets/23012f55-527a-4ec1-b264-b93b55ee643a) | ![Starlight site title with focus ring fully visible](https://github.com/user-attachments/assets/760b612a-6d04-4ba3-89ce-361d3d2568fe) |


<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
