### PR TITLE
improve mobile preferences position in sidebar

### DIFF
--- a/packages/starlight/components/MobileMenuFooter.astro
+++ b/packages/starlight/components/MobileMenuFooter.astro
@@ -25,8 +25,8 @@ import ThemeSelect from 'virtual:starlight/components/ThemeSelect';
 	.mobile-preferences {
 		justify-content: space-between;
 		flex-wrap: wrap;
-		border-top: 1px solid var(--sl-color-gray-6);
+		border-bottom: 1px solid var(--sl-color-gray-6);
 		column-gap: 1rem;
-		padding: 0.5rem 0;
+		padding: 0 0.5rem;
 	}
 </style>

--- a/packages/starlight/components/Sidebar.astro
+++ b/packages/starlight/components/Sidebar.astro
@@ -5,11 +5,11 @@ import SidebarSublist from './SidebarSublist.astro';
 
 const { sidebar } = Astro.locals.starlightRoute;
 ---
+<div class="md:sl-hidden">
+	<MobileMenuFooter />
+</div>
 
 <SidebarPersister>
 	<SidebarSublist sublist={sidebar} />
 </SidebarPersister>
 
-<div class="md:sl-hidden">
-	<MobileMenuFooter />
-</div>

--- a/packages/starlight/components/SidebarSublist.astro
+++ b/packages/starlight/components/SidebarSublist.astro
@@ -82,6 +82,10 @@ const { sublist, nested } = Astro.props;
 		color: var(--sl-color-white);
 	}
 
+	.top-level {
+		padding-bottom: 16px;
+	}
+
 	.top-level > li + li {
 		margin-top: 0.75rem;
 	}


### PR DESCRIPTION
#### Description

- As a first-time user opening the docs site, language or color scheme is probably the first thing they expect to update according to their preference.
- While these preferences are easily visible on the desktop, on mobile they are not that straight-forward to find.
- User has to scroll to the very end of the sidebar list to discover the preferences section. The longer the list, the lesser that chances that the user discovers this menu.

### Live Link
- Please find the updated changes in the link below. (use mobile-view)
- [https://starlight-mobile-preferences.netlify.app/getting-started](https://starlight-mobile-preferences.netlify.app/getting-started)

### How other frameworks do this
<details>

<summary>VitePress has a separate menu for preferences.</summary>

![vitepress](https://github.com/user-attachments/assets/da421b3d-6283-429e-91d9-d3a474691ba5)

</details>
<details>

<summary>Docusarus has it's color theme switch at the top but the language selection is at the bottom of the sidbar items. (that too, after clicking the `← Back to main menu` button)</summary>

![docusaurus01](https://github.com/user-attachments/assets/e751579a-6e3e-4f1b-b7ab-ba6ae3123e64)
![docusaurus02](https://github.com/user-attachments/assets/116415ac-67da-4d0f-a942-ae5496c5d9ee)

</details>

### Changes
- Move mobile preferences position from bottom of sidebar to the top of sidebar
- update `MobileMenuFooter.mobile-preferences` `padding` and `border` to align it properly with the SidebarSublist below

- add `padding-bottom` to `SidebarSublist.top-level` to allow some breathing room for the last item in SidebarSublist

<details>

<summary>Before</summary>

![before01](https://github.com/user-attachments/assets/8cd98493-6be8-48b2-8450-5a05b6fdda44)
![before02](https://github.com/user-attachments/assets/b103a9a8-bfe9-4af7-8eb3-b793a84d0bdc)

</details>

<details>

<summary>After</summary>

![after01](https://github.com/user-attachments/assets/3bfa8c65-2224-41a4-b2d5-88e25f52ae1d)
![after02](https://github.com/user-attachments/assets/87dc930c-e492-4aa0-9151-8bef04b86b7b)

</details>