### PR TITLE
Disable renovate docker updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,7 @@
 		':ignoreModulesAndTests',
 		'workarounds:all',
 		'helpers:pinGitHubActionDigestsToSemver',
+		'docker:disable',
 	],
 	rangeStrategy: 'bump',
 	ignorePaths: ['**/node_modules/**'],


### PR DESCRIPTION
Based on https://docs.renovatebot.com/docker/#disable-all-docker-renovation, this PR disables all Docker renovations, e.g. like this one https://github.com/withastro/starlight/pull/2981