### PR TITLE
i18n(fr): update links in various pages

### DIFF
--- a/docs/src/content/docs/fr/components/using-components.mdx
+++ b/docs/src/content/docs/fr/components/using-components.mdx
@@ -9,7 +9,7 @@ Les composants vous permettent de réutiliser facilement un élément d'interfac
 Il peut s'agir par exemple d'une carte de liaison ou d'une intégration YouTube.
 Starlight prend en charge l'utilisation de composants dans les fichiers [MDX](https://mdxjs.com/) et [Markdoc](https://markdoc.dev/) et fournit des composants courants que vous pouvez utiliser.
 
-[Pour en savoir plus sur la création de composants, consultez la documentation d'Astro](https://docs.astro.build/fr/core-concepts/astro-components/).
+[Pour en savoir plus sur la création de composants, consultez la documentation d'Astro](https://docs.astro.build/fr/basics/astro-components/).
 
 ## Utilisation d'un composant avec MDX
 

--- a/docs/src/content/docs/fr/environmental-impact.md
+++ b/docs/src/content/docs/fr/environmental-impact.md
@@ -137,6 +137,6 @@ Ces tests avec le [Website Carbon Calculator][wcc] comparent des pages similaire
 [sf]: https://www.sciencefocus.com/science/what-is-the-carbon-footprint-of-the-internet/
 [bbc]: https://www.bbc.com/future/article/20200305-why-your-internet-habits-are-not-as-clean-as-you-think
 [http]: https://httparchive.org/reports/state-of-the-web
-[assets]: https://docs.astro.build/en/guides/assets/
-[islands]: https://docs.astro.build/en/concepts/islands/
+[assets]: https://docs.astro.build/fr/guides/images/
+[islands]: https://docs.astro.build/fr/concepts/islands/
 [wcc]: https://www.websitecarbon.com/

--- a/docs/src/content/docs/fr/guides/authoring-content.mdx
+++ b/docs/src/content/docs/fr/guides/authoring-content.mdx
@@ -45,7 +45,7 @@ Vous pouvez mettre en évidence le `code en ligne` à l'aide de barres de défil
 
 ## Images
 
-Les images dans Starlight utilisent [la prise en charge intégrée des ressources optimisées d'Astro](https://docs.astro.build/en/guides/assets/).
+Les images dans Starlight utilisent [la prise en charge intégrée des ressources optimisées d'Astro](https://docs.astro.build/fr/guides/images/).
 
 Markdown et MDX supportent la syntaxe Markdown pour l'affichage des images qui inclut le texte alt pour les lecteurs d'écran et les technologies d'assistance.
 

--- a/docs/src/content/docs/fr/guides/overriding-components.mdx
+++ b/docs/src/content/docs/fr/guides/overriding-components.mdx
@@ -84,7 +84,7 @@ import Default from '@astrojs/starlight/components/SocialIcons.astro';
 Lorsque vous affichez un composant intégré dans un composant personnalisé :
 
 - Décomposez `Astro.props` dans celui-ci. Cela permet de s'assurer qu'il reçoit toutes les données dont il a besoin pour être affiché.
-- Ajoutez un élément [`<slot />`](https://docs.astro.build/fr/core-concepts/astro-components/#les-emplacements-slots) à l'intérieur du composant par défaut. Cela permet de s'assurer que si le composant reçoit des éléments enfants, Astro sait où les afficher.
+- Ajoutez un élément [`<slot />`](https://docs.astro.build/fr/basics/astro-components/#les-emplacements-slots) à l'intérieur du composant par défaut. Cela permet de s'assurer que si le composant reçoit des éléments enfants, Astro sait où les afficher.
 
 Si vous réutilisez les composants [`PageFrame`](/fr/reference/overrides/#pageframe) ou [`TwoColumnContent`](/fr/reference/overrides/#twocolumncontent) qui contiennent des [emplacements (slots) nommés](https://docs.astro.build/fr/basics/astro-components/#les-emplacements-slots-nomm%C3%A9s), vous devez également [transférer](https://docs.astro.build/fr/basics/astro-components/#transf%C3%A9rer-les-emplacements) ces emplacements.
 
@@ -141,7 +141,7 @@ Dans l'exemple suivant, un composant redéfinissant le composant [`Footer`](/fr/
 import type { Props } from '@astrojs/starlight/props';
 import Default from '@astrojs/starlight/components/Footer.astro';
 
-const isHomepage = Astro.props.slug === '';
+const isHomepage = Astro.props.id === '';
 ---
 
 {
@@ -155,4 +155,4 @@ const isHomepage = Astro.props.slug === '';
 }
 ```
 
-Pour en savoir plus sur le rendu conditionnel, consultez le [guide de syntaxe d'Astro](https://docs.astro.build/fr/core-concepts/astro-syntax/#html-dynamique).
+Pour en savoir plus sur le rendu conditionnel, consultez le [guide de syntaxe d'Astro](https://docs.astro.build/fr/basics/astro-syntax/#html-dynamique).

--- a/docs/src/content/docs/fr/reference/configuration.mdx
+++ b/docs/src/content/docs/fr/reference/configuration.mdx
@@ -462,7 +462,7 @@ Pagefind ne peut pas être activé lorsque l'option [`prerender`](#prerender) es
 **Type :** `boolean`  
 **Par défaut :** `true`
 
-Définit si les pages générées par Starlight doivent être pré-rendues en HTML statique ou rendues à la demande par un [adaptateur SSR](https://docs.astro.build/fr/guides/server-side-rendering/).
+Définit si les pages générées par Starlight doivent être pré-rendues en HTML statique ou rendues à la demande par un [adaptateur SSR](https://docs.astro.build/fr/guides/on-demand-rendering/).
 
 Les pages Starlight sont pré-rendues par défaut.
 Si vous utilisez un adaptateur SSR et que vous souhaitez générer les pages Starlight à la demande, définissez `prerender: false`.
@@ -568,7 +568,7 @@ Par example, cette page a pour titre « Référence de configuration » et ce si
 **Type :** `boolean`  
 **Par défaut :** `false`
 
-Désactive l'injection de la [page 404](https://docs.astro.build/fr/core-concepts/astro-pages/#page-derreur-404-personnalis%C3%A9e) par défaut de Starlight. Pour utiliser une route personnalisée `src/pages/404.astro` dans votre projet, définissez cette option à `true`.
+Désactive l'injection de la [page 404](https://docs.astro.build/fr/basics/astro-pages/#page-derreur-404-personnalis%C3%A9e) par défaut de Starlight. Pour utiliser une route personnalisée `src/pages/404.astro` dans votre projet, définissez cette option à `true`.
 
 ### `components`
 


### PR DESCRIPTION
#### Description

This PR updates mostly links in the French version of the following pages with the changes from #2612 & #2685:

- `components/using-components`
- `environmental-impact`
- `guides/authoring-content`
- `reference/configuration`
- `guides/overriding-components`