### PR TITLE
Fix list item spacing bug on Firefox

### DIFF
--- a/.changeset/proud-apricots-warn.md
+++ b/.changeset/proud-apricots-warn.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes a list item spacing issue where line break elements (`<br>`) could receive a margin, breaking layout in Firefox

--- a/packages/starlight/style/markdown.css
+++ b/packages/starlight/style/markdown.css
@@ -24,7 +24,7 @@
 
 .sl-markdown-content
 	li
-	> :last-child:not(li, ul, ol):not(a, strong, em, del, span, input, :where(.not-content *)) {
+	> :last-child:not(li, ul, ol, a, strong, em, del, span, input, code, br, :where(.not-content *)) {
 	margin-bottom: 1.25rem;
 }
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Firefox renders margins applied to `<br>` unlike other browsers.

- We had a style which unintentionally applied `margin-bottom` to `<br>` inside list items, which would cause odd spacing in lists only in Firefox. For example, in the [Astro docs](https://docs.astro.build/en/reference/error-reference/):

   ![unordered list with irregular spacing of items](https://github.com/user-attachments/assets/a6771f11-10cb-4ad7-ad40-9aaf98e57773)

- This PR fixes this by excluding `<br>` from that style, and also adds `<code>` to avoid the same issue impacting list items with a last child that is an inline code element.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
