### PR TITLE
Use semantic color name instead of absolute color name

### DIFF
--- a/.changeset/grumpy-terms-accept.md
+++ b/.changeset/grumpy-terms-accept.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Uses semantic `var(--sl-color-hairline)` for the page sidebar border instead of `var(--sl-color-gray-6)`. This is visually the same as previously but makes it easier to override the hairline color consistently across a site.

--- a/packages/starlight/components/TwoColumnContent.astro
+++ b/packages/starlight/components/TwoColumnContent.astro
@@ -32,7 +32,7 @@ import type { Props } from '../props';
 		.right-sidebar {
 			position: fixed;
 			top: 0;
-			border-inline-start: 1px solid var(--sl-color-gray-6);
+			border-inline-start: 1px solid var(--sl-color-hairline);
 			padding-top: var(--sl-nav-height);
 			width: 100%;
 			height: 100vh;


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #2790
- This PR updates the right sidebar to use the semantic color name (`--sl-color-hairline`) instead of an absolute color name (`--sl-color-gray-6`).
- This means that when a theme customises the hairline colors, the right sidebar will be automatically use that.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
