### PR TITLE
Avoid clipping focus indicator around site title

### DIFF
--- a/.changeset/five-radios-laugh.md
+++ b/.changeset/five-radios-laugh.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes display of focus indicator around site title

--- a/packages/starlight/components/Header.astro
+++ b/packages/starlight/components/Header.astro
@@ -39,14 +39,6 @@ const shouldRenderSearch =
 		height: 100%;
 	}
 
-	.title-wrapper {
-		/* Prevent long titles overflowing and covering the search and menu buttons on narrow viewports. */
-		overflow: clip;
-		/* Avoid clipping focus ring around link inside title wrapper. */
-		padding: 0.25rem;
-		margin: -0.25rem;
-	}
-
 	.right-group,
 	.social-icons {
 		gap: 1rem;

--- a/packages/starlight/components/SiteTitle.astro
+++ b/packages/starlight/components/SiteTitle.astro
@@ -29,7 +29,7 @@ const { siteTitle, siteTitleHref } = Astro.props;
 			</>
 		)
 	}
-	<span class:list={{ 'sr-only': config.logo?.replacesTitle }}>
+	<span class:list={[{ 'sr-only': config.logo?.replacesTitle }, 'site-title-text']}>
 		{siteTitle}
 	</span>
 </a>
@@ -43,6 +43,12 @@ const { siteTitle, siteTitleHref } = Astro.props;
 		color: var(--sl-color-text-accent);
 		text-decoration: none;
 		white-space: nowrap;
+		min-width: 0;
+	}
+	.site-title-text {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		text-wrap: nowrap;
 	}
 	img {
 		height: calc(var(--sl-nav-height) - 2 * var(--sl-nav-pad-y));


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #2696
- What does this PR change? #2704 improved the cosmetic of focus ring in site title, however there were a couple of remaining issues as described [here](https://github.com/withastro/starlight/pull/2704#issuecomment-2546736076).  This PR eliminates the `overflow: hidden` and applies `min-width` to ensure the `title-wrapper` is constrained to available space by flexbox.  Additionally, it styles the title text (if its displayed) with elipses providing an improved UI so that text is no longer abruptly cut-off but rather gives an indication that there is more text that just isn't visible.  If a logo is present, it will be automatically scaled and therefore doesn't require a container with `overflow: hidden`.  Tested in Edge, Chrome & Firefox.
- Did you change something visual? A before/after screenshot can be helpful.

With a forced outline of `10px solid green`:

Before:
![image](https://github.com/user-attachments/assets/cc61bcce-d6f2-408a-9052-9c9a0b2f831b)

After:
![image](https://github.com/user-attachments/assets/66c6e51c-6098-418b-be57-b230677293f7)

> [!IMPORTANT]
> In performing testing on this PR, I identified other issues related to the way the header is displayed with large images and/or long text.  ~~Will create a separate issue to track those.~~ Created #2715.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
