### PR TITLE
i18n(fr): update various content layer related pages

### DIFF
--- a/docs/src/content/docs/fr/guides/i18n.mdx
+++ b/docs/src/content/docs/fr/guides/i18n.mdx
@@ -188,16 +188,17 @@ Vous pouvez fournir des traductions pour les langues supplémentaires que vous s
 
 <Steps>
 
-1. Configurez la collection de contenus `i18n` dans `src/content/config.ts` si elle n'est pas déjà configurée :
+1. Configurez la collection de contenus `i18n` dans `src/content.config.ts` si elle n'est pas déjà configurée :
 
-   ```diff lang="js" ins=/, (i18nSchema)/
-   // src/content/config.ts
+   ```diff lang="js" ins=/, (i18nLoader|i18nSchema)/
+   // src/content.config.ts
    import { defineCollection } from 'astro:content';
+   import { docsLoader, i18nLoader } from '@astrojs/starlight/loaders';
    import { docsSchema, i18nSchema } from '@astrojs/starlight/schema';
 
    export const collections = {
-   	docs: defineCollection({ schema: docsSchema() }),
-   +	i18n: defineCollection({ type: 'data', schema: i18nSchema() }),
+   	docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+   +	i18n: defineCollection({ loader: i18nLoader(), schema: i18nSchema() }),
    };
    ```
 
@@ -257,14 +258,15 @@ Ajoutez des clés personnalisées aux dictionnaires de traduction de votre site 
 Dans l'exemple suivant, une nouvelle clé optionnelle `custom.label` est ajoutée aux clés par défaut :
 
 ```diff lang="js"
-// src/content/config.ts
+// src/content.config.ts
 import { defineCollection, z } from 'astro:content';
