### PR TITLE
docs: update `authoring-content` Markdown/MDX tab labels

### DIFF
--- a/docs/src/content/docs/guides/authoring-content.mdx
+++ b/docs/src/content/docs/guides/authoring-content.mdx
@@ -248,7 +248,7 @@ Some of the most common examples are shown below:
 
   <Tabs syncKey="content-type">
 
-  <TabItem label="MDX">
+  <TabItem label="Markdown/MDX">
 
   ````md
   ```js {2-3}
@@ -287,7 +287,7 @@ Some of the most common examples are shown below:
 
   <Tabs syncKey="content-type">
 
-  <TabItem label="MDX">
+  <TabItem label="Markdown/MDX">
 
   ````md
   ```js "Individual terms" /Even.*supported/
@@ -327,7 +327,7 @@ Some of the most common examples are shown below:
 
   <Tabs syncKey="content-type">
 
-  <TabItem label="MDX">
+  <TabItem label="Markdown/MDX">
 
   ````md
   ```js "return true;" ins="inserted" del="deleted"
@@ -370,7 +370,7 @@ Some of the most common examples are shown below:
 
   <Tabs syncKey="content-type">
 
-  <TabItem label="MDX">
+  <TabItem label="Markdown/MDX">
 
   ````md
   ```diff lang="js"
@@ -419,7 +419,7 @@ A code block’s optional title can be set either with a `title="..."` attribute
 
   <Tabs syncKey="content-type">
 
-  <TabItem label="MDX">
+  <TabItem label="Markdown/MDX">
 
   ````md
   ```js
@@ -451,7 +451,7 @@ A code block’s optional title can be set either with a `title="..."` attribute
 
   <Tabs syncKey="content-type">
 
-  <TabItem label="MDX">
+  <TabItem label="Markdown/MDX">
 
   ````md
   ```bash title="Installing dependencies…"
@@ -481,7 +481,7 @@ A code block’s optional title can be set either with a `title="..."` attribute
 
   <Tabs syncKey="content-type">
 
-  <TabItem label="MDX">
+  <TabItem label="Markdown/MDX">
 
   ````md
   ```bash frame="none"


### PR DESCRIPTION
This PR changes the labels of the tabs added in #2931 to `Markdown/MDX` instead of just `MDX` which is more accurate in the context of this page.