### PR TITLE
docs: add `credits` type to configuration reference

### DIFF
--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -638,6 +638,9 @@ See the [Plugins Reference](/reference/plugins/) for details about creating your
 
 ### `credits`
 
+**type:** `boolean`  
+**default:** `false`
+
 Enable displaying a “Built with Starlight” link in your site’s footer.
 
 ```js


### PR DESCRIPTION
#### Description

This PR adds the type and default value for the `credits` configuration option in the documentation. Noticed that it was missing while working on a different PR.

The type is fairly obvious, but this should still be documented nevertheless, just for consistency and completeness.
