### PR TITLE
Add clientOptionsModule option to DocSearch plugin

### DIFF
--- a/.changeset/three-pumpkins-turn.md
+++ b/.changeset/three-pumpkins-turn.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight-docsearch': minor
+---
+
+Add an optional `clientOptionsModule` configuration option, used to point towards a JavaScript module containing a default export to configure unserializable DocSearch options such as `resultsFooterComponent`.

--- a/.changeset/three-pumpkins-turn.md
+++ b/.changeset/three-pumpkins-turn.md
@@ -2,4 +2,6 @@
 '@astrojs/starlight-docsearch': minor
 ---
 
-Add an optional `clientOptionsModule` configuration option, used to point towards a JavaScript module containing a default export to configure unserializable DocSearch options such as `resultsFooterComponent`.
+Adds a new `clientOptionsModule` plugin option to support configuring unserializable DocSearch options such as `resultsFooterComponent()`.
+
+See [“DocSearch configuration”](https://starlight.astro.build/guides/site-search/#docsearch-configuration) in the Starlight docs for more details.

--- a/docs/src/content/docs/guides/site-search.mdx
+++ b/docs/src/content/docs/guides/site-search.mdx
@@ -123,8 +123,6 @@ The Starlight DocSearch plugin supports customizing the DocSearch component with
 
 A separate configuration file is required to pass function options like `transformItems()` or `resultsFooterComponent()` to the DocSearch component.
 
-{/* The Starlight DocSearch plugin’s inline options only support configuring JSON-serializable values to pass to the DocSearch component. */}
-
 <Steps>
 
 1. Create a TypeScript file exporting your DocSearch configuration.

--- a/docs/src/content/docs/guides/site-search.mdx
+++ b/docs/src/content/docs/guides/site-search.mdx
@@ -1,6 +1,8 @@
 ---
 title: Site Search
 description: Learn about Starlight’s built-in site search features and how to customize them.
+tableOfContents:
+  maxHeadingLevel: 4
 ---
 
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
@@ -110,12 +112,63 @@ With this updated configuration, the search bar on your site will now open an Al
 
 #### DocSearch configuration
 
-The Starlight DocSearch plugin also supports customizing the DocSearch component with the following additional options:
+The Starlight DocSearch plugin supports customizing the DocSearch component with the following inline options:
 
 - `maxResultsPerGroup`: Limit the number of results displayed for each search group. Default is `5`.
 - `disableUserPersonalization`: Prevent DocSearch from saving a user’s recent searches and favorites to local storage. Default is `false`.
 - `insights`: Enable the Algolia Insights plugin and send search events to your DocSearch index. Default is `false`.
 - `searchParameters`: An object customizing the [Algolia Search Parameters](https://www.algolia.com/doc/api-reference/search-api-parameters/).
+
+##### Additional DocSearch options
+
+The Starlight DocSearch plugin’s inline options only support configuring JSON-serializable values to pass to the DocSearch component.
+A separate configuration file is required to set function options like `transformItems()` or `resultsFooterComponent()`.
+
+<Steps>
+
+1. Create a file exporting your DocSearch configuration.
+   In TypeScript files, you can use the `DocSearchClientOptions` to type check your configuration.
+
+   ```ts
+   // src/config/docsearch.ts
+   import type { DocSearchClientOptions } from '@astrojs/starlight-docsearch';
+
+   export default {
+   	appId: 'YOUR_APP_ID',
+   	apiKey: 'YOUR_SEARCH_API_KEY',
+   	indexName: 'YOUR_INDEX_NAME',
+   	getMissingResultsUrl({ query }) {
+   		return `https://github.com/algolia/docsearch/issues/new?title=${query}`;
+   	},
+   	// ...
+   } satisfies DocSearchClientOptions;
+   ```
+
+2. Pass the path to your configuration file to the Starlight DocSearch plugin in `astro.config.mjs`.
+
+   ```js {11-13}
+   // astro.config.mjs
+   import { defineConfig } from 'astro/config';
+   import starlight from '@astrojs/starlight';
+   import starlightDocSearch from '@astrojs/starlight-docsearch';
+
+   export default defineConfig({
+   	integrations: [
+   		starlight({
+   			title: 'Site with DocSearch',
+   			plugins: [
+   				starlightDocSearch({
+   					clientOptionsModule: './src/config/docsearch.ts',
+   				}),
+   			],
+   		}),
+   	],
+   });
+   ```
+
+</Steps>
+
+See the [DocSearch JavaScript client API Reference](https://docsearch.algolia.com/docs/api/) for all supported options.
 
 #### Translating the DocSearch UI
 

--- a/docs/src/content/docs/guides/site-search.mdx
+++ b/docs/src/content/docs/guides/site-search.mdx
@@ -121,13 +121,13 @@ The Starlight DocSearch plugin supports customizing the DocSearch component with
 
 ##### Additional DocSearch options
 
-The Starlight DocSearch plugin’s inline options only support configuring JSON-serializable values to pass to the DocSearch component.
-A separate configuration file is required to set function options like `transformItems()` or `resultsFooterComponent()`.
+A separate configuration file is required to pass function options like `transformItems()` or `resultsFooterComponent()` to the DocSearch component.
+
+{/* The Starlight DocSearch plugin’s inline options only support configuring JSON-serializable values to pass to the DocSearch component. */}
 
 <Steps>
 
-1. Create a file exporting your DocSearch configuration.
-   In TypeScript files, you can use the `DocSearchClientOptions` to type check your configuration.
+1. Create a TypeScript file exporting your DocSearch configuration.
 
    ```ts
    // src/config/docsearch.ts

