### PR TITLE
fix: `themes.mdx` sidebar order [i18nIgnore]

### DIFF
--- a/docs/src/content/docs/de/resources/themes.mdx
+++ b/docs/src/content/docs/de/resources/themes.mdx
@@ -3,7 +3,7 @@ title: Themes
 description: Gestalte deine Dokumentation mit einem Community-Theme für Starlight
 tableOfContents: false
 sidebar:
-  order: 1
+  order: 2
 head:
   - tag: style
     content: |

--- a/docs/src/content/docs/fr/resources/themes.mdx
+++ b/docs/src/content/docs/fr/resources/themes.mdx
@@ -3,7 +3,7 @@ title: Thèmes
 description: Modifiez l'apparence visuelle de votre documentation avec un thème communautaire pour Starlight
 tableOfContents: false
 sidebar:
-  order: 1
+  order: 2
 head:
   - tag: style
     content: |

--- a/docs/src/content/docs/ko/resources/themes.mdx
+++ b/docs/src/content/docs/ko/resources/themes.mdx
@@ -3,7 +3,7 @@ title: 테마
 description: Starlight의 커뮤니티 테마로 문서를 스타일링하세요.
 tableOfContents: false
 sidebar:
-  order: 1
+  order: 2
 head:
   - tag: style
     content: |

--- a/docs/src/content/docs/resources/themes.mdx
+++ b/docs/src/content/docs/resources/themes.mdx
@@ -3,7 +3,7 @@ title: Themes
 description: Style your docs with a community theme for Starlight
 tableOfContents: false
 sidebar:
-  order: 1
+  order: 2
 head:
   - tag: style
     content: |


### PR DESCRIPTION
themes.mdx and plugins.mdx have the same sidebar order.
