### PR TITLE
feat: Add dark and light variants for images

### DIFF
--- a/.changeset/empty-beds-heal.md
+++ b/.changeset/empty-beds-heal.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': minor
+---
+
+Make light and dark image variants

--- a/docs/src/content/docs/guides/authoring-content.mdx
+++ b/docs/src/content/docs/guides/authoring-content.mdx
@@ -75,6 +75,8 @@ If you want to show different images for light and dark color schemes, you can a
 ![Image for the light theme](https://github.com/user-attachments/assets/5ff75483-d761-4dbd-b3a0-c7823b137ec5#only-light)
 ![Image for the dark theme](https://github.com/user-attachments/assets/ab396486-d6a3-41ac-85ff-a961f319fbca#only-dark)
 
+The browser will load both versions of the image in any case, but the user will only see one, depending on the current theme.
+
 ## Headings
 
 You can structure content using a heading. Headings in Markdown are indicated by a number of `#` at the start of the line.

--- a/docs/src/content/docs/guides/authoring-content.mdx
+++ b/docs/src/content/docs/guides/authoring-content.mdx
@@ -63,6 +63,18 @@ Relative image paths are also supported for images stored locally in your projec
 ![A rocketship in space](../../assets/images/rocket.svg)
 ```
 
+### Light and dark variants
+
+If you want to show different images for light and dark color schemes, you can append a `#only-light` or `#only-dark` hash fragment to the image URL:
+
+```md
+![Image for the light theme](../../assets/light-logo.svg#only-light)
+![Image for the dark theme](../../assets/dark-logo.svg#only-dark)
+```
+
+![Image for the light theme](https://github.com/user-attachments/assets/5ff75483-d761-4dbd-b3a0-c7823b137ec5#only-light)
+![Image for the dark theme](https://github.com/user-attachments/assets/ab396486-d6a3-41ac-85ff-a961f319fbca#only-dark)
+
 ## Headings
 
 You can structure content using a heading. Headings in Markdown are indicated by a number of `#` at the start of the line.

--- a/packages/starlight/style/print.css
+++ b/packages/starlight/style/print.css
@@ -177,4 +177,11 @@
 		/* Ensure steps guidelines are visible when background colors are disabled. */
 		box-shadow: inset 99rem 99rem var(--sl-color-hairline-light);
 	}
+
+	[data-theme='dark'] img[src$='#only-dark'] {
+	  display: none;
+	}
+	[data-theme='dark'] img[src$='#only-light'] {
+	  display: block !important;
+	}
 }

--- a/packages/starlight/style/util.css
+++ b/packages/starlight/style/util.css
@@ -47,6 +47,12 @@
 [data-theme='dark'] .dark\:sl-hidden {
 	display: none;
 }
+[data-theme='light'] img[src$="#only-dark"] {
+	display: none;
+}
+[data-theme='dark'] img[src$="#only-light"] {
+	display: none;
+}
 
 /*
 Flip an element around the y-axis when in an RTL context.


### PR DESCRIPTION
#### Description

This PR adds dark and light variants for images in Markdown.

Source of inspiration: [the corresponding feature](https://squidfunk.github.io/mkdocs-material/reference/images/?h=light#light-and-dark-mode) in Material for MkDocs

#### Examples:

![sshot-29](https://github.com/user-attachments/assets/f4d8b42c-1916-4374-951a-5818cc923475)
![sshot-23](https://github.com/user-attachments/assets/69664a0b-d9cd-49a0-a210-b7d26cd22a54)
