### PR TITLE
docs: move `starlight-fullview-mode` to plugins list

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -148,6 +148,11 @@ Extend your site with official plugins supported by the Starlight team and commu
 		title="starlight-markdown-blocks"
 		description="Extend Starlight’s Markdown asides syntax with custom block types."
 	/>
+	<LinkCard
+		href="https://github.com/WindMillCode/starlight-fullview-mode"
+		title="starlight-fullview-mode"
+		description="Collapse sidebars and expand content for a fullscreen experience."
+	/>
 </CardGrid>
 
 ## Community tools and integrations
@@ -197,10 +202,4 @@ These community tools and integrations can be used to add features to your Starl
 		title="starlight-to-pdf"
 		description="A CLI tool to convert Starlight websites into PDF files."
 	/>
-	<LinkCard
-		href="https://github.com/WindMillCode/starlight-fullview-mode"
-		title="starlight-fullview-mode"
-		description="Collapse sidebars and expand content for a fullscreen experience."
-	/>
-
 </CardGrid>


### PR DESCRIPTION
#### Description

This PR moves the plugin added in #3037 to the "Community plugins" section instead of the "Community tools and integrations" section (and also remove an extra empty line).
