### PR TITLE
i18n(fr): update `reference/icons`, `components/icons` & `components/using-components`

### DIFF
--- a/docs/src/content/docs/fr/components/icons.mdx
+++ b/docs/src/content/docs/fr/components/icons.mdx
@@ -95,7 +95,7 @@ Le composant `<Icon>` accepte les props suivants :
 ### `name`
 
 **Obligatoire**  
-**Type :** `string`
+**Type :** [`StarlightIcon`](/fr/reference/icons/#type-starlighticon)
 
 Le nom de l'icône à afficher correspondant à [une des icônes disponibles avec Starlight](/fr/reference/icons/#toutes-les-icônes).
 

--- a/docs/src/content/docs/fr/components/using-components.mdx
+++ b/docs/src/content/docs/fr/components/using-components.mdx
@@ -83,14 +83,14 @@ Si ces styles entrent en conflit avec l'apparence de votre composant, utilisez l
 Utilisez le type [`ComponentProps`](https://docs.astro.build/fr/guides/typescript/#type-componentprops) depuis `astro/types` pour référencer les `Props` acceptées par un composant même si elles ne sont pas exportées par le composant lui-même.
 Cela peut être utile lorsqu'il s'agit d'entourer ou d'étendre un composant existant.
 
-L'exemple suivant utilise `ComponentProps` pour obtenir le type des props acceptées par le composant `Icon` intégré à Starlight :
+L'exemple suivant utilise `ComponentProps` pour obtenir le type des props acceptées par le composant `Badge` intégré à Starlight :
 
 ```astro
 ---
 // src/components/Exemple.astro
 import type { ComponentProps } from 'astro/types';
-import { Icon } from '@astrojs/starlight/components';
+import { Badge } from '@astrojs/starlight/components';
 
-type IconProps = ComponentProps<typeof Icon>;
+type BadgeProps = ComponentProps<typeof Badge>;
 ---
 ```

--- a/docs/src/content/docs/fr/reference/icons.mdx
+++ b/docs/src/content/docs/fr/reference/icons.mdx
@@ -10,6 +10,19 @@ Starlight fournit un ensemble d'icônes intégrées que vous pouvez afficher dan
 Les icônes peuvent être affichées en utilisant le composant [`<Icon>`](/fr/components/icons/).
 Elles sont également souvent utilisées dans d'autres composants, comme les [cartes](/fr/components/cards/) ou des paramètres comme les [actions de la section d'en-tête](/fr/reference/frontmatter/#hero).
 
+## Type `StarlightIcon`
+
+Utilisez le type TypeScript `StarlightIcon` pour référencer les noms des [icônes disponibles avec Starlight](#toutes-les-icônes).
+
+```ts {2} /icon: (StarlightIcon)/
+// src/icon.ts
+import type { StarlightIcon } from '@astrojs/starlight/types';
+
+function getIconLabel(icon: StarlightIcon) {
+	// …
+}
+```
+
 ## Toutes les icônes
 
 Une liste de toutes les icônes disponibles est affichée ci-dessous avec leurs noms associés. Cliquez sur une icône pour copier son nom dans votre presse-papiers.


### PR DESCRIPTION
#### Description

This PR updates the French version of the `reference/icons`, `components/icons`, and `components/using-components` pages with the changes from #2805.

Decided to group these changes together as they all relate to the same PR and are fairly small changes.