### PR TITLE
fix(de): replace translation of "icon" in german language [i18nIgnore]

### DIFF
--- a/docs/src/content/docs/de/components/cards.mdx
+++ b/docs/src/content/docs/de/components/cards.mdx
@@ -107,4 +107,4 @@ Der Titel der anzuzeigenden Karte.
 
 **Typ:** `string`
 
-Eine Karte kann ein `icon`-Attribut enthalten, das auf den Namen [eines von Starlights eingebauten Icons](/de/reference/icons/#alle-symbole) gesetzt ist.
+Eine Karte kann ein `icon`-Attribut enthalten, das auf den Namen [eines von Starlights eingebauten Symbolen](/de/reference/icons/#alle-symbole) gesetzt ist.

--- a/docs/src/content/docs/de/components/icons.mdx
+++ b/docs/src/content/docs/de/components/icons.mdx
@@ -29,7 +29,7 @@ import { Icon } from '@astrojs/starlight/components';
 ## Verwendung
 
 Zeigt ein Symbol mit der Komponente `<Icon>` an.
-Ein Symbole benötigt einen [`name`](#name), der auf [eines der in Starlight eingebauten Icons](/de/reference/icons/#alle-symbole) gesetzt ist, und kann optional ein [`label`](#label) enthalten, um Kontext für Screenreader zu liefern.
+Ein Symbole benötigt einen [`name`](#name), der auf [eines der in Starlight eingebauten Symbolen](/de/reference/icons/#alle-symbole) gesetzt ist, und kann optional ein [`label`](#label) enthalten, um Kontext für Screenreader zu liefern.
 
 <Preview>
 

--- a/docs/src/content/docs/de/components/tabs.mdx
+++ b/docs/src/content/docs/de/components/tabs.mdx
@@ -218,4 +218,4 @@ Eine Registerkarte muss ein Attribut `label` enthalten, das auf den Text gesetzt
 
 **Typ:** `string`
 
-Jedes Tab-Element kann ein `icon`-Attribut enthalten, das auf den Namen [eines von Starlights eingebauten Icons](/de/reference/icons/#alle-symbole) gesetzt ist, um ein Icon neben dem Label anzuzeigen.
+Jedes Tab-Element kann ein `icon`-Attribut enthalten, das auf den Namen [eines von Starlights eingebauten Symbolen](/de/reference/icons/#alle-symbole) gesetzt ist, um ein Symbol neben dem Label anzuzeigen.

--- a/docs/src/content/docs/de/reference/configuration.mdx
+++ b/docs/src/content/docs/de/reference/configuration.mdx
@@ -347,7 +347,7 @@ import SocialLinksType from '~/components/social-links-type.astro';
 
 **Typ:** <SocialLinksType />
 
-Optionale Angaben zu den Social-Media-Konten für diese Website. Wenn du eines dieser Konten hinzufügst, werden sie als Icon-Links in der Kopfzeile der Website angezeigt.
+Optionale Angaben zu den Social-Media-Konten für diese Website. Wenn du eines dieser Konten hinzufügst, werden sie als Symbol-Links in der Kopfzeile der Website angezeigt.
 
 ```js
 starlight({
@@ -561,7 +561,7 @@ Eine Seite kann diese Einstellung oder den Linktext und/oder die URL mit Hilfe d
 **Typ:** `string`  
 **Standard:** `'/favicon.svg'`
 
-Legt den Pfad des Standard-Favicons für deine Website fest. Dieses sollte sich im Verzeichnis `public/` befinden und eine gültige Icon-Datei (`.ico`, `.gif`, `.jpg`, `.png` oder `.svg`) sein.
+Legt den Pfad des Standard-Favicons für deine Website fest. Dieses sollte sich im Verzeichnis `public/` befinden und eine gültige Symbol-Datei (`.ico`, `.gif`, `.jpg`, `.png` oder `.svg`) sein.
 
 ```js
 starlight({

--- a/docs/src/content/docs/de/reference/icons.mdx
+++ b/docs/src/content/docs/de/reference/icons.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Symbole
 ---
 
-Starlight bietet eine Reihe von eingebauten Icons, die du mit Hilfe der Komponente `<Icon>` in deinem Inhalt anzeigen kannst.
+Starlight bietet eine Reihe von eingebauten Symbolen, die du mit Hilfe der Komponente `<Icon>` in deinem Inhalt anzeigen kannst.
 
 ## Symbole verwenden
 
@@ -14,7 +14,7 @@ Sie werden auch häufig in anderen Komponenten verwendet, wie [Karten](/de/compo
 
 ## `StarlightIcon`-Typ
 
-Verwende den TypeScript-Typ `StarlightIcon`, um die Namen von [Starlights eingebauten Icons](#alle-symbole) zu referenzieren.
+Verwende den TypeScript-Typ `StarlightIcon`, um die Namen von [Starlights eingebauten Symbolen](#alle-symbole) zu referenzieren.
 
 ```ts {2} /icon: (StarlightIcon)/
 // src/icon.ts

--- a/docs/src/content/docs/de/reference/overrides.md
+++ b/docs/src/content/docs/de/reference/overrides.md
@@ -115,7 +115,7 @@ So kannst du eine Benutzeroberfläche für alternative Suchanbieter hinzufügen,
 
 **Standardkomponente:** [`SocialIcons.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/SocialIcons.astro)
 
-Diese Komponente wird in der Kopfzeile der Website gerendert und enthält soziale Symbol-Links.
+Diese Komponente wird in der Kopfzeile der Website gerendert und enthält Symbol-Links zu sozialen Netzwerken.
 Die Standard&shy;implementierung verwendet die Option [`social`](/de/reference/configuration/#social) in der Starlight-Konfiguration, um Symbole und Links darzustellen.
 
 #### `ThemeSelect`

--- a/docs/src/content/docs/de/reference/overrides.md
+++ b/docs/src/content/docs/de/reference/overrides.md
@@ -115,8 +115,8 @@ So kannst du eine Benutzeroberfläche für alternative Suchanbieter hinzufügen,
 
 **Standardkomponente:** [`SocialIcons.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/SocialIcons.astro)
 
-Diese Komponente wird in der Kopfzeile der Website gerendert und enthält Links zu sozialen Symbolen.
-Die Standard&shy;implementierung verwendet die Option [`social`](/de/reference/configuration/#social) in der Starlight-Konfiguration, um Icons und Links darzustellen.
+Diese Komponente wird in der Kopfzeile der Website gerendert und enthält soziale Symbol-Links.
+Die Standard&shy;implementierung verwendet die Option [`social`](/de/reference/configuration/#social) in der Starlight-Konfiguration, um Symbole und Links darzustellen.
 
 #### `ThemeSelect`
 

--- a/docs/src/content/docs/de/resources/community-content.mdx
+++ b/docs/src/content/docs/de/resources/community-content.mdx
@@ -76,7 +76,7 @@ Erkunde die von der Community erstellten Inhalte, die von Starlight-Benutzern ge
 	/>
 	<LinkCard
 		href="https://hideoo.dev/notes/starlight-third-party-icon-sets"
-		title="Iconsets von Drittanbietern in Starlight verwenden"
+		title="Symbol-Sets von Drittanbietern in Starlight verwenden"
 		description="Eine Anleitung zur Verwendung von unplugin-icons, um die Auswahl an verfügbaren Symbolen für Starlight zu erweitern"
 	/>
 	<LinkCard


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- This PR replaces translations of the English word `icon` from the German translation `Icon` to `Symbol` so it is consistent across all pages. Therefore the i18nIgnore, because this should not mark pages as completed in any way.
- This is a follow-up PR of #2949 where Chris and I agreed on making the translation consistent the other way around (initially I wanted to replace all `Symbol` with `Icon`, but [Wikipedia](https://de.wikipedia.org/wiki/Icon_(Computer)) says, `Symbol` is the generally more acceptable translation of `icon`
- I again ask a native speaker to review this PR, maybe @delucis wants to step up again and help out as always 💜 (I think I didn't miss any `Icon`s with my global VS Code search...)

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
