### PR TITLE
i18n(de): update expressive code links and fix some polite forms (German thing)

### DIFF
--- a/docs/src/content/docs/de/components/link-buttons.mdx
+++ b/docs/src/content/docs/de/components/link-buttons.mdx
@@ -5,7 +5,7 @@ description: Erfahre, wie du in Starlight Link-Buttons für visuell eindeutige C
 
 import { LinkButton } from '@astrojs/starlight/components';
 
-Um visuell eindeutige Call-to-Action-Links anzuzeigen, verwenden Sie die Komponente `<LinkButton>`.
+Um visuell eindeutige Call-to-Action-Links anzuzeigen, verwende die Komponente `<LinkButton>`.
 
 import Preview from '~/components/component-preview.astro';
 

--- a/docs/src/content/docs/de/guides/authoring-content.mdx
+++ b/docs/src/content/docs/de/guides/authoring-content.mdx
@@ -113,7 +113,7 @@ Nebenbemerkungen (auch bekannt als "Ermahnungen" oder "Callouts") sind nützlich
 
 Starlight bietet eine eigene Markdown-Syntax für die Darstellung von Nebeninformationen. Seitenblöcke werden mit einem Paar dreifacher Doppelpunkte `:::` angezeigt, um den Inhalt zu umschließen, und können vom Typ `note`, `tip`, `caution` oder `danger` sein.
 
-Sie können alle anderen Markdown-Inhaltstypen innerhalb einer Nebenbemerkung verschachteln, allerdings eignen sich diese am besten für kurze und prägnante Inhaltsstücke.
+Du kannst alle anderen Markdown-Inhaltstypen innerhalb einer Nebenbemerkung verschachteln, allerdings eignen sich diese am besten für kurze und prägnante Inhaltsstücke.
 
 ### Nebenbemerkung `note`
 
@@ -154,7 +154,7 @@ Astro hilft dir, schnellere Websites mit ["Islands Architecture"](https://docs.a
 ### Weitere Typen
 
 Vorsichts- und Gefahrenhinweise sind hilfreich, um die Aufmerksamkeit des Benutzers auf Details zu lenken, über die er stolpern könnte.
-Wenn du diese häufig verwenden, kann das auch ein Zeichen dafür sein, dass die Sache, die Sie dokumentieren, von einem neuen Design profitieren könnte.
+Wenn du diese häufig verwenden, kann das auch ein Zeichen dafür sein, dass die Sache, die du dokumentierest, von einem neuen Design profitieren könnte.
 
 :::caution
 Wenn du nicht sicher bist, ob du eine großartige Dokumentseite willst, überlege es dir zweimal, bevor du [Starlight](/de/) verwendest.
@@ -220,13 +220,13 @@ var fun = function lang(l) {
 
 ### Expressive Code-Merkmale
 
-Starlight verwendet [Expressive Code](https://github.com/expressive-code/expressive-code/tree/main/packages/astro-expressive-code), um die Formatierungsmöglichkeiten für Codeblöcke zu erweitern.
+Starlight verwendet [Expressive Code](https://expressive-code.com/), um die Formatierungsmöglichkeiten für Codeblöcke zu erweitern.
 Die Textmarker und Fensterrahmen-Plugins von Expressive Code sind standardmäßig aktiviert.
 Die Darstellung von Codeblöcken kann mit Starlights [`expressiveCode` Konfigurationsoption](/de/reference/configuration/#expressivecode) konfiguriert werden.
 
 #### Textmarkierungen
 
-Du kannst bestimmte Zeilen oder Teile deiner Codeblöcke hervorheben, indem du [Expressive Code Textmarkierungen](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-text-markers/README.md#usage-in-markdown--mdx-documents) in der ersten Zeile deines Codeblocks verwendest.
+Du kannst bestimmte Zeilen oder Teile deiner Codeblöcke hervorheben, indem du [Expressive Code Textmarkierungen](https://expressive-code.com/key-features/text-markers/) in der ersten Zeile deines Codeblocks verwendest.
 Verwende geschweifte Klammern (`{ }`), um ganze Zeilen hervorzuheben, und Anführungszeichen, um Textabschnitte zu markieren.
 
 Es gibt drei Hervorhebungsstile: neutral, um auf den Code aufmerksam zu machen, grün, um eingefügten Code zu kennzeichnen, und rot, um gelöschten Code zu kennzeichnen.
@@ -234,10 +234,10 @@ Sowohl Text als auch ganze Zeilen können mit der Standardmarkierung oder in Kom
 
 Expressive Code bietet mehrere Optionen zur Anpassung des visuellen Erscheinungsbildes deiner Codebeispiele.
 Viele dieser Optionen können kombiniert werden, um sehr anschauliche Codebeispiele zu erstellen.
-Bitte schaue dir die [Expressive Code Dokumentation](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-text-markers/README.md) an, um dich über die umfangreichen Optionen zu informieren.
+Bitte schaue dir die [Expressive Code Dokumentation](https://expressive-code.com/key-features/text-markers/#configuration) an, um dich über die umfangreichen Optionen zu informieren.
 Einige der gebräuchlichsten Beispiele sind unten aufgeführt:
 
-- [Markiere ganze Zeilen und Zeilenbereiche mit dem Marker `{ }`](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-text-markers/README.md#marking-entire-lines--line-ranges):
+- [Markiere ganze Zeilen und Zeilenbereiche mit dem Marker `{ }`](https://expressive-code.com/key-features/text-markers/#marking-full-lines--line-ranges):
 
   ```js {2-3}
   function demo() {
@@ -255,7 +255,7 @@ Einige der gebräuchlichsten Beispiele sind unten aufgeführt:
   ```
   ````
 
-- [Markieren von Textabschnitten mit der Markierung `" "` oder regulären Ausdrücken](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-text-markers/README.md#marking-individual-text-inside-lines):
+- [Markieren von Textabschnitten mit der Markierung `" "` oder regulären Ausdrücken](https://expressive-code.com/key-features/text-markers/#marking-individual-text-inside-lines):
 
   ```js "einzelne Begriffe" /Auch.*unterstützt/
   // Auch einzelne Begriffe können hervorgehoben werden
@@ -273,7 +273,7 @@ Einige der gebräuchlichsten Beispiele sind unten aufgeführt:
   ```
   ````
 
-- [Text oder Zeilen mit `ins` oder `del` als eingefügt oder gelöscht markieren](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-text-markers/README.md#selecting-marker-types-mark-ins-del):
+- [Text oder Zeilen mit `ins` oder `del` als eingefügt oder gelöscht markieren](https://expressive-code.com/key-features/text-markers/#selecting-inline-marker-types-mark-ins-del):
 
   ```js "return true;" ins="eingefügte" del="gelöschte"
   function demo() {
@@ -293,7 +293,7 @@ Einige der gebräuchlichsten Beispiele sind unten aufgeführt:
   ```
   ````
 
-- [Kombinieren Sie die Syntaxhervorhebung mit einer `diff`-ähnlichen Syntax](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-text-markers/README.md#combining-syntax-highlighting-with-diff-like-syntax):
+- [Kombiniere die Syntaxhervorhebung mit einer `diff`-ähnlichen Syntax](https://expressive-code.com/key-features/text-markers/#combining-syntax-highlighting-with-diff-like-syntax):
 
   ```diff lang="js"
     function thisIsJavaScript() {
@@ -323,7 +323,7 @@ Andere Sprachen werden in einem Rahmen im Stil eines Code-Editors angezeigt, wen
 
 Der optionale Titel eines Code-Blocks kann entweder mit einem `title="..."`-Attribut gesetzt werden, das den öffnenden Backticks und dem Sprachbezeichner des Code-Blocks folgt, oder mit einem Dateinamenkommentar in den ersten Zeilen des Codes.
 
-- [Hinzufügen einer Registerkarte für den Dateinamen mit einem Kommentar](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-frames/README.md#adding-titles-open-file-tab-or-terminal-window-title)
+- [Hinzufügen einer Registerkarte für den Dateinamen mit einem Kommentar](https://expressive-code.com/key-features/frames/#code-editor-frames)
 
   ```js
   // meine-test-datei.js
@@ -337,7 +337,7 @@ Der optionale Titel eines Code-Blocks kann entweder mit einem `title="..."`-Attr
   ```
   ````
 
-- [Hinzufügen eines Titels zu einem Terminalfenster](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-frames/README.md#adding-titles-open-file-tab-or-terminal-window-title)
+- [Hinzufügen eines Titels zu einem Terminalfenster](https://expressive-code.com/key-features/frames/#terminal-frames)
 
   ```bash title="Installieren von Abhängigkeiten…"
   npm install
@@ -349,7 +349,7 @@ Der optionale Titel eines Code-Blocks kann entweder mit einem `title="..."`-Attr
   ```
   ````
 
-- [Fensterrahmen mit `frame="none"` deaktivieren](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-frames/README.md#overriding-frame-types)
+- [Fensterrahmen mit `frame="none"` deaktivieren](https://expressive-code.com/key-features/frames/#overriding-frame-types)
 
   ```bash frame="none"
   echo "Dies wird trotz Verwendung der Bash-Sprache nicht als Terminal dargestellt"

--- a/docs/src/content/docs/de/guides/authoring-content.mdx
+++ b/docs/src/content/docs/de/guides/authoring-content.mdx
@@ -154,7 +154,7 @@ Astro hilft dir, schnellere Websites mit ["Islands Architecture"](https://docs.a
 ### Weitere Typen
 
 Vorsichts- und Gefahrenhinweise sind hilfreich, um die Aufmerksamkeit des Benutzers auf Details zu lenken, über die er stolpern könnte.
-Wenn du diese häufig verwenden, kann das auch ein Zeichen dafür sein, dass die Sache, die du dokumentierest, von einem neuen Design profitieren könnte.
+Wenn du diese häufig verwenden, kann das auch ein Zeichen dafür sein, dass die Sache, die du dokumentierst, von einem neuen Design profitieren könnte.
 
 :::caution
 Wenn du nicht sicher bist, ob du eine großartige Dokumentseite willst, überlege es dir zweimal, bevor du [Starlight](/de/) verwendest.

--- a/docs/src/content/docs/de/guides/i18n.mdx
+++ b/docs/src/content/docs/de/guides/i18n.mdx
@@ -221,7 +221,7 @@ Du kannst Übersetzungen für zusätzliche Sprachen, die du unterstützt, über 
 
    <UIStringsList />
 
-   Die Codeblöcke von Starlight werden von der [Expressive Code](https://github.com/expressive-code/expressive-code) Bibliothek unterstützt.
+   Die Codeblöcke von Starlight werden von der [Expressive Code](https://expressive-code.com/) Bibliothek unterstützt.
    Du kannst die Übersetzungen für die UI-Strings in derselben JSON-Datei mit Hilfe von `expressiveCode`-Schlüsseln festlegen:
 
    ```json

--- a/docs/src/content/docs/de/reference/configuration.mdx
+++ b/docs/src/content/docs/de/reference/configuration.mdx
@@ -386,10 +386,10 @@ starlight({
 **Typ:** `StarlightExpressiveCodeOptions | boolean`  
 **Standard:** `true`
 
-Starlight verwendet [Expressive Code](https://github.com/expressive-code/expressive-code/tree/main/packages/astro-expressive-code), um Codeblöcke zu rendern und Unterstützung für das Hervorheben von Teilen von Codebeispielen, das Hinzufügen von Dateinamen zu Codeblöcken und mehr hinzuzufügen.
+Starlight verwendet [Expressive Code](https://expressive-code.com), um Codeblöcke zu rendern und Unterstützung für das Hervorheben von Teilen von Codebeispielen, das Hinzufügen von Dateinamen zu Codeblöcken und mehr hinzuzufügen.
 Im [Handbuch „Codeblöcke“](/de/guides/authoring-content/#codeblöcke) erfährst du, wie du die Expressive Code-Syntax in deinen Markdown- und MDX-Inhalten verwendest.
 
-Du kannst alle standardmäßigen [Expressive Code-Konfigurationsoptionen](https://github.com/expressive-code/expressive-code/blob/main/packages/astro-expressive-code/README.md#configuration) sowie einige Starlight-spezifische Eigenschaften verwenden, indem du sie in der Option `expressiveCode` von Starlight festlegst.
+Du kannst alle standardmäßigen [Expressive Code-Konfigurationsoptionen](https://expressive-code.com/reference/configuration/) sowie einige Starlight-spezifische Eigenschaften verwenden, indem du sie in der Option `expressiveCode` von Starlight festlegst.
 Lege beispielsweise die Option `styleOverrides` von Expressive Code fest, um das Standard-CSS zu überschreiben. Dadurch sind Anpassungen möglich, beispielsweise das Hinzufügen abgerundeter Ecken zu deinen Codeblöcken:
 
 ```js ins={2-4}
@@ -416,7 +416,7 @@ Zusätzlich zu den standardmäßigen Expressive Code-Optionen kannst du in deine
 **Standard:** `['starlight-dark', 'starlight-light']`
 
 Lege die Designs fest, die zum Stylen von Codeblöcken verwendet werden.
-Weitere Informationen zu den unterstützten Designformaten findest du in der [Expressive Code-Dokumentation zu Designs](https://github.com/expressive-code/expressive-code/blob/main/packages/astro-expressive-code/README.md#themes).
+Weitere Informationen zu den unterstützten Designformaten findest du in der [Expressive Code-Dokumentation zu Designs](https://expressive-code.com/guides/themes/).
 
 Starlight verwendet standardmäßig die dunkle und helle Variante von Sarah Drasners [Night Owl-Thema](https://github.com/sdras/night-owl-vscode-theme).
 
@@ -429,7 +429,7 @@ Konfiguriere dieses Verhalten mit der Option [`useStarlightDarkModeSwitch`](#use
 **Standard:** `true`
 
 Falls `true`, wechseln Codeblöcke automatisch zwischen hellen und dunklen Designs, wenn sich das Site-Design ändert.
-Falls `false`, müssen Sie manuell CSS hinzufügen, um das Wechseln zwischen mehreren Designs zu handhaben.
+Falls `false`, musst du manuell CSS hinzufügen, um das Wechseln zwischen mehreren Designs zu handhaben.
 
 :::note
 Beim Festlegen von `themes` musst du mindestens ein dunkles und ein helles Design angeben, damit der Wechsel zum Starlight-Dunkelmodus funktioniert.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- #2782 
- update `Sie` to `du` in several places

For non-native reviewers: In German the term "you" can be translated to a polite form "Sie", [which we chose not to use in German](https://github.com/withastro/docs/blob/61cab8bbf7bbfa5f058e2847261989d46001d109/i18n-guides/deutsch.md?plain=1#L61), and the inpolite form "du" which is more personal. I found some polite forms and replaced them with inpolite forms, also changing the grammer respectfully.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
