### PR TITLE
Add instant behavior to synced tab scrolling

### DIFF
--- a/.changeset/chilly-paws-smell.md
+++ b/.changeset/chilly-paws-smell.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Ensures `<Tab>` component toggling is stable when smooth scrolling is enabled via custom CSS

--- a/packages/starlight/user-components/Tabs.astro
+++ b/packages/starlight/user-components/Tabs.astro
@@ -224,6 +224,7 @@ if (isSynced) {
 				StarlightTabs.#syncTabs(this, newTab);
 				window.scrollTo({
 					top: window.scrollY + (this.getBoundingClientRect().top - previousTabsOffset),
+					behavior: 'instant',
 				});
 			}
 		}


### PR DESCRIPTION
#### Description

- *Closes:* #2746

- *What does this PR change? Give us a brief description.*
  This ensures the scroll behavior will be instant as expected whenever clicking a synced tab triggers a window scroll, which fixes the odd "smooth scroll jump" on Starlight sites which use `html { scroll-behavior: smooth; }` in their global CSS. This provides a nicer UX on sites which use smooth scrolling, where e.g. clicking an item in the ToC smooth scrolls to that section on the page, but clicking a new synced tab doesn't cause an awkward jump as it scrolls to the new tab's position. It should be a non-breaking change to existing Starlight sites since the default scroll behavior is already instant. 🙂

- *Did you change something visual? A before/after screenshot can be helpful.*
  Nope, just a tiny quality-of-life improvement for tabs on pages which use smooth scrolling!
