### PR TITLE
Disable Renovate package manager updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,5 +21,11 @@
 			matchDepTypes: ['devDependencies', 'dependencies', 'peerDependencies'],
 			enabled: false,
 		},
+		{
+			description: 'Disable package manager version updates',
+			matchPackageNames: ['pnpm'],
+			matchDepTypes: ['packageManager'],
+			enabled: false,
+		},
 	],
 }


### PR DESCRIPTION
This PR should hopefully disable `packageManager` updates.