### PR TITLE
Disable Renovate Dashboard

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
 	$schema: 'https://docs.renovatebot.com/renovate-schema.json',
 	extends: [
-		':dependencyDashboard',
+		':disableDependencyDashboard',
 		':semanticPrefixFixDepsChoreOthers',
 		':ignoreModulesAndTests',
 		'workarounds:all',


### PR DESCRIPTION
As discussed today in Talking & Doc'ing, considering we are at the moment only using Renovate for GitHub Actions updates, we want to mostly rely on new pull requests rather than the dashboard.

This PR [disables](https://docs.renovatebot.com/key-concepts/dashboard/#how-to-disable-the-dashboard) the Renovate Dashboard.