### PR TITLE
fix(core): `isFallback` type is `true` instead of `boolean`

### DIFF
--- a/.changeset/brown-bottles-stare.md
+++ b/.changeset/brown-bottles-stare.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Updates the type of the `isFallback` field in route data from `true` to `boolean`, keeping it optional but allowing `false` as a possible value.

--- a/packages/starlight/__tests__/basics/starlight-page-route-data.test.ts
+++ b/packages/starlight/__tests__/basics/starlight-page-route-data.test.ts
@@ -64,11 +64,13 @@ test('adds custom data to route shape', async () => {
 		hasSidebar: false,
 		dir: 'rtl',
 		lang: 'ks',
+		isFallback: true,
 	};
 	const data = await generateStarlightPageRouteData({ props, url: starlightPageUrl });
 	expect(data.hasSidebar).toBe(props.hasSidebar);
 	expect(data.entryMeta.dir).toBe(props.dir);
 	expect(data.entryMeta.lang).toBe(props.lang);
+	expect(data.isFallback).toBe(props.isFallback);
 });
 
 test('adds custom frontmatter data to route shape', async () => {

--- a/packages/starlight/utils/routing/types.ts
+++ b/packages/starlight/utils/routing/types.ts
@@ -68,7 +68,7 @@ export interface Route extends LocaleData {
 	/** The slug or unique ID if using the `legacy.collections` flag. */
 	id: string;
 	/** True if this page is untranslated in the current language and using fallback content from the default locale. */
-	isFallback?: true;
+	isFallback?: boolean;
 	[key: string]: unknown;
 }
 

--- a/packages/starlight/utils/routing/types.ts
+++ b/packages/starlight/utils/routing/types.ts
@@ -67,8 +67,8 @@ export interface Route extends LocaleData {
 	slug: string;
 	/** The slug or unique ID if using the `legacy.collections` flag. */
 	id: string;
-	/** True if this page is untranslated in the current language and using fallback content from the default locale. */
-	isFallback?: true;
+	/** Whether this page is untranslated in the current language and using fallback content from the default locale. */
+	isFallback?: boolean;
 	[key: string]: unknown;
 }
 

--- a/packages/starlight/utils/routing/types.ts
+++ b/packages/starlight/utils/routing/types.ts
@@ -68,7 +68,7 @@ export interface Route extends LocaleData {
 	/** The slug or unique ID if using the `legacy.collections` flag. */
 	id: string;
 	/** True if this page is untranslated in the current language and using fallback content from the default locale. */
-	isFallback?: boolean;
+	isFallback?: true;
 	[key: string]: unknown;
 }
 

--- a/packages/starlight/utils/starlight-page.ts
+++ b/packages/starlight/utils/starlight-page.ts
@@ -76,12 +76,19 @@ const validateSidebarProp = (
  */
 export type StarlightPageProps = Prettify<
 	// Remove the index signature from `Route`, omit undesired properties and make the rest optional.
-	Partial<Omit<RemoveIndexSignature<PageProps>, 'entry' | 'entryMeta' | 'id' | 'locale' | 'slug'>> &
+	Partial<
+		Omit<
+			RemoveIndexSignature<PageProps>,
+			'entry' | 'entryMeta' | 'id' | 'locale' | 'slug' | 'isFallback'
+		>
+	> &
 		// Add the sidebar definitions for a Starlight page.
 		Partial<Pick<StarlightRouteData, 'hasSidebar'>> & {
 			sidebar?: StarlightUserConfig['sidebar'];
 			// And finally add the Starlight page frontmatter properties in a `frontmatter` property.
 			frontmatter: StarlightPageFrontmatter;
+			// Modified to accept any boolean value instead of just `true`
+			isFallback?: boolean;
 		}
 >;
 

--- a/packages/starlight/utils/starlight-page.ts
+++ b/packages/starlight/utils/starlight-page.ts
@@ -76,19 +76,12 @@ const validateSidebarProp = (
  */
 export type StarlightPageProps = Prettify<
 	// Remove the index signature from `Route`, omit undesired properties and make the rest optional.
-	Partial<
-		Omit<
-			RemoveIndexSignature<PageProps>,
-			'entry' | 'entryMeta' | 'id' | 'locale' | 'slug' | 'isFallback'
-		>
-	> &
+	Partial<Omit<RemoveIndexSignature<PageProps>, 'entry' | 'entryMeta' | 'id' | 'locale' | 'slug'>> &
 		// Add the sidebar definitions for a Starlight page.
 		Partial<Pick<StarlightRouteData, 'hasSidebar'>> & {
 			sidebar?: StarlightUserConfig['sidebar'];
 			// And finally add the Starlight page frontmatter properties in a `frontmatter` property.
 			frontmatter: StarlightPageFrontmatter;
-			// Modified to accept any boolean value instead of just `true`
-			isFallback?: boolean;
 		}
 >;
 
@@ -112,7 +105,7 @@ export async function generateStarlightPageRouteData({
 	props: StarlightPageProps;
 	url: URL;
 }): Promise<StarlightRouteData> {
-	const { isFallback, frontmatter, ...routeProps } = props;
+	const { frontmatter, ...routeProps } = props;
 	const slug = urlToSlug(url);
 	const pageFrontmatter = await getStarlightPageFrontmatter(frontmatter);
 	const id = project.legacyCollections ? `${stripLeadingAndTrailingSlashes(slug)}.md` : slug;
@@ -170,9 +163,6 @@ export async function generateStarlightPageRouteData({
 			slug,
 		}),
 	};
-	if (isFallback) {
-		routeData.isFallback = true;
-	}
 	return routeData;
 }
 


### PR DESCRIPTION
#### Description

This is rather a question / discussion of the decision why the `isFallback` type is defined as type `true` instead of `boolean`:

https://github.com/withastro/starlight/blob/bdb05e704a6cf06a029367f99b6bf2f575e5a5f3/packages/starlight/utils/routing/types.ts#L61-L73

This has the consequence that my editor gives me the warning (when I use `<StarlightPage>`:

![image](https://github.com/user-attachments/assets/1db88572-3b1f-4556-b674-36a49897a14f)

My var `isFallback` is of type boolean: 

![image](https://github.com/user-attachments/assets/04625808-e1f5-4989-b753-dd60b9881737)

I'm not sure if this is an oversight or has a specific reason, therefore I'm creating this as a draft PR...