### PR TITLE
i18n(de): change translation of icon

### DIFF
--- a/docs/src/content/docs/de/components/asides.mdx
+++ b/docs/src/content/docs/de/components/asides.mdx
@@ -27,7 +27,7 @@ import { Aside } from '@astrojs/starlight/components';
 
 Zeige eine Nebenbemerkung (auch bekannt als „Hinweise“, „Ermahnungen“ oder „Aufrufe“) mit Hilfe der Komponente `<Aside>`.
 
-Ein `<Aside>` kann ein optionales [`type`](#type) Attribute haben, welches die Farbe, das Symbol und den Standardtitel der Nebenbemerkung steuert.
+Ein `<Aside>` kann ein optionales [`type`](#type) Attribute haben, welches die Farbe, das Icon und den Standardtitel der Nebenbemerkung steuert.
 
 <Preview>
 
@@ -145,10 +145,10 @@ Die Komponente `<Aside>` akzeptiert die folgenden Eigenschaften:
 
 Die Art der Nebenbemerkung, die angezeigt werden soll:
 
-- `note` Hinweise (die Standardeinstellung) sind blau und zeigen ein Informationssymbol an.
-- `tip` Hinweise sind violett und zeigen ein Raketensymbol an.
-- `caution` Hinweise sind gelb und zeigen ein dreieckiges Warnsymbol an.
-- `danger` Hinweise sind rot und zeigen ein achteckiges Warnsymbol an.
+- `note` Hinweise (die Standardeinstellung) sind blau und zeigen ein Informationsicon an.
+- `tip` Hinweise sind violett und zeigen ein Raketenicon an.
+- `caution` Hinweise sind gelb und zeigen ein dreieckiges Warnicon an.
+- `danger` Hinweise sind rot und zeigen ein achteckiges Warnicon an.
 
 ### `title`
 

--- a/docs/src/content/docs/de/components/cards.mdx
+++ b/docs/src/content/docs/de/components/cards.mdx
@@ -55,9 +55,9 @@ Interessante Inhalte, die du hervorheben möchtest.
 
 </Preview>
 
-### Hinzufügen von Symbolen zu Karten
+### Hinzufügen von Icons zu Karten
 
-Füge ein Symbol in eine Karte ein, indem du das Attribut [`icon`](#icon) auf den Namen [eines von Starlights eingebauten Symbolen](/de/reference/icons/#alle-symbole) setzt.
+Füge ein Icon in eine Karte ein, indem du das Attribut [`icon`](#icon) auf den Namen [eines von Starlights eingebauten Icons](/de/reference/icons/#alle-icons) setzt.
 
 <Preview>
 
@@ -107,4 +107,4 @@ Der Titel der anzuzeigenden Karte.
 
 **Typ:** `string`
 
-Eine Karte kann ein `icon`-Attribut enthalten, das auf den Namen [eines von Starlights eingebauten Icons](/de/reference/icons/#alle-symbole) gesetzt ist.
+Eine Karte kann ein `icon`-Attribut enthalten, das auf den Namen [eines von Starlights eingebauten Icons](/de/reference/icons/#alle-icons) gesetzt ist.

--- a/docs/src/content/docs/de/components/file-tree.mdx
+++ b/docs/src/content/docs/de/components/file-tree.mdx
@@ -1,11 +1,11 @@
 ---
 title: Verzeichnisbaum
-description: Lerne, wie du die Struktur eines Verzeichnisses mit Dateisymbolen und einklappbaren Unterverzeichnissen in Starlight anzeigen kannst.
+description: Lerne, wie du die Struktur eines Verzeichnisses mit Dateiicons und einklappbaren Unterverzeichnissen in Starlight anzeigen kannst.
 ---
 
 import { FileTree } from '@astrojs/starlight/components';
 
-Um die Struktur eines Verzeichnisses mit Dateisymbolen und einklappbaren Unterverzeichnissen anzuzeigen, verwende die Komponente `<FileTree>`.
+Um die Struktur eines Verzeichnisses mit Dateiicons und einklappbaren Unterverzeichnissen anzuzeigen, verwende die Komponente `<FileTree>`.
 
 import Preview from '~/components/component-preview.astro';
 
@@ -34,7 +34,7 @@ import { FileTree } from '@astrojs/starlight/components';
 
 ## Verwendung
 
-Zeige einen Dateibaum mit Dateisymbolen und zusammenklappbaren Unterverzeichnissen unter Verwendung der Komponente `<FileTree>` an.
+Zeige einen Dateibaum mit Dateiicons und zusammenklappbaren Unterverzeichnissen unter Verwendung der Komponente `<FileTree>` an.
 
 Gib die Struktur deiner Dateien und Verzeichnisse mit einer [ungeordneten Markdown-Liste](https://www.markdownguide.org/basic-syntax/#unordered-lists) innerhalb von `<FileTree>` an.
 Erstelle ein Unterverzeichnis mit einer verschachtelten Liste oder füge ein `/` am Ende eines Listenelements hinzu, um es als Verzeichnis ohne spezifischen Inhalt darzustellen.

--- a/docs/src/content/docs/de/components/icons.mdx
+++ b/docs/src/content/docs/de/components/icons.mdx
@@ -1,11 +1,11 @@
 ---
-title: Symbole
-description: Erfahre, wie du Symbole in Starlight anzeigen kannst.
+title: Icons
+description: Erfahre, wie du Icons in Starlight anzeigen kannst.
 ---
 
 import { Icon } from '@astrojs/starlight/components';
 
-Um Symbole aus Starlights [eingebautem Symbol-Set](/de/reference/icons/#alle-symbole) anzuzeigen, verwende die `<Icon>` Komponente.
+Um Icons aus Starlights [eingebautem Icon-Set](/de/reference/icons/#alle-icons) anzuzeigen, verwende die `<Icon>` Komponente.
 
 import Preview from '~/components/component-preview.astro';
 
@@ -28,8 +28,8 @@ import { Icon } from '@astrojs/starlight/components';
 
 ## Verwendung
 
-Zeigt ein Symbol mit der Komponente `<Icon>` an.
-Ein Symbole benötigt einen [`name`](#name), der auf [eines der in Starlight eingebauten Icons](/de/reference/icons/#alle-symbole) gesetzt ist, und kann optional ein [`label`](#label) enthalten, um Kontext für Screenreader zu liefern.
+Zeigt ein Icon mit der Komponente `<Icon>` an.
+Ein Icon benötigt einen [`name`](#name), der auf [eines der in Starlight eingebauten Icons](/de/reference/icons/#alle-icons) gesetzt ist, und kann optional ein [`label`](#label) enthalten, um Kontext für Screenreader zu liefern.
 
 <Preview>
 
@@ -56,10 +56,10 @@ import { Icon } from '@astrojs/starlight/components';
 
 </Preview>
 
-### Anpassen von Symbolen
+### Anpassen von Icons
 
-Die Attribute [`size`](#size) und [`color`](#color) können verwendet werden, um das Aussehen des Symbols mit CSS-Einheiten und Farbwerten anzupassen.
-Das Attribut [`class`](#class) kann verwendet werden, um dem Symbol eigene CSS-Klassen hinzuzufügen.
+Die Attribute [`size`](#size) und [`color`](#color) können verwendet werden, um das Aussehen des Icons mit CSS-Einheiten und Farbwerten anzupassen.
+Das Attribut [`class`](#class) kann verwendet werden, um dem Icon eigene CSS-Klassen hinzuzufügen.
 
 <Preview>
 
@@ -97,7 +97,7 @@ Die Komponente `<Icon>` akzeptiert die folgenden Eigenschaften:
 **Erforderlich**  
 **Typ:** [`StarlightIcon`](/de/reference/icons/#starlighticon-typ)
 
-Der Name des anzuzeigenden Symbols wird auf [eines der in Starlight integrierten Symbole](/de/reference/icons/#alle-symbole) gesetzt.
+Der Name des anzuzeigenden Icons wird auf [eines der in Starlight integrierten Icons](/de/reference/icons/#alle-icons) gesetzt.
 
 ### `label`
 
@@ -105,24 +105,24 @@ Der Name des anzuzeigenden Symbols wird auf [eines der in Starlight integrierten
 
 Eine optionale Beschriftung, die den Kontext für unterstützende Technologien wie Bildschirm&shy;lesegeräte liefert.
 
-Wenn `label` nicht gesetzt ist, wird das Symbol von assistiven Technologien vollständig ausgeblendet.
-In diesem Fall ist darauf zu achten, dass der Kontext auch ohne das Symbol verständlich ist.
-Ein Link, der nur das Symbol enthält, **muss** das Attribut `label` enthalten, um zugänglich zu sein, aber wenn ein Link Text enthält und das Symbol rein dekorativ ist, kann es sinnvoll sein, das `label` wegzulassen.
+Wenn `label` nicht gesetzt ist, wird das Icon von assistiven Technologien vollständig ausgeblendet.
+In diesem Fall ist darauf zu achten, dass der Kontext auch ohne das Icon verständlich ist.
+Ein Link, der nur das Icon enthält, **muss** das Attribut `label` enthalten, um zugänglich zu sein, aber wenn ein Link Text enthält und das Icon rein dekorativ ist, kann es sinnvoll sein, das `label` wegzulassen.
 
 ### `size`
 
 **Typ:** `string`
 
-Die Größe des Symbols in CSS-Einheiten.
+Die Größe des Icons in CSS-Einheiten.
 
 ### `color`
 
 **Typ:** `string`
 
-Die Farbe des Symbols unter Verwendung eines CSS-Farbwerts.
+Die Farbe des Icons unter Verwendung eines CSS-Farbwerts.
 
 ### `class`
 
 **Typ:** `string`
 
-Benutzerdefinierte CSS-Klassen, die dem Symbol hinzugefügt werden können.
+Benutzerdefinierte CSS-Klassen, die dem Icon hinzugefügt werden können.

--- a/docs/src/content/docs/de/components/link-buttons.mdx
+++ b/docs/src/content/docs/de/components/link-buttons.mdx
@@ -63,11 +63,11 @@ Konfiguration Referenz
 
 </Preview>
 
-### Hinzufügen von Symbolen zu Link-Buttons
+### Hinzufügen von Icons zu Link-Buttons
 
-Füge ein Symbol in einen Link-Button ein, indem du das Attribut [`icon`](#icon) auf den Namen [eines von Starlights eingebauten Symbolen](/de/reference/icons/#alle-symbole) setzt.
+Füge ein Icon in einen Link-Button ein, indem du das Attribut [`icon`](#icon) auf den Namen [eines von Starlights eingebauten Icons](/de/reference/icons/#alle-icons) setzt.
 
-Das Attribut [`iconPlacement`](#iconplacement) kann verwendet werden, um das Symbol vor dem Text zu platzieren, indem man es auf `start` setzt (Standardwert ist `end`).
+Das Attribut [`iconPlacement`](#iconplacement) kann verwendet werden, um das Icon vor dem Text zu platzieren, indem man es auf `start` setzt (Standardwert ist `end`).
 
 <Preview>
 
@@ -135,11 +135,11 @@ Setze auf `primary` für einen auffälligen Call-to-Action-Link mit der Akzentfa
 
 **Typ:** `string`
 
-Ein Link-Button kann ein `icon`-Attribut enthalten, das auf den Namen [eines von Starlights eingebauten Symbolen](/de/reference/icons/#alle-symbole) gesetzt ist.
+Ein Link-Button kann ein `icon`-Attribut enthalten, das auf den Namen [eines von Starlights eingebauten Icons](/de/reference/icons/#alle-icons) gesetzt ist.
 
 ### `iconPlacement`
 
 **Typ:** `'start' | 'end'`  
 **Standard:** `'end'`
 
-Bestimmt die Platzierung des Symbols im Verhältnis zum Text des Link-Buttons.
+Bestimmt die Platzierung des Icons im Verhältnis zum Text des Link-Buttons.

--- a/docs/src/content/docs/de/components/tabs.mdx
+++ b/docs/src/content/docs/de/components/tabs.mdx
@@ -143,9 +143,9 @@ _Ein paar Exoplaneten:_
 
 </Preview>
 
-### Hinzufügen von Symbolen zu Registerkarten
+### Hinzufügen von Icons zu Registerkarten
 
-Füge ein Symbol in ein Tab-Element ein, indem du das Attribut [`icon`](#icon) auf den Namen [eines der in Starlight eingebauten Symbole](/de/reference/icons/#alle-symbole) setzt, um ein Symbol neben dem Label anzuzeigen.
+Füge ein Icon in ein Tab-Element ein, indem du das Attribut [`icon`](#icon) auf den Namen [eines der in Starlight eingebauten Icons](/de/reference/icons/#alle-icons) setzt, um ein Icon neben dem Label anzuzeigen.
 
 <Preview>
 
@@ -218,4 +218,4 @@ Eine Registerkarte muss ein Attribut `label` enthalten, das auf den Text gesetzt
 
 **Typ:** `string`
 
-Jedes Tab-Element kann ein `icon`-Attribut enthalten, das auf den Namen [eines von Starlights eingebauten Icons](/de/reference/icons/#alle-symbole) gesetzt ist, um ein Icon neben dem Label anzuzeigen.
+Jedes Tab-Element kann ein `icon`-Attribut enthalten, das auf den Namen [eines von Starlights eingebauten Icons](/de/reference/icons/#alle-icons) gesetzt ist, um ein Icon neben dem Label anzuzeigen.

--- a/docs/src/content/docs/de/reference/icons.mdx
+++ b/docs/src/content/docs/de/reference/icons.mdx
@@ -1,20 +1,20 @@
 ---
-title: Symbole Referenz
-description: Eine Übersicht über alle in Starlight verfügbaren Symbole.
+title: Icons Referenz
+description: Eine Übersicht über alle in Starlight verfügbaren Icons.
 sidebar:
-  label: Symbole
+  label: Icons
 ---
 
 Starlight bietet eine Reihe von eingebauten Icons, die du mit Hilfe der Komponente `<Icon>` in deinem Inhalt anzeigen kannst.
 
-## Symbole verwenden
+## Icons verwenden
 
-Symbole können mit der Komponente [`<Icon>`](/de/components/icons/) angezeigt werden.
+Icons können mit der Komponente [`<Icon>`](/de/components/icons/) angezeigt werden.
 Sie werden auch häufig in anderen Komponenten verwendet, wie [Karten](/de/components/cards/) oder Umgebungen wie [Hero-Komponenten](/de/reference/frontmatter/#hero).
 
 ## `StarlightIcon`-Typ
 
-Verwende den TypeScript-Typ `StarlightIcon`, um die Namen von [Starlights eingebauten Icons](#alle-symbole) zu referenzieren.
+Verwende den TypeScript-Typ `StarlightIcon`, um die Namen von [Starlights eingebauten Icons](#alle-icons) zu referenzieren.
 
 ```ts {2} /icon: (StarlightIcon)/
 // src/icon.ts
@@ -25,9 +25,9 @@ function getIconLabel(icon: StarlightIcon) {
 }
 ```
 
-## Alle Symbole
+## Alle Icons
 
-Nachstehend findest du eine Liste aller verfügbaren Symbole mit den zugehörigen Namen. Klicke auf ein Symbol, um den Namen in deine Zwischenablage zu kopieren.
+Nachstehend findest du eine Liste aller verfügbaren Icons mit den zugehörigen Namen. Klicke auf ein Icon, um den Namen in deine Zwischenablage zu kopieren.
 
 import IconsList from '~/components/icons-list.astro';
 

--- a/docs/src/content/docs/de/reference/overrides.md
+++ b/docs/src/content/docs/de/reference/overrides.md
@@ -115,7 +115,7 @@ So kannst du eine Benutzeroberfläche für alternative Suchanbieter hinzufügen,
 
 **Standardkomponente:** [`SocialIcons.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/SocialIcons.astro)
 
-Diese Komponente wird in der Kopfzeile der Website gerendert und enthält Links zu sozialen Symbolen.
+Diese Komponente wird in der Kopfzeile der Website gerendert und enthält soziale Icon-Links.
 Die Standard&shy;implementierung verwendet die Option [`social`](/de/reference/configuration/#social) in der Starlight-Konfiguration, um Icons und Links darzustellen.
 
 #### `ThemeSelect`

--- a/docs/src/content/docs/de/resources/community-content.mdx
+++ b/docs/src/content/docs/de/resources/community-content.mdx
@@ -77,7 +77,7 @@ Erkunde die von der Community erstellten Inhalte, die von Starlight-Benutzern ge
 	<LinkCard
 		href="https://hideoo.dev/notes/starlight-third-party-icon-sets"
 		title="Iconsets von Drittanbietern in Starlight verwenden"
-		description="Eine Anleitung zur Verwendung von unplugin-icons, um die Auswahl an verfügbaren Symbolen für Starlight zu erweitern"
+		description="Eine Anleitung zur Verwendung von unplugin-icons, um die Auswahl an verfügbaren Icons für Starlight zu erweitern"
 	/>
 	<LinkCard
 		href="https://hideoo.dev/notes/starlight-custom-html-head"


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- The German translation currently uses `Symbol` as a translation of `Icon`. Maybe we should change it to `Icon` because it is also a commonly used work in German.
- Native speaker needed!

Some words read a little bit weird now tho:

- `Dateiicon` (maybe `Datei-Icon`?)

Okay, maybe it's only one word :)

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