--- a/packages/docsearch/DocSearch.astro
+++ b/packages/docsearch/DocSearch.astro
@@ -131,8 +131,7 @@ const docsearchTranslations: DocSearchTranslationProps = {
 			super();
 			window.addEventListener('DOMContentLoaded', async () => {
 				const { default: docsearch } = await import('@docsearch/js');
-				type DocSearchOptions = Parameters<typeof docsearch>[0];
-				const options = { ...config, container: 'sl-doc-search' } as DocSearchOptions;
+				const options = { ...config, container: 'sl-doc-search' };
 				try {
 					const translations = JSON.parse(this.dataset.translations || '{}');
 					Object.assign(options, translations);

--- a/packages/docsearch/index.ts
+++ b/packages/docsearch/index.ts
@@ -49,29 +49,34 @@ const DocSearchConfigSchema = z
 		z
 			.object({
 				/**
-				 * A JavaScript module containing a default export of options
-				 * which are passed to the DocSearch library.
+				 * The path to a JavaScript or TypeScript file containing a default export of options to
+				 * pass to the DocSearch client.
 				 *
-				 * It can be used to configure options that are not serializable,
-				 * such as `transformSearchClient` or `resultsFooterComponent`.
+				 * The value can be a path to a local JS/TS file relative to the root of your project,
+				 * e.g. `'/src/docsearch.js'`, or an npm module specifier for a package you installed,
+				 * e.g. `'@company/docsearch-config'`.
 				 *
-				 * Supports local JS files relative to the root of your project,
-				 * e.g. `'/src/docsearch.js'`, and JS you installed as an npm
-				 * module, e.g. `'@company/docsearch-config'`.
+				 * Use `clientOptionsModule` when you need to configure options that are not serializable,
+				 * such as `transformSearchClient()` or `resultsFooterComponent()`.
+				 *
+				 * When `clientOptionsModule` is set, all options must be set via the module file. Other
+				 * inline options passed to the plugin in `astro.config.mjs` will be ignored.
 				 *
 				 * @see https://docsearch.algolia.com/docs/api
+				 *
 				 * @example
 				 * // astro.config.mjs
-				 * starlightDocSearch({
-				 *   // ...
-				 *   clientOptionsModule: "./src/config/docsearch.ts",
-				 * })
+				 * // ...
+				 * starlightDocSearch({ clientOptionsModule: './src/config/docsearch.ts' }),
+				 * // ...
 				 *
 				 * // src/config/docsearch.ts
 				 * import type { DocSearchClientOptions } from '@astrojs/starlight-docsearch';
 				 *
 				 * export default {
-				 *   // ...
+				 *   appId: '...',
+				 *   apiKey: '...',
+				 *   indexName: '...',
 				 *   getMissingResultsUrl({ query }) {
 				 *     return `https://github.com/algolia/docsearch/issues/new?title=${query}`;
 				 *   },

--- a/packages/docsearch/virtual.d.ts
+++ b/packages/docsearch/virtual.d.ts
@@ -1,4 +1,4 @@
 declare module 'virtual:starlight/docsearch-config' {
-	const DocSearchConfig: import('./index').DocSearchConfig;
-	export default DocSearchConfig;
+	const DocSearchProps: Parameters<typeof import('@docsearch/js').default>[0];
+	export default DocSearchProps;
 }

--- a/packages/docsearch/virtual.d.ts
+++ b/packages/docsearch/virtual.d.ts
@@ -1,4 +1,4 @@
 declare module 'virtual:starlight/docsearch-config' {
-	const DocSearchProps: Parameters<typeof import('@docsearch/js').default>[0];
-	export default DocSearchProps;
+	const DocSearchClientOptions: import('./index').DocSearchClientOptions;
+	export default DocSearchClientOptions;
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes https://github.com/withastro/starlight/discussions/2806
- Adds a `clientOptionsModule` option to the `starlightDocSearch` plugin.
  - This takes the shape of a path to a JavaScript or TypeScript file which will be imported (if present) and merged with existing options in the `starlight/docsearch-config` virtual module.
  - If an option exists in both, i.e `appId`, the option in the `clientOptionsModule` file will be used.

#### Considerations

- Updating documentation

https://github.com/withastro/starlight/blob/66a4131c63ec8ff425c6f04c1c496abbdfddc945/docs/src/content/docs/guides/site-search.mdx?plain=1#L111-L118

- Tests

Whilst this is probably not a large enough package to warrant it, I did setup try out setting up Vitest for this package where `vitePluginDocSearch` is passed in `vitest.config.ts` but since it would need a lot of work to setup a harness to test `starlightDocSearch` I opted against including it.