### PR TITLE
Update labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,42 +2,49 @@
 
 '🚨 action':
   - changed-files:
-      - .github/workflows/**
+      - any-glob-to-any-file:
+          - .github/workflows/**
 
 i18n:
   - changed-files:
-      - docs/src/content/docs/de/**/*
-      - docs/src/content/docs/es/**/*
-      - docs/src/content/docs/fr/**/*
-      - docs/src/content/docs/it/**/*
-      - docs/src/content/docs/ja/**/*
-      - docs/src/content/docs/zh-cn/**/*
-      - docs/src/content/docs/pt-br/**/*
-      - docs/src/content/docs/pt-pt/**/*
-      - docs/src/content/docs/ko/**/*
-      - docs/src/content/docs/ru/**/*
-      - docs/src/content/docs/id/**/*
-      - docs/src/content/docs/tr/**/*
-      - docs/src/content/docs/hi/**/*
-      - docs/src/content/docs/da/**/*
-      - docs/src/content/docs/uk/**/*
+      - any-glob-to-any-file:
+          - docs/src/content/docs/de/**/*
+          - docs/src/content/docs/es/**/*
+          - docs/src/content/docs/fr/**/*
+          - docs/src/content/docs/it/**/*
+          - docs/src/content/docs/ja/**/*
+          - docs/src/content/docs/zh-cn/**/*
+          - docs/src/content/docs/pt-br/**/*
+          - docs/src/content/docs/pt-pt/**/*
+          - docs/src/content/docs/ko/**/*
+          - docs/src/content/docs/ru/**/*
+          - docs/src/content/docs/id/**/*
+          - docs/src/content/docs/tr/**/*
+          - docs/src/content/docs/hi/**/*
+          - docs/src/content/docs/da/**/*
+          - docs/src/content/docs/uk/**/*
 
 '🌟 core':
   - changed-files:
-      - packages/starlight/**
+      - any-glob-to-any-file:
+          - packages/starlight/**
 
 '🌟 tailwind':
   - changed-files:
-      - packages/tailwind/**
+      - any-glob-to-any-file:
+          - packages/tailwind/**
 
 '🌟 docsearch':
   - changed-files:
-      - packages/docsearch/**
+      - any-glob-to-any-file:
+          - packages/docsearch/**
 
 '🌟 markdoc':
   - changed-files:
-      - packages/markdoc/**
+      - any-glob-to-any-file:
+          - packages/markdoc/**
 
 '📚 docs':
   - changed-files:
-      - docs/**
+      - any-glob-to-any-file:
+          - docs/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,36 +1,43 @@
 # See https://github.com/actions/labeler
 
 '🚨 action':
-  - .github/workflows/**
+  - changed-files:
+      - .github/workflows/**
 
 i18n:
-  - docs/src/content/docs/de/**/*
-  - docs/src/content/docs/es/**/*
-  - docs/src/content/docs/fr/**/*
-  - docs/src/content/docs/it/**/*
-  - docs/src/content/docs/ja/**/*
-  - docs/src/content/docs/zh-cn/**/*
-  - docs/src/content/docs/pt-br/**/*
-  - docs/src/content/docs/pt-pt/**/*
-  - docs/src/content/docs/ko/**/*
-  - docs/src/content/docs/ru/**/*
-  - docs/src/content/docs/id/**/*
-  - docs/src/content/docs/tr/**/*
-  - docs/src/content/docs/hi/**/*
-  - docs/src/content/docs/da/**/*
-  - docs/src/content/docs/uk/**/*
+  - changed-files:
+      - docs/src/content/docs/de/**/*
+      - docs/src/content/docs/es/**/*
+      - docs/src/content/docs/fr/**/*
+      - docs/src/content/docs/it/**/*
+      - docs/src/content/docs/ja/**/*
+      - docs/src/content/docs/zh-cn/**/*
+      - docs/src/content/docs/pt-br/**/*
+      - docs/src/content/docs/pt-pt/**/*
+      - docs/src/content/docs/ko/**/*
+      - docs/src/content/docs/ru/**/*
+      - docs/src/content/docs/id/**/*
+      - docs/src/content/docs/tr/**/*
+      - docs/src/content/docs/hi/**/*
+      - docs/src/content/docs/da/**/*
+      - docs/src/content/docs/uk/**/*
 
 '🌟 core':
-  - packages/starlight/**
+  - changed-files:
+      - packages/starlight/**
 
 '🌟 tailwind':
-  - packages/tailwind/**
+  - changed-files:
+      - packages/tailwind/**
 
 '🌟 docsearch':
-  - packages/docsearch/**
+  - changed-files:
+      - packages/docsearch/**
 
 '🌟 markdoc':
-  - packages/markdoc/**
+  - changed-files:
+      - packages/markdoc/**
 
 '📚 docs':
-  - docs/**
+  - changed-files:
+      - docs/**


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

This aims to fix the [GitHub labeler action](https://github.com/actions/labeler) that runs for every PR for compatibility with v5.

Their docs are pretty bad, but IIUC, they introduced different match types which means we need to use a `changed-files` key for each of our existing labels.