### PR TITLE
Prevent title from being translated

### DIFF
--- a/.changeset/smart-moons-repair.md
+++ b/.changeset/smart-moons-repair.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Prevents the header title from being translated by automatic translation systems.

--- a/packages/starlight/components/SiteTitle.astro
+++ b/packages/starlight/components/SiteTitle.astro
@@ -29,7 +29,7 @@ const { siteTitle, siteTitleHref } = Astro.props;
 			</>
 		)
 	}
-	<span class:list={{ 'sr-only': config.logo?.replacesTitle }}>
+	<span class:list={{ 'sr-only': config.logo?.replacesTitle }} translate="no">
 		{siteTitle}
 	</span>
 </a>


### PR DESCRIPTION
#### Description

This PR adds the [`translate` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate) to the header site title to indicates that the element must not be translated.

> Although not all browsers recognize this attribute, it is respected by automatic translation systems such as Google Translate, and may also be respected by tools used by human translators. As such it's important that web authors use this attribute to mark content that should not be translated.

For example, commenting the `logo` configuration option in the Astro config of the Starlight Docs and asking Google Translate to translate the English version of the website to French will result in the following:

<img width="805" alt="SCR-20250107-ovfr" src="https://github.com/user-attachments/assets/92377f97-f6c9-4eb5-9fe9-41b584c8ce39" />

After this PR, the header site title will no longer be translated:

<img width="805" alt="SCR-20250107-ovia" src="https://github.com/user-attachments/assets/1cd185b8-dc4a-4cf9-aebe-37d8f7956982" />