### PR TITLE
Fix issue with rewriting

### DIFF
--- a/.changeset/forty-ways-beam.md
+++ b/.changeset/forty-ways-beam.md
@@ -2,4 +2,4 @@
 '@astrojs/starlight': patch
 ---
 
-Fixes an issue preventing to use [rewrites](https://docs.astro.build/en/guides/routing/#rewrites).
+Fixes an issue preventing the use of [rewrites](https://docs.astro.build/en/guides/routing/#rewrites).

--- a/.changeset/forty-ways-beam.md
+++ b/.changeset/forty-ways-beam.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes an issue preventing to use [rewrites](https://docs.astro.build/en/guides/routing/#rewrites).

--- a/packages/starlight/__e2e__/fixtures/ssr/src/middleware.ts
+++ b/packages/starlight/__e2e__/fixtures/ssr/src/middleware.ts
@@ -1,0 +1,8 @@
+import { defineMiddleware } from 'astro:middleware';
+
+export const onRequest = defineMiddleware((context, next) => {
+	if (context.url.pathname === '/content') {
+		return context.rewrite('/demo');
+	}
+	return next();
+});

--- a/packages/starlight/__e2e__/ssr.test.ts
+++ b/packages/starlight/__e2e__/ssr.test.ts
@@ -54,6 +54,14 @@ test('SSR mode renders the same splash page as prerendering', async ({
 	expectEquivalentHTML(prerenderContent, ssrContent);
 });
 
+test('supports middleware rewriting', async ({ page, getProdServer }) => {
+	const starlight = await getProdServer();
+	const response = await starlight.goto('/content');
+
+	expect(response?.status()).toBe(200);
+	await expect(page.locator('#server-check')).toHaveText('On server');
+});
+
 function expectEquivalentHTML(a: string, b: string) {
 	expect(getNormalizedHTML(a)).toEqual(getNormalizedHTML(b));
 }

--- a/packages/starlight/locals.ts
+++ b/packages/starlight/locals.ts
@@ -20,8 +20,8 @@ export const onRequest = defineMiddleware(async (context, next) => {
  * avoid generating route data in this middleware which also runs for non-Starlight route.
  */
 export function initializeStarlightRoute(context: APIContext) {
-	const state: { routeData: StarlightRouteData | undefined } = { routeData: undefined };
 	if ('starlightRoute' in context.locals) return;
+	const state: { routeData: StarlightRouteData | undefined } = { routeData: undefined };
 	Object.defineProperty(context.locals, 'starlightRoute', {
 		get() {
 			if (!state.routeData) {

--- a/packages/starlight/locals.ts
+++ b/packages/starlight/locals.ts
@@ -21,6 +21,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
  */
 export function initializeStarlightRoute(context: APIContext) {
 	const state: { routeData: StarlightRouteData | undefined } = { routeData: undefined };
+	if ('starlightRoute' in context.locals) return;
 	Object.defineProperty(context.locals, 'starlightRoute', {
 		get() {
 			if (!state.routeData) {


### PR DESCRIPTION
#### Description

- Closes #2903

This PR fixes an issue with rewriting, e.g. in a middleware using `context.rewrite()`, which would cause the following error:

```
Cannot redefine property: starlightRoute
```

This is due to the fact that the property is not configurable and [rewriting](https://docs.astro.build/en/guides/middleware/#rewriting) causes any middleware to be re-executed, which would try to redefine the property.

> This will trigger a new rendering phase, causing any middleware to be re-executed.