### PR TITLE
i18n(fr): fix highlighting in `reference/plugins.md`

### DIFF
--- a/docs/src/content/docs/fr/reference/plugins.md
+++ b/docs/src/content/docs/fr/reference/plugins.md
@@ -348,7 +348,7 @@ starlight({
 
 Un module d'extension peut déterminer la langue d'un fichier en utilisant son chemin absolu :
 
-```ts {6-8} /en/
+```ts {6-8} //(en)//
 // module-extension.ts
 export default {
   name: 'plugin-utilisant-traductions',


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Updates the French translation of `reference/plugins` to fix a code snippet highlighting.

I suggested a fix in https://github.com/withastro/starlight/pull/2886#discussion_r1957375034 but I didn't pay attention that we already have `en` in the string so the highlighting is currently wrong.

|Before|After|
|---|---|
|![starlight-before](https://github.com/user-attachments/assets/bf6c70dd-6d85-46a6-9ae2-315d73af7735)|![starlight-after](https://github.com/user-attachments/assets/094663e9-fc03-4794-b39c-50a95ba67590)|

I'm not used to Expressive Code so perhaps there is better a way... Looking at the docs it seems we need [capture groups](https://expressive-code.com/key-features/text-markers/#marking-capture-group-contents). The [recommended syntax](https://expressive-code.com/key-features/text-markers/#escaping-forward-slashes) is `/\/(en)\//` but Prettier removes the escape characters... Tested locally with the dev server, it also works without!

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
