### PR TITLE
Step up and Badge on

### DIFF
--- a/docs/src/content/docs/guides/route-data.mdx
+++ b/docs/src/content/docs/guides/route-data.mdx
@@ -3,6 +3,8 @@ title: Route Data
 description: Learn how Starlight’s page data model is used to render your pages and how you can customize it.
 ---
 
+import { Steps } from '@astrojs/starlight/components';
+
 When Starlight renders a page in your documentation, it first creates a route data object to represent what is on that page.
 This guide explains how route data is generated, how it is used, and how you can customize it to modify Starlight’s default behavior.
 
@@ -58,6 +60,7 @@ Changes like this do not require modifying Starlight’s default components, onl
 You can customize route data using a special form of “middleware”.
 This is a function that is called every time Starlight renders a page and can modify values in the route data object.
 
+<Steps>
 1. Create a new file exporting an `onRequest` function using Starlight’s `defineRouteMiddleware()` utility:
 
    ```ts
@@ -75,12 +78,12 @@ This is a function that is called every time Starlight renders a page and can mo
    import starlight from '@astrojs/starlight';
 
    export default defineConfig({
-     integrations: [
-       starlight({
-         title: 'My delightful docs site',
-         routeMiddleware: './src/routeData.ts',
-       }),
-     ],
+   	integrations: [
+   		starlight({
+   			title: 'My delightful docs site',
+   			routeMiddleware: './src/routeData.ts',
+   		}),
+   	],
    });
    ```
 
@@ -96,9 +99,10 @@ This is a function that is called every time Starlight renders a page and can mo
    import { defineRouteMiddleware } from '@astrojs/starlight/route-data';
 
    export const onRequest = defineRouteMiddleware((context) => {
-     // Get the content collection entry for this page.
-     const { entry } = context.locals.starlightRoute;
-     // Update the title to add an exclamation mark.
-     entry.data.title = entry.data.title + '!';
+   	// Get the content collection entry for this page.
+   	const { entry } = context.locals.starlightRoute;
+   	// Update the title to add an exclamation mark.
+   	entry.data.title = entry.data.title + '!';
    });
    ```
+</Steps>

--- a/docs/src/content/docs/guides/route-data.mdx
+++ b/docs/src/content/docs/guides/route-data.mdx
@@ -78,12 +78,12 @@ This is a function that is called every time Starlight renders a page and can mo
    import starlight from '@astrojs/starlight';
 
    export default defineConfig({
-   	integrations: [
-   		starlight({
-   			title: 'My delightful docs site',
-   			routeMiddleware: './src/routeData.ts',
-   		}),
-   	],
+   	 integrations: [
+   		 starlight({
+   			 title: 'My delightful docs site',
+   			 routeMiddleware: './src/routeData.ts',
+   		 }),
+   	 ],
    });
    ```
 
@@ -99,10 +99,10 @@ This is a function that is called every time Starlight renders a page and can mo
    import { defineRouteMiddleware } from '@astrojs/starlight/route-data';
 
    export const onRequest = defineRouteMiddleware((context) => {
-   	// Get the content collection entry for this page.
-   	const { entry } = context.locals.starlightRoute;
-   	// Update the title to add an exclamation mark.
-   	entry.data.title = entry.data.title + '!';
+   	 // Get the content collection entry for this page.
+   	 const { entry } = context.locals.starlightRoute;
+   	 // Update the title to add an exclamation mark.
+   	 entry.data.title = entry.data.title + '!';
    });
    ```
 </Steps>

--- a/docs/src/content/docs/guides/route-data.mdx
+++ b/docs/src/content/docs/guides/route-data.mdx
@@ -78,12 +78,12 @@ This is a function that is called every time Starlight renders a page and can mo
    import starlight from '@astrojs/starlight';
 
    export default defineConfig({
-   	 integrations: [
-   		 starlight({
-   			 title: 'My delightful docs site',
-   			 routeMiddleware: './src/routeData.ts',
-   		 }),
-   	 ],
+     integrations: [
+       starlight({
+         title: 'My delightful docs site',
+         routeMiddleware: './src/routeData.ts',
+       }),
+     ],
    });
    ```
 
@@ -99,10 +99,10 @@ This is a function that is called every time Starlight renders a page and can mo
    import { defineRouteMiddleware } from '@astrojs/starlight/route-data';
 
    export const onRequest = defineRouteMiddleware((context) => {
-   	 // Get the content collection entry for this page.
-   	 const { entry } = context.locals.starlightRoute;
-   	 // Update the title to add an exclamation mark.
-   	 entry.data.title = entry.data.title + '!';
+     // Get the content collection entry for this page.
+     const { entry } = context.locals.starlightRoute;
+     // Update the title to add an exclamation mark.
+     entry.data.title = entry.data.title + '!';
    });
    ```
 </Steps>

--- a/docs/src/content/docs/reference/route-data.mdx
+++ b/docs/src/content/docs/reference/route-data.mdx
@@ -3,8 +3,6 @@ title: Route Data Reference
 description: The full reference documentation for Starlight’s route data object.
 ---
 
-import { Badge } from '@astrojs/starlight/components';
-
 Starlight’s route data object contains information about the current page.
 Learn more about how Starlight’s data model works in the [“Route Data” guide](/guides/route-data/).
 
@@ -64,7 +62,7 @@ The site title for this page’s locale.
 The value for the site title’s `href` attribute, linking back to the homepage, e.g. `/`.
 For multilingual sites this will include the current locale, e.g. `/en/` or `/zh-cn/`.
 
-### `slug` <Badge text="deprecated" variant="caution" size='medium'/> 
+### `slug`
 
 **Type:** `string`
 

--- a/docs/src/content/docs/reference/route-data.mdx
+++ b/docs/src/content/docs/reference/route-data.mdx
@@ -3,6 +3,8 @@ title: Route Data Reference
 description: The full reference documentation for Starlight’s route data object.
 ---
 
+import { Badge } from '@astrojs/starlight/components';
+
 Starlight’s route data object contains information about the current page.
 Learn more about how Starlight’s data model works in the [“Route Data” guide](/guides/route-data/).
 
@@ -62,7 +64,7 @@ The site title for this page’s locale.
 The value for the site title’s `href` attribute, linking back to the homepage, e.g. `/`.
 For multilingual sites this will include the current locale, e.g. `/en/` or `/zh-cn/`.
 
-### `slug`
+### `slug` <Badge text="deprecated" variant="caution" size='medium'/> 
 
 **Type:** `string`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Personally - having some experience with translating the docs - I think that creating `.mdx` files immediately, instead of renaming later (because _often_ md files end up having to be mdx files because of components) has the benefit for translators, that the changes are better traceable. That's the first reason for this PR.

The second reason is more relatable for the maintainers probably: I think that the new route-data guide should use the Step component instead of having just the numbered list...

I also found a reasonable place in the route-data reference for a component: the `slug` could have a badge label somewhere. Here I think the change to a `.mdx` file is not that necessary because the Badge doesn't need to be there, further discussion maybe?

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