+import { docsLoader, i18nLoader } from '@astrojs/starlight/loaders';
 import { docsSchema, i18nSchema } from '@astrojs/starlight/schema';
 
 export const collections = {
-	docs: defineCollection({ schema: docsSchema() }),
+	docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
 	i18n: defineCollection({
-		type: 'data',
+		loader: i18nLoader(),
 		schema: i18nSchema({
 +			extend: z.object({
 +				'custom.label': z.string().optional(),
@@ -274,7 +276,7 @@ export const collections = {
 };
 ```
 
-Consultez [« Définir un schéma de collection de contenus »](https://docs.astro.build/fr/guides/content-collections/#defining-a-collection-schema) dans la documentation d'Astro pour en savoir plus sur les schémas de collection de contenus.
+Consultez [« Définir un schéma de collection de contenus »](https://docs.astro.build/fr/guides/content-collections/#définition-dun-schéma-de-collection) dans la documentation d'Astro pour en savoir plus sur les schémas de collection de contenus.
 
 ## Utiliser les traductions de l'interface utilisateur
 

--- a/docs/src/content/docs/fr/guides/project-structure.mdx
+++ b/docs/src/content/docs/fr/guides/project-structure.mdx
@@ -5,12 +5,12 @@ description: Apprenez à organiser les fichiers dans votre projet Starlight.
 
 Ce guide vous montrera comment un projet Starlight est organisé et ce que font les différents fichiers de votre projet.
 
-Les projets Starlight suivent généralement la même structure de fichiers et de répertoires que les autres projets Astro. Voir [la documentation sur la structure des projets Astro](https://docs.astro.build/fr/core-concepts/project-structure/) pour plus de détails.
+Les projets Starlight suivent généralement la même structure de fichiers et de répertoires que les autres projets Astro. Voir [la documentation sur la structure des projets Astro](https://docs.astro.build/fr/basics/project-structure/) pour plus de détails.
 
 ## Fichiers et répertoires
 
 - `astro.config.mjs` — Le fichier de configuration d'Astro ; inclut l'intégration et la configuration de Starlight.
-- `src/content/config.ts` — Fichier de configuration des collections de contenu ; ajoute les schémas de la matière première de Starlight à votre projet.
+- `src/content.config.ts` — Fichier de configuration des collections de contenu ; ajoute les schémas de la matière première de Starlight à votre projet.
 - `src/content/docs/` — Fichiers de contenu. Starlight transforme chaque fichier `.md`, `.mdx` ou `.mdoc` de ce répertoire en une page de votre site.
 - `src/content/i18n/` (optionnel) — Données de traduction pour prendre en charge l'[internationalisation](/fr/guides/i18n/).
 - `src/` — Autre code source et fichiers (composants, styles, images, etc.) pour votre projet.
@@ -39,8 +39,7 @@ import { FileTree } from '@astrojs/starlight/components';
         - 01-getting-started.md
         - 02-advanced.md
       - index.mdx
-    - config.ts
-  - env.d.ts
+  - content.config.ts
 - astro.config.mjs
 - package.json
 - tsconfig.json

--- a/docs/src/content/docs/fr/guides/site-search.mdx
+++ b/docs/src/content/docs/fr/guides/site-search.mdx
@@ -126,16 +126,17 @@ Ajoutez des traductions de l'interface utilisateur de la modale pour votre langu
 
 1. Étendez la définition de la collection de contenus `i18n` de Starlight avec le schéma DocSearch dans `src/content/config.ts` :
 
-   ```js ins={4} ins=/{ extend: .+ }/
-   // src/content/config.ts
+   ```js ins={5} ins=/{ extend: .+ }/
+   // src/content.config.ts
    import { defineCollection } from 'astro:content';
+   import { docsLoader, i18nLoader } from '@astrojs/starlight/loaders';
    import { docsSchema, i18nSchema } from '@astrojs/starlight/schema';
    import { docSearchI18nSchema } from '@astrojs/starlight-docsearch/schema';
 
    export const collections = {
-   	docs: defineCollection({ schema: docsSchema() }),
+   	docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
    	i18n: defineCollection({
-   		type: 'data',
+   		loader: i18nLoader(),
    		schema: i18nSchema({ extend: docSearchI18nSchema() }),
    	}),
    };

--- a/docs/src/content/docs/fr/manual-setup.mdx
+++ b/docs/src/content/docs/fr/manual-setup.mdx
@@ -62,19 +62,23 @@ Retrouvez toutes les options disponibles dans la [référence de configuration S
 
 ### Configurer les collections de contenu
 
-Starlight s'appuie sur les [collections de contenu d'Astro](https://docs.astro.build/fr/guides/content-collections/), qui sont configurées dans le fichier `src/content/config.ts`.
+Starlight s'appuie sur les [collections de contenu d'Astro](https://docs.astro.build/fr/guides/content-collections/), qui sont configurées dans le fichier `src/content.config.ts`.
 
-Créez ou mettez à jour le fichier de configuration du contenu, en ajoutant une collection `docs` qui utilise le schéma `docsSchema` de Starlight :
+Créez ou mettez à jour le fichier de configuration du contenu, en ajoutant une collection `docs` qui utilise les `docsLoader` et `docsSchema` de Starlight :
 
-```js ins={3,6}
-// src/content/config.ts
+```js ins={3-4,7}
+// src/content.config.ts
 import { defineCollection } from 'astro:content';
+import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
 
 export const collections = {
-	docs: defineCollection({ schema: docsSchema() }),
+	docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
 };
 ```
+
+Starlight supporte également [l'drapeau `legacy.collections`](https://docs.astro.build/fr/reference/legacy-flags/) où les collections sont gérées en utilisant l'implémentation de collections de contenu héritée.
+Celà est utile si vous avez un projet Astro existant et que vous ne pouvez pas apporter de modifications aux collections pour utiliser un chargeur.
 
 ### Ajouter du contenu
 
@@ -125,6 +129,6 @@ import { FileTree } from '@astrojs/starlight/components';
 
 ### Utiliser Starlight avec SSR
 
-Pour activer le SSR, suivez le guide [« Adaptateurs de rendu à la demande »](https://docs.astro.build/fr/guides/server-side-rendering/) dans la documentation d'Astro pour ajouter un adaptateur serveur à votre projet Starlight.
+Pour activer le SSR, suivez le guide [« Adaptateurs de rendu à la demande »](https://docs.astro.build/fr/guides/on-demand-rendering/) dans la documentation d'Astro pour ajouter un adaptateur serveur à votre projet Starlight.
 
 Les pages de documentation générées par Starlight sont pré-rendues par défaut, quel que soit le mode de rendu de votre projet. Pour désactiver le pré-rendu de vos pages Starlight, définissez [l'option de configuration `prerender`](/fr/reference/configuration/#prerender) à `false`.

--- a/docs/src/content/docs/fr/manual-setup.mdx
+++ b/docs/src/content/docs/fr/manual-setup.mdx
@@ -77,7 +77,7 @@ export const collections = {
 };
 ```
 
-Starlight supporte également [l'drapeau `legacy.collections`](https://docs.astro.build/fr/reference/legacy-flags/) où les collections sont gérées en utilisant l'implémentation de collections de contenu héritée.
+Starlight supporte également [l'option `legacy.collections`](https://docs.astro.build/fr/reference/legacy-flags/) où les collections sont gérées en utilisant l'implémentation de collections de contenu héritée.
 Celà est utile si vous avez un projet Astro existant et que vous ne pouvez pas apporter de modifications aux collections pour utiliser un chargeur.
 
 ### Ajouter du contenu

--- a/docs/src/content/docs/fr/reference/frontmatter.md
+++ b/docs/src/content/docs/fr/reference/frontmatter.md
@@ -33,7 +33,7 @@ La description de la page est utilisée pour les métadonnées de la page et ser
 
 **type**: `string`
 
-Remplace le slug de la page. Consultez [« Définition d’un slug personnalisé »](https://docs.astro.build/fr/guides/content-collections/#d%C3%A9finition-dun-slug-personnalis%C3%A9e) dans la documentation d'Astro pour plus de détails.
+Remplace le slug de la page. Consultez [« Définition d’identifiants personnalisés »](https://docs.astro.build/fr/guides/content-collections/#définition-didentifiants-personnalisés) dans la documentation d'Astro pour plus de détails.
 
 ### `editUrl`
 
@@ -397,19 +397,20 @@ sidebar:
 
 ## Personnaliser le schéma du frontmatter
 
-Le schéma du frontmatter de la collection de contenus `docs` de Starlight est configuré dans `src/content/config.ts` en utilisant l'utilitaire `docsSchema()` :
+Le schéma du frontmatter de la collection de contenus `docs` de Starlight est configuré dans `src/content.config.ts` en utilisant l'utilitaire `docsSchema()` :
 
-```ts {3,6}
-// src/content/config.ts
+```ts {4,7}
+// src/content.config.ts
 import { defineCollection } from 'astro:content';
+import { docsLoader, i18nLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
 
 export const collections = {
-  docs: defineCollection({ schema: docsSchema() }),
+  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
 };
 ```
 
-Consultez [« Définir un schéma de collection de contenus »](https://docs.astro.build/fr/guides/content-collections/#defining-a-collection-schema) dans la documentation d'Astro pour en savoir plus sur les schémas de collection de contenus.
+Consultez [« Définir un schéma de collection de contenus »](https://docs.astro.build/fr/guides/content-collections/#définition-dun-schéma-de-collection) dans la documentation d'Astro pour en savoir plus sur les schémas de collection de contenus.
 
 `docsSchema()` accepte les options suivantes :
 
@@ -423,13 +424,15 @@ La valeur doit être un [schéma Zod](https://docs.astro.build/fr/guides/content
 
 Dans l'exemple suivant, nous définissons un type plus strict pour `description` pour le rendre obligatoire et ajouter un nouveau champ `category` facultatif :
 
-```ts {8-13}
-// src/content/config.ts
+```ts {10-15}
+// src/content.config.ts
 import { defineCollection, z } from 'astro:content';
+import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
 
 export const collections = {
   docs: defineCollection({
+    loader: docsLoader(),
     schema: docsSchema({
       extend: z.object({
         // Rend un champ de base obligatoire au lieu de facultatif.
@@ -444,13 +447,15 @@ export const collections = {
 
 Pour tirer parti de l'[utilitaire `image()` d'Astro](https://docs.astro.build/fr/guides/images/#images-in-content-collections), utilisez une fonction qui retourne votre extension de schéma :
 
-```ts {8-13}
-// src/content/config.ts
+```ts {10-15}
+// src/content.config.ts
 import { defineCollection, z } from 'astro:content';
+import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
 
 export const collections = {
   docs: defineCollection({
+    loader: docsLoader(),
     schema: docsSchema({
       extend: ({ image }) => {
         return z.object({

--- a/docs/src/content/docs/fr/reference/overrides.md
+++ b/docs/src/content/docs/fr/reference/overrides.md
@@ -69,11 +69,14 @@ Pour les sites multilingues, cette valeur inclura la locale actuelle, par exempl
 
 Le slug de la page généré à partir du nom du fichier du contenu.
 
+Cette propriété est dépréciée et sera supprimée dans une version future de Starlight.
+Migrez vers la nouvelle API Content Layer en utilisant le [`docsLoader` de Starlight](/fr/manual-setup/#configurer-les-collections-de-contenu) et utilisez la propriété [`id`](#id) à la place.
+
 #### `id`
 
 **Type :** `string`
 
-L'identifiant unique de cette page basé sur le nom du fichier du contenu.
+Le slug de cette page ou l'identifiant unique de cette page basé sur le nom du fichier du contenu si l'option [`legacy.collections`](https://docs.astro.build/fr/reference/legacy-flags/#collections) est utilisée.
 
 #### `isFallback`
 


### PR DESCRIPTION
#### Description

This PR updates the French version of the following pages with the changes from #2707, #2676, and #2612 which are all Content Layer related to I decided to group them together in one PR:

- `guides/i18n`
- `guides/project-structure`
- `guides/site-search`
- `manual-setup`
- `reference/frontmatter`
- `reference/overrides`