### PR TITLE
Add farcaster to social links

### DIFF
--- a/.changeset/real-pugs-fold.md
+++ b/.changeset/real-pugs-fold.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Adds social link support for Farcaster

--- a/packages/starlight/__tests__/basics/config-errors.test.ts
+++ b/packages/starlight/__tests__/basics/config-errors.test.ts
@@ -114,7 +114,7 @@ test('errors with bad social icon config', () => {
 		"[AstroUserError]:
 			Invalid config passed to starlight integration
 		Hint:
-			**social.unknown**: Invalid enum value. Expected 'twitter' | 'mastodon' | 'github' | 'gitlab' | 'bitbucket' | 'discord' | 'gitter' | 'codeberg' | 'codePen' | 'youtube' | 'threads' | 'linkedin' | 'twitch' | 'azureDevOps' | 'microsoftTeams' | 'instagram' | 'stackOverflow' | 'x.com' | 'telegram' | 'rss' | 'facebook' | 'email' | 'reddit' | 'patreon' | 'signal' | 'slack' | 'matrix' | 'openCollective' | 'hackerOne' | 'blueSky' | 'discourse' | 'zulip' | 'pinterest' | 'tiktok' | 'nostr' | 'backstage', received 'unknown'
+			**social.unknown**: Invalid enum value. Expected 'twitter' | 'mastodon' | 'github' | 'gitlab' | 'bitbucket' | 'discord' | 'gitter' | 'codeberg' | 'codePen' | 'youtube' | 'threads' | 'linkedin' | 'twitch' | 'azureDevOps' | 'microsoftTeams' | 'instagram' | 'stackOverflow' | 'x.com' | 'telegram' | 'rss' | 'facebook' | 'email' | 'reddit' | 'patreon' | 'signal' | 'slack' | 'matrix' | 'openCollective' | 'hackerOne' | 'blueSky' | 'discourse' | 'zulip' | 'pinterest' | 'tiktok' | 'nostr' | 'backstage' | 'farcaster', received 'unknown'
 			**social.unknown**: Invalid url"
 	`
 	);

--- a/packages/starlight/schemas/social.ts
+++ b/packages/starlight/schemas/social.ts
@@ -37,6 +37,7 @@ export const socialLinks = [
 	'tiktok',
 	'nostr',
 	'backstage',
+	'farcaster',
 ] as const;
 
 export const SocialLinksSchema = () =>
@@ -89,6 +90,7 @@ export const SocialLinksSchema = () =>
 					tiktok: 'TikTok',
 					nostr: 'Nostr',
 					backstage: 'Backstage',
+					farcaster: 'Farcaster',
 				}[key];
 				labelledLinks[key] = { label, url };
 			}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

This PR should allow `'farcaster'` to be used as an option in the social icons schema. This is so that starlight users can add a social link to their farcaster site (eg. warpcast) like so:

```javascript
social: {
    ...
    farcaster: 'https://warpcast.com/@someone`
}
```

Do I need to add a changeset..?