### PR TITLE
Fix pagefind data attribute

### DIFF
--- a/.changeset/olive-hairs-battle.md
+++ b/.changeset/olive-hairs-battle.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes an issue preventing Pagefind to be disabled using the `pagefind` frontmatter field.

--- a/packages/starlight/components/Page.astro
+++ b/packages/starlight/components/Page.astro
@@ -36,13 +36,16 @@ const pagefindEnabled =
 	!Astro.props.entry.slug.endsWith('/404') &&
 	Astro.props.entry.data.pagefind !== false;
 
-const dataAttributes: DOMStringMap = { 'data-theme': 'dark' };
-if (Boolean(Astro.props.toc)) dataAttributes['data-has-toc'] = '';
-if (Astro.props.hasSidebar) dataAttributes['data-has-sidebar'] = '';
-if (Boolean(Astro.props.entry.data.hero)) dataAttributes['data-has-hero'] = '';
+const htmlDataAttributes: DOMStringMap = { 'data-theme': 'dark' };
+if (Boolean(Astro.props.toc)) htmlDataAttributes['data-has-toc'] = '';
+if (Astro.props.hasSidebar) htmlDataAttributes['data-has-sidebar'] = '';
+if (Boolean(Astro.props.entry.data.hero)) htmlDataAttributes['data-has-hero'] = '';
+
+const mainDataAttributes: DOMStringMap = {};
+if (pagefindEnabled) mainDataAttributes['data-pagefind-body'] = '';
 ---
 
-<html lang={Astro.props.lang} dir={Astro.props.dir} {...dataAttributes}>
+<html lang={Astro.props.lang} dir={Astro.props.dir} {...htmlDataAttributes}>
 	<head>
 		<Head {...Astro.props} />
 		<style>
@@ -82,7 +85,7 @@ if (Boolean(Astro.props.entry.data.hero)) dataAttributes['data-has-hero'] = '';
 			<TwoColumnContent {...Astro.props}>
 				<PageSidebar slot="right-sidebar" {...Astro.props} />
 				<main
-					data-pagefind-body={pagefindEnabled}
+					{...mainDataAttributes}
 					lang={Astro.props.entryMeta.lang}
 					dir={Astro.props.entryMeta.dir}
 				>


### PR DESCRIPTION
#### Description

- Closes #2739

This PR fixes an issue preventing to disable Pagefind using the `pagefind` frontmatter field.

With the Astro 5 change to [non-boolean HTML attribute values](https://docs.astro.build/en/guides/upgrade-to/v5/#changed-non-boolean-html-attribute-values), disabling pagefind using the `pagefind` frontmatter field would render `data-pagefind-body="false"` in the HTML instead of omitting the attribute entirely.