### PR TITLE
Enable last-updated times in Starlight docs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -41,6 +41,7 @@ export default defineConfig({
 				dark: '/src/assets/logo-dark.svg',
 				replacesTitle: true,
 			},
+			lastUpdated: true,
 			editLink: {
 				baseUrl: 'https://github.com/withastro/starlight/edit/main/docs/',
 			},


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Enables git-based last-updated times in the Starlight docs site
- We used to have this enabled and disabled it when migrating to Vercel due to Git issues they have. But now we’re back on Netlify I think it’s helpful to enable this as an extra check that the feature is working as expected.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
