### PR TITLE
Expose navigation functions via the internal module.

### DIFF
--- a/packages/starlight/internal.ts
+++ b/packages/starlight/internal.ts
@@ -1,6 +1,7 @@
 /**
- * @file This file contains utility functions imported by the `<Code>` component.
+ * @file This file contains utility functions imported by the `<Code>` and `<Sidebar>` components.
  */
 
 export { useTranslations } from './utils/translations';
 export { getStarlightEcConfigPreprocessor } from './integrations/expressive-code';
+export { getSidebar, getSidebarFromConfig } from './utils/navigation';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
- What does this PR change? Give us a brief description.

    Currently, if a developer wants to utilize the `sidebar` config structure to do something custom on a page utilizing the `<StarlightPage>` component, there is no way to access that generated config.

    The `starlight/utils/navigation` module exposes two functions that the `<Sidebar>` component uses: `getSidebar` and `getSidebarFromConfig`. However, those functions are not exposed publicly to developers. This PR simply exposes those functions via the existing `@astrojs/starlight/internal` module.

- Did you change something visual? A before/after screenshot can be helpful.

    No, this is just a developer enhancement for niche scenarios that want to do something custom on a 

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
