### PR TITLE
i18n(fr): update `components/using-components`

### DIFF
--- a/docs/src/content/docs/fr/components/using-components.mdx
+++ b/docs/src/content/docs/fr/components/using-components.mdx
@@ -89,7 +89,7 @@ L'exemple suivant utilise `ComponentProps` pour obtenir le type des props accept
 ---
 // src/components/Exemple.astro
 import type { ComponentProps } from 'astro/types';
-import { Icon } from '@astrojs/starlight/icon';
+import { Icon } from '@astrojs/starlight/components';
 
 type IconProps = ComponentProps<typeof Icon>;
 ---


### PR DESCRIPTION
#### Description

This PR updates the French version of the `components/using-components` page with the changes from #2751.