### PR TITLE
fix: Search ranking on merge indexes

### DIFF
--- a/.changeset/five-glasses-shout.md
+++ b/.changeset/five-glasses-shout.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fixes default ranking of merged indexes when using multi-site search

--- a/packages/starlight/schemas/pagefind.ts
+++ b/packages/starlight/schemas/pagefind.ts
@@ -66,10 +66,8 @@ const pagefindIndexOptionsSchema = z.object({
 	language: z.string().optional(),
 	/**
 	 * Configure how search result rankings are calculated by Pagefind.
-	 * 
-	 * We applied the default value for the merged indexes in order to have the same search
-	 * conditions on them and do not let them have a better scoring than the current site.
 	 */
+	 // We apply a default value to merged indexes in order to share the same ranking for them and the current site when not set explicitly.
 	ranking: pagefindRankingWeightsSchema.default({}),
 });
 

--- a/packages/starlight/schemas/pagefind.ts
+++ b/packages/starlight/schemas/pagefind.ts
@@ -66,8 +66,11 @@ const pagefindIndexOptionsSchema = z.object({
 	language: z.string().optional(),
 	/**
 	 * Configure how search result rankings are calculated by Pagefind.
+	 * 
+	 * We applied the default value for the merged indexes in order to have the same search
+	 * conditions on them and do not let them have a better scoring than the current site.
 	 */
-	ranking: pagefindRankingWeightsSchema.optional(),
+	ranking: pagefindRankingWeightsSchema.default({}),
 });
 
 const pagefindSchema = z.object({


### PR DESCRIPTION
## Description

This PR:
- Closes #2989
- Set up default values to the ranking property of merged indexes in pagefind to prevent search collision research between the current site and the sites hosting the merged indexes
- This PR do not changes starlight visual

## Test

I've tested locally with 2 variants of the starlight's documentation:
1. The first variant is the one from the main branch, without any merged indexes nor any modifications
2. The second one is nearly the same as the one from the main branch, with little modifications:
    1. A markdown file changed, replacing `climate impact` by `climate exchange`
    2. And a merge index pointing to the first site on pagefind configuration

To test it I searched for `climate exchange` (the modified text) on the second site.

Before applying the fix, search shown the original site as first result, and after the fix, modified site was first in search result (due to corp. network policies I can't upload screenshot right now to prove it)

### Details

I used this script to build and serve locally the 2 variants:
```sh
#! /bin/bash

echo "Installing serve globaly"
npm i -g serve

echo "Building the documentation for port 3001"
if [ -d "dist-3001" ]; then
    rm -rf "dist-3001"
fi
pnpm build
mv dist dist-3001

echo "Changing the content of the documentation"
sed -i 's/climate impact/climate exchange/' src/content/docs/environmental-impact.md
sed -i '52i\ \t\t\tpagefind: { indexWeight: 2.0, mergeIndex: [{ bundlePath: "http://localhost:3001/pagefind/", indexWeight: 0.5, }] },' astro.config.mjs


echo "Building the documentation for port 3002"
if [ -d "dist-3002" ]; then
    rm -rf "dist-3002"
fi
pnpm build
mv dist dist-3002

echo "Serving the 2 sites"
serve -l 3001 --cors ./dist-3001 &
serve -l 3002 --cors ./dist-3002
```