### PR TITLE
Update `social` configuration option TSDoc example

### DIFF
--- a/.changeset/smooth-otters-taste.md
+++ b/.changeset/smooth-otters-taste.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Updates the `social` configuration option TSDoc example to match the shape of the expected value.

--- a/packages/starlight/utils/user-config.ts
+++ b/packages/starlight/utils/user-config.ts
@@ -51,18 +51,13 @@ const UserConfigSchema = z.object({
 	 * Optional details about the social media accounts for this site.
 	 *
 	 * @example
-	 * social: {
-	 *   codeberg: 'https://codeberg.org/knut/examples',
-	 *   discord: 'https://astro.build/chat',
-	 *   github: 'https://github.com/withastro/starlight',
-	 *   gitlab: 'https://gitlab.com/delucis',
-	 *   linkedin: 'https://www.linkedin.com/company/astroinc',
-	 *   mastodon: 'https://m.webtoo.ls/@astro',
-	 *   threads: 'https://www.threads.net/@nmoodev',
-	 *   twitch: 'https://www.twitch.tv/bholmesdev',
-	 *   twitter: 'https://twitter.com/astrodotbuild',
-	 *   youtube: 'https://youtube.com/@astrodotbuild',
-	 * }
+	 * social: [
+	 *   { icon: 'codeberg', label: 'Codeberg', href: 'https://codeberg.org/knut' },
+	 *   { icon: 'discord', label: 'Discord', href: 'https://astro.build/chat' },
+	 *   { icon: 'github', label: 'GitHub', href: 'https://github.com/withastro' },
+	 *   { icon: 'gitlab', label: 'GitLab', href: 'https://gitlab.com/delucis' },
+	 *   { icon: 'mastodon', label: 'Mastodon', href: 'https://m.webtoo.ls/@astro' },
+	 * ]
 	 */
 	social: SocialLinksSchema(),
 


### PR DESCRIPTION
#### Description

Following the changes in #3025, this PR updates the `social` configuration option TSDoc example to reflect the new format.

The example content is the [same one](https://github.com/withastro/starlight/pull/3025/files#diff-889e6ae5a36c15d03a30012e2936df94a63753b335bd5a8c56fac9a42e5c1dff) as the documentation.

| Before | After |
| --- | --- |
| <img width="381" alt="SCR-20250408-ngpa" src="https://github.com/user-attachments/assets/56157e4e-1cf3-4197-95b4-b1ec181f9ed2" /> | <img width="517" alt="SCR-20250408-ngsh" src="https://github.com/user-attachments/assets/b2a72610-0bcb-4db2-bf76-db763494fd9b" /> |
