### PR TITLE
Fix list styling issue

### DIFF
--- a/.changeset/calm-cobras-breathe.md
+++ b/.changeset/calm-cobras-breathe.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes a potential list styling issue if the last element of a list item is a `<script>` tag.

--- a/packages/starlight/style/markdown.css
+++ b/packages/starlight/style/markdown.css
@@ -24,7 +24,29 @@
 
 .sl-markdown-content
 	li
-	> :last-child:not(li, ul, ol, a, strong, em, del, span, input, code, br, :where(.not-content *)) {
+	> :is(
+		:last-child:not(
+				li,
+				ul,
+				ol,
+				a,
+				strong,
+				em,
+				del,
+				span,
+				input,
+				code,
+				br,
+				script,
+				:where(.not-content *)
+			),
+			/**
+			 * For list items ending with 1 or multiple script elements (`:has(~ script:last-child)`), we
+			 * need to style the last non-script element (`:not(script)`) that doesn't have a subsequent
+			 * sibling that is not a script (`:not(:has(~ :not(script)))`).
+			 */
+		:not(script):has(~ script:last-child):not(:has(~ :not(script)))
+	) {
 	margin-bottom: 1.25rem;
 }
 


### PR DESCRIPTION
#### Description

Initially reported in Discord by Chris and Sarah, this PR fixes a list styling issue that can happen when the last child element of a list item is a script tag.

This can naturally happen in Starlight, e.g. in a list of steps where the last element of a step is the first occurence of a set of tabs in the page. The issue is visible in the Starlight documentation of the `<Steps>` component:

|         | Before                                          | After           |
| ------- | ----------------------------------------------- | --------------- |
| URL     | https://starlight.astro.build/components/steps/ | // TODO(HiDeoo) |
| Preview | <img width="746" alt="SCR-20250327-kkgd" src="https://github.com/user-attachments/assets/3ec5a179-69e2-4cea-b001-b7cad4e707f6" /> | <img width="746" alt="SCR-20250327-kkkr" src="https://github.com/user-attachments/assets/302e66b8-8533-416f-b529-74c13e25ee90" /> |

We cannot really target the built-in tabs component to fix this issue, as we could have more components that could lead to the same issue in the future, or the user could have their own component that triggers the issue.

We also cannot fix this issue if only the last child element of a list item is a script tag, as even if rare, the last n child elements could be script tags too.

This leads to quite the complex selector to try to handle all cases, I tried to comment it as much as possible to make it more understandable.