### PR TITLE
Added starlight-to-pdf tool to Plugins and Integrations page

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -184,4 +184,9 @@ These community tools and integrations can be used to add features to your Starl
 		title="@hideoo/starlight-plugin"
 		description="A generator to quickly scaffold Starlight plugins."
 	/>
+	<LinkCard
+		href="https://github.com/Linkerin/starlight-to-pdf"
+		title="starlight-to-pdf"
+		description="A CLI tool to convert Starlight websites into PDF files."
+	/>
 </CardGrid>


### PR DESCRIPTION
#### Description

The PR adds a link to the [starlight-to-pdf](https://github.com/Linkerin/starlight-to-pdf) cli tool for converting Starlight into PDF into the [Plugins and Integrations](https://starlight.astro.build/resources/plugins/) page, `Community tools and integrations` section.

A solution to the following discussion: [Export docs to PDF #964](https://github.com/withastro/starlight/discussions/964).