### PR TITLE
docs: fix invalid import in `ComponentProps` example

### DIFF
--- a/docs/src/content/docs/components/using-components.mdx
+++ b/docs/src/content/docs/components/using-components.mdx
@@ -87,7 +87,7 @@ The following example uses `ComponentProps` to get the type of the props accepte
 ---
 // src/components/Example.astro
 import type { ComponentProps } from 'astro/types';
-import { Icon } from '@astrojs/starlight/icon';
+import { Icon } from '@astrojs/starlight/components';
 
 type IconProps = ComponentProps<typeof Icon>;
 ---


### PR DESCRIPTION
#### Description

As [reported](https://discord.com/channels/830184174198718474/1070481941863878697/1325375830402273323) on Discord, the `ComponentProps` example contains an invalid import statement.

This PR fixes the import statement.