### PR TITLE
i18n(fr): update `resources/themes`

### DIFF
--- a/docs/src/content/docs/fr/resources/themes.mdx
+++ b/docs/src/content/docs/fr/resources/themes.mdx
@@ -67,6 +67,12 @@ Installez un thème créé par la communauté pour personnaliser rapidement l'ap
 			href: 'https://delucis.github.io/starlight-theme-flexoki/',
 			previews: { light: 'flexoki-light.png', dark: 'flexoki-dark.png' },
 		},
+		{
+			title: 'Starlight Nova',
+			description: 'Un superbe thème moderne pour Starlight.',
+			href: 'https://starlight-theme-nova.pages.dev/',
+			previews: { light: 'nova-light.png', dark: 'nova-dark.png' },
+		},
 	]}
 />
 


### PR DESCRIPTION
This PR updates the French version of the `resources/themes` page with the changes from #3012.