### PR TITLE
Add new `link` option to `LogoConfig`

### DIFF
--- a/.changeset/long-trains-jog.md
+++ b/.changeset/long-trains-jog.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Allow for custom link target when clicking logo

--- a/docs/src/content/docs/guides/customization.mdx
+++ b/docs/src/content/docs/guides/customization.mdx
@@ -50,12 +50,14 @@ Adding a custom logo to the site header is a quick way to add your individual br
 By default, the logo will be displayed alongside your site’s `title`.
 If your logo image already includes the site title, you can visually hide the title text by setting the `replacesTitle` option.
 The `title` text will still be included for screen readers so that the header remains accessible.
+Use the `href` option to define a custom destination when clicking the logo, in case you prefer a value different from `site`.
 
-```js {5}
+```js {5-6}
 starlight({
   title: 'Docs With My Logo',
   logo: {
     src: './src/assets/my-logo.svg',
+    href: 'my-domain.example',
     replacesTitle: true,
   },
 }),

--- a/packages/starlight/components/SiteTitle.astro
+++ b/packages/starlight/components/SiteTitle.astro
@@ -4,7 +4,7 @@ import config from 'virtual:starlight/user-config';
 const { siteTitle, siteTitleHref } = Astro.locals.starlightRoute;
 ---
 
-<a href={siteTitleHref} class="site-title sl-flex">
+<a href={config?.logo?.href || siteTitleHref} class="site-title sl-flex">
 	{
 		config.logo && logos.dark && (
 			<>

--- a/packages/starlight/schemas/logo.ts
+++ b/packages/starlight/schemas/logo.ts
@@ -6,6 +6,8 @@ export const LogoConfigSchema = () =>
 			z.object({
 				/** Source of the image file to use. */
 				src: z.string(),
+				/** Link to follow when clicking the logo. */
+				href: z.string().optional(),
 				/** Alternative text description of the logo. */
 				alt: z.string().default(''),
 				/** Set to `true` to hide the site title text and only show the logo. */
@@ -16,6 +18,8 @@ export const LogoConfigSchema = () =>
 				dark: z.string(),
 				/** Source of the image file to use in light mode. */
 				light: z.string(),
+				/** Link to follow when clicking the logo. */
+				href: z.string().optional(),
 				/** Alternative text description of the logo. */
 				alt: z.string().default(''),
 				/** Set to `true` to hide the site title text and only show the logo. */


### PR DESCRIPTION
This PR adds a new `link` option to `LogoConfig` so that it becomes possible to choose a destination when clicking the logo.

This comes in handy when it's desired to link back from the docs to the product's website.