### PR TITLE
add SidebarItem to @astrojs/starlight/types export

### DIFF
--- a/packages/starlight/types.ts
+++ b/packages/starlight/types.ts
@@ -1,4 +1,5 @@
 export type { StarlightConfig } from './utils/user-config';
+export type { SidebarItem } from './schemas/sidebar';
 export type {
 	StarlightPlugin,
 	StarlightUserConfigWithPlugins as StarlightUserConfig,


### PR DESCRIPTION
#### Description

I want to separate out the sidebar configuration into it's own file to make it easier for non tech people to know what to edit.
and also it's getting quite large with all the sections we have.

But I want to get type safety in this file, and currently the SidebarItem type is not exposed in the exports.


So this PR adds the SidebarItem type export to @astrojs/starlight/types

- Closes #2951