### PR TITLE
fix(de): make `e.g.` consistent in German translation [i18nIgnore]

### DIFF
--- a/docs/src/content/docs/de/components/badges.mdx
+++ b/docs/src/content/docs/de/components/badges.mdx
@@ -5,7 +5,7 @@ description: Lerne, wie du in Starlight Abzeichen verwenden kannst, um zusätzli
 
 import { Badge } from '@astrojs/starlight/components';
 
-Um wenige Informationen, wie z.B. einen Status oder eine Kategorie, anzuzeigen, verwende die Komponente `<Badge>`.
+Um wenige Informationen, wie z.&nbsp;B. einen Status oder eine Kategorie, anzuzeigen, verwende die Komponente `<Badge>`.
 
 import Preview from '~/components/component-preview.astro';
 

--- a/docs/src/content/docs/de/components/code.mdx
+++ b/docs/src/content/docs/de/components/code.mdx
@@ -32,7 +32,7 @@ import { Code } from '@astrojs/starlight/components';
 
 ## Verwendung
 
-Verwende die Komponente `<Code>`, um Code mit hervorgehobener Syntax darzustellen, z. B. bei der Anzeige von Code aus externen Quellen.
+Verwende die Komponente `<Code>`, um Code mit hervorgehobener Syntax darzustellen, z.&nbsp;B. bei der Anzeige von Code aus externen Quellen.
 
 Siehe die [Ausdrucksstarker Code „Code Komponente“ Dokumentation](https://expressive-code.com/key-features/code-component/) für alle Details über die Verwendung der `<Code>` Komponente und die Liste der verfügbaren Eigenschaften.
 

--- a/docs/src/content/docs/de/components/file-tree.mdx
+++ b/docs/src/content/docs/de/components/file-tree.mdx
@@ -89,7 +89,7 @@ import { FileTree } from '@astrojs/starlight/components';
 
 ### Einträge hervorheben
 
-Hebe eine Datei oder ein Verzeichnis hervor, indem du seinen Namen fett druckst, z. B. `**README.md**`.
+Hebe eine Datei oder ein Verzeichnis hervor, indem du seinen Namen fett druckst, z.&nbsp;B. `**README.md**`.
 
 <Preview>
 

--- a/docs/src/content/docs/de/components/tabs.mdx
+++ b/docs/src/content/docs/de/components/tabs.mdx
@@ -69,7 +69,7 @@ Io, Europa, Ganymed
 Halte mehrere Registerkarten&shy;gruppen synchron, indem du das Attribut [`syncKey`](#synckey) hinzufügst.
 
 Alle `<Tabs>` auf einer Seite mit demselben Wert für `syncKey` zeigen dasselbe aktive Label an.
-Auf diese Weise kann dein Leser eine Auswahl treffen (z. B. sein Betriebssystem oder den Paketmanager), die dann beim Navigieren durch die Seiten beibehalten wird.
+Auf diese Weise kann dein Leser eine Auswahl treffen (z.&nbsp;B. sein Betriebssystem oder den Paketmanager), die dann beim Navigieren durch die Seiten beibehalten wird.
 
 Um zusammenhängende Tabs zu synchronisieren, füge eine identische `syncKey`-Eigenschaft zu jeder `<Tabs>`-Komponente hinzu und stelle sicher, dass sie alle die gleichen `<TabItem>`-Beschriftungen verwenden:
 

--- a/docs/src/content/docs/de/components/using-components.mdx
+++ b/docs/src/content/docs/de/components/using-components.mdx
@@ -65,7 +65,7 @@ In der Seitenleiste findst du eine Liste der verfügbaren Komponenten und deren 
 
 ## Kompatibilität mit den Stilen von Starlight
 
-Starlight wendet Standardstile auf deinen Markdown-Inhalt an, z.B. fügt es einen Rand zwischen den Elementen hinzu.
+Starlight wendet Standardstile auf deinen Markdown-Inhalt an, z.&nbsp;B. fügt es einen Rand zwischen den Elementen hinzu.
 Wenn diese Stile mit dem Erscheinungsbild deiner Komponente in Konflikt stehen, setze die Klasse `not-content` für deine Komponente, um sie zu deaktivieren.
 
 ```astro 'class="not-content"'

--- a/docs/src/content/docs/de/guides/authoring-content.mdx
+++ b/docs/src/content/docs/de/guides/authoring-content.mdx
@@ -139,7 +139,7 @@ npm create astro@latest -- --template starlight
 
 ### Benutzerdefinierte Nebenbemerkungs&shy;titel
 
-Du kannst einen benutzerdefinierten Titel für die Nebenbemerkung in eckigen Klammern nach dem Typen angeben, z.B. `:::tip[Wusstest du schon?]`.
+Du kannst einen benutzerdefinierten Titel für die Nebenbemerkung in eckigen Klammern nach dem Typen angeben, z.&nbsp;B. `:::tip[Wusstest du schon?]`.
 
 :::tip[Wusstest du schon?]
 Astro hilft dir, schnellere Websites mit ["Inselarchitektur"](https://docs.astro.build/de/concepts/islands/) zu erstellen.
@@ -405,7 +405,7 @@ Einige der gebräuchlichsten Beispiele sind unten aufgeführt:
 #### Rahmen und Überschriften
 
 Codeblöcke können innerhalb eines fensterähnlichen Rahmens dargestellt werden.
-Ein Rahmen, der wie ein Terminalfenster aussieht, wird für Shell-Skriptsprachen (z.B. `bash` oder `sh`) verwendet.
+Ein Rahmen, der wie ein Terminalfenster aussieht, wird für Shell-Skriptsprachen (z.&nbsp;B. `bash` oder `sh`) verwendet.
 Andere Sprachen werden in einem Rahmen im Stil eines Code-Editors angezeigt, wenn sie einen Titel enthalten.
 
 Der optionale Titel eines Code-Blocks kann entweder mit einem `title="..."`-Attribut gesetzt werden, das den öffnenden Backticks und dem Sprachbezeichner des Code-Blocks folgt, oder mit einem Dateinamenkommentar in den ersten Zeilen des Codes.

--- a/docs/src/content/docs/de/guides/css-and-tailwind.mdx
+++ b/docs/src/content/docs/de/guides/css-and-tailwind.mdx
@@ -287,7 +287,7 @@ import ThemeDesigner from '~/components/theme-designer.astro';
 				'Der Fließtext wird in einem Grauton mit hohem Kontrast zum Hintergrund dargestellt.',
 			linkText: 'Links sind farbig.',
 			dimText:
-				'Einige Texte, wie z. B. das Inhaltsverzeichnis, haben einen geringeren Kontrast.',
+				'Einige Texte, wie z.&nbsp;B. das Inhaltsverzeichnis, haben einen geringeren Kontrast.',
 			inlineCode: 'Inline-Code hat einen eindeutigen Hintergrund.',
 		},
 	}}

--- a/docs/src/content/docs/de/guides/i18n.mdx
+++ b/docs/src/content/docs/de/guides/i18n.mdx
@@ -137,13 +137,13 @@ export default defineConfig({
 });
 ```
 
-Dies ermöglicht es dir, die Standardsprache von Starlight zu überschreiben, ohne andere Internationalisierungs&shy;funktionen für mehrsprachige Websites zu aktivieren, wie z.B. die Sprachauswahl.
+Dies ermöglicht es dir, die Standardsprache von Starlight zu überschreiben, ohne andere Internationalisierungs&shy;funktionen für mehrsprachige Websites zu aktivieren, wie z.&nbsp;B. die Sprachauswahl.
 
 ## Fallback-Inhalt
 
 Starlight erwartet, dass du äquivalente Seiten in allen deinen Sprachen erstellst. Wenn du zum Beispiel eine `de/about.md` Datei hast, erstelle eine `about.md` für jede andere Sprache, die du unterstützt. Dies ermöglicht Starlight, automatisch Ersatzinhalte für Seiten zu liefern, die noch nicht übersetzt wurden.
 
-Wenn für eine Sprache noch keine Übersetzung verfügbar ist, zeigt Starlight den Lesern den Inhalt dieser Seite in der Standardsprache (eingestellt über `defaultLocale`). Wenn du z.B. noch keine französische Version deiner "About"-Seite erstellt hast und deine Standardsprache Englisch ist, werden Besucher von `/fr/about` den englischen Inhalt von `/en/about` sehen, mit einem Hinweis, dass diese Seite noch nicht übersetzt wurde. Auf diese Weise kannst du Inhalte in deiner Standardsprache hinzufügen und sie dann nach und nach übersetzen, wenn du Lust dazu hast.
+Wenn für eine Sprache noch keine Übersetzung verfügbar ist, zeigt Starlight den Lesern den Inhalt dieser Seite in der Standardsprache (eingestellt über `defaultLocale`). Wenn du z.&nbsp;B. noch keine französische Version deiner "About"-Seite erstellt hast und deine Standardsprache Englisch ist, werden Besucher von `/fr/about` den englischen Inhalt von `/en/about` sehen, mit einem Hinweis, dass diese Seite noch nicht übersetzt wurde. Auf diese Weise kannst du Inhalte in deiner Standardsprache hinzufügen und sie dann nach und nach übersetzen, wenn du Lust dazu hast.
 
 ## Übersetze den Seitentitel
 
@@ -178,7 +178,7 @@ export default defineConfig({
 import LanguagesList from '~/components/languages-list.astro';
 import UIStringsList from '~/components/ui-strings-list.astro';
 
-Starlight bietet nicht nur übersetzte Inhaltsdateien, sondern auch die Möglichkeit, die Standard-Benutzeroberfläche zu übersetzen (z.B. die Überschrift "Auf dieser Seite" im Inhaltsverzeichnis), so dass deine Leser deine Website vollständig in der ausgewählten Sprache erleben können.
+Starlight bietet nicht nur übersetzte Inhaltsdateien, sondern auch die Möglichkeit, die Standard-Benutzeroberfläche zu übersetzen (z.&nbsp;B. die Überschrift "Auf dieser Seite" im Inhaltsverzeichnis), so dass deine Leser deine Website vollständig in der ausgewählten Sprache erleben können.
 
 <LanguagesList startsSentence /> werden standardmäßig übersetzt, und wir freuen
 uns über [Beiträge zur Aufnahme weiterer
@@ -215,7 +215,7 @@ Du kannst Übersetzungen für zusätzliche Sprachen, die du unterstützt, über 
 
    </FileTree>
 
-3. Füge Übersetzungen für die Schlüssel hinzu, die in den JSON-Dateien übersetzt werden sollen. Übersetze nur die Werte und belasse die Schlüssel auf Englisch (z.B. `"search.label": "Buscar"`).
+3. Füge Übersetzungen für die Schlüssel hinzu, die in den JSON-Dateien übersetzt werden sollen. Übersetze nur die Werte und belasse die Schlüssel auf Englisch (z.&nbsp;B. `"search.label": "Buscar"`).
 
    Dies sind die englischen Standardwerte der vorhandenen Strings, mit denen Starlight ausgeliefert wird:
 

--- a/docs/src/content/docs/de/guides/pages.mdx
+++ b/docs/src/content/docs/de/guides/pages.mdx
@@ -168,7 +168,7 @@ Legt die Schreibrichtung für den Inhalt dieser Seite fest.
 **Typ:** `String`  
 **Standard:** die Sprache des aktuellen Gebietsschemas
 
-Setzt das BCP-47 Sprach-Tag für den Inhalt dieser Seite, z.B. `en`, `zh-CN` oder `pt-BR`.
+Setzt das BCP-47 Sprach-Tag für den Inhalt dieser Seite, z.&nbsp;B. `en`, `zh-CN` oder `pt-BR`.
 
 ##### `isFallback`
 

--- a/docs/src/content/docs/de/guides/route-data.mdx
+++ b/docs/src/content/docs/de/guides/route-data.mdx
@@ -123,7 +123,7 @@ export default defineConfig({
 #### Warten auf spätere Routen-Middleware
 
 Um darauf zu warten, dass die Middleware später im Stapel ausgeführt wird, bevor du deinen Code ausführst, kannst du den `next()` Callback abwarten, der als zweites Argument an deine Middleware-Funktion übergeben wird.
-Das kann z.B. nützlich sein, um zu warten, bis die Middleware eines Plugins läuft, bevor du Änderungen vornimmst.
+Das kann z.&nbsp;B. nützlich sein, um zu warten, bis die Middleware eines Plugins läuft, bevor du Änderungen vornimmst.
 
 ```ts "next" "await next();"
 // src/routeData.ts

--- a/docs/src/content/docs/de/guides/sidebar.mdx
+++ b/docs/src/content/docs/de/guides/sidebar.mdx
@@ -351,7 +351,7 @@ Die obige Konfiguration erzeugt die folgende Seitenleiste:
 
 Passe das Design des Abzeichens mit einem Objekt mit den Eigenschaften `text`, `variant` und `class` an.
 
-Der `text` steht für den anzuzeigenden Inhalt (z.B. "Neu").
+Der `text` steht für den anzuzeigenden Inhalt (z.&nbsp;B. "Neu").
 Überschreibe das `default`-Styling, das die Akzentfarbe deiner Website verwendet, indem du die Eigenschaft `variant` auf einen der folgenden Werte setzt: `note`, `tip`, `danger`, `caution` oder `success`.
 
 Optional kannst du einen benutzerdefinierten Abzeichenstil erstellen, indem du die Eigenschaft `class` auf einen CSS-Klassennamen setzt.
@@ -438,7 +438,7 @@ Die obige Konfiguration erzeugt die folgende Seitenleiste:
 
 ## Internationalisierung
 
-Verwende die Eigenschaft `translations` für Link- und Gruppeneinträge, um die Link- oder Gruppenbeschriftung für jede unterstützte Sprache zu übersetzen, indem du ein [BCP-47](https://www.w3.org/International/questions/qa-choosing-language-tags) Sprach-Tag, z.B. `"en"`, `"ar"`, oder `"zh-CN"`, als Schlüssel und die übersetzte Beschriftung als Wert angibst.
+Verwende die Eigenschaft `translations` für Link- und Gruppeneinträge, um die Link- oder Gruppenbeschriftung für jede unterstützte Sprache zu übersetzen, indem du ein [BCP-47](https://www.w3.org/International/questions/qa-choosing-language-tags) Sprach-Tag, z.&nbsp;B. `"en"`, `"ar"`, oder `"zh-CN"`, als Schlüssel und die übersetzte Beschriftung als Wert angibst.
 Die Eigenschaft `label` wird für das Standard&shy;gebietsschema und für Sprachen ohne Übersetzung verwendet.
 
 ```js {5-7,11-13,18-20}
@@ -525,7 +525,7 @@ Wenn du zum Beispiel Seiten unter `en/intro` und `pt-br/intro` hast, ist der Slu
 ### Internationalisierung mit Badges
 
 Für [Abzeichen](#abzeichen) kann die Eigenschaft `text` ein String sein oder für mehrsprachige Seiten ein Objekt mit Werten für jedes unterschiedliche Gebietsschema.
-Wenn du die Objektform verwendest, müssen die Schlüssel [BCP-47](https://www.w3.org/International/questions/qa-choosing-language-tags) Tags sein (z.B. `en`, `ar` oder `zh-CN`):
+Wenn du die Objektform verwendest, müssen die Schlüssel [BCP-47](https://www.w3.org/International/questions/qa-choosing-language-tags) Tags sein (z.&nbsp;B. `en`, `ar` oder `zh-CN`):
 
 ```js {11-16}
 starlight({

--- a/docs/src/content/docs/de/reference/configuration.mdx
+++ b/docs/src/content/docs/de/reference/configuration.mdx
@@ -32,7 +32,7 @@ Du kannst die folgenden Optionen an die `starlight` Integration übergeben.
 Lege den Titel für deine Website fest. Wird in den Metadaten und im Titel der Browser-Tabs verwendet.
 
 Der Wert kann eine Zeichenkette sein, oder für mehrsprachige Websites ein Objekt mit Werten für jedes Gebietsschema.
-Wenn die Objektform verwendet wird, müssen die Schlüssel BCP-47-Tags sein (z. B. `en`, `ar` oder `zh-CN`):
+Wenn die Objektform verwendet wird, müssen die Schlüssel BCP-47-Tags sein (z.&nbsp;B. `en`, `ar` oder `zh-CN`):
 
 ```ts
 starlight({
@@ -104,9 +104,9 @@ Konfiguriere die Navigationselemente der Seitenleiste deiner Website.
 Eine Seitenleiste ist eine Array von Links und Linkgruppen.
 Mit Ausnahme von Einträgen, die `slug` verwenden, muss jeder Eintrag ein `label` und eine der folgenden Eigenschaften haben:
 
-- `link` - ein einzelner Link zu einer bestimmten URL, z.B. `'/home'` oder `'https://example.com'`.
+- `link` - ein einzelner Link zu einer bestimmten URL, z.&nbsp;B. `'/home'` oder `'https://example.com'`.
 
-- `slug` - ein Verweis auf eine interne Seite, z.B. `'guides/getting-started'`.
+- `slug` - ein Verweis auf eine interne Seite, z.&nbsp;B. `'guides/getting-started'`.
 
 - `items` - ein Array, das weitere Links und Untergruppen enthält.
 
@@ -297,13 +297,13 @@ Du kannst die folgenden Optionen für jedes Locale-Schema festlegen:
 
 **Typ:** `string`
 
-Die Bezeichnung für diese Sprache, die den Benutzern angezeigt werden soll, z. B. im Sprachumschalter. Meistens wird dies der Name der Sprache sein, wie ihn ein Benutzer dieser Sprache erwarten würde, z.B. `"English"`, `"العربية"`, oder `"简体中文"`.
+Die Bezeichnung für diese Sprache, die den Benutzern angezeigt werden soll, z.&nbsp;B. im Sprachumschalter. Meistens wird dies der Name der Sprache sein, wie ihn ein Benutzer dieser Sprache erwarten würde, z.&nbsp;B. `"English"`, `"العربية"`, oder `"简体中文"`.
 
 ##### `lang`
 
 **Typ:** `string`
 
-Das BCP-47-Tag für diese Sprache, z. B. `"en"`, `"ar"` oder `"zh-CN"`. Wenn nicht gesetzt, wird standardmäßig der Verzeichnisname der Sprache verwendet. Sprach-Tags mit regionalen Unter-Tags (z.B. `"pt-BR"` oder `"en-US"`) verwenden integrierte UI-Übersetzungen für deine Basissprache, wenn keine regional&shy;spezifischen Übersetzungen gefunden werden.
+Das BCP-47-Tag für diese Sprache, z.&nbsp;B. `"en"`, `"ar"` oder `"zh-CN"`. Wenn nicht gesetzt, wird standardmäßig der Verzeichnisname der Sprache verwendet. Sprach-Tags mit regionalen Unter-Tags (z.&nbsp;B. `"pt-BR"` oder `"en-US"`) verwenden integrierte UI-Übersetzungen für deine Basissprache, wenn keine regional&shy;spezifischen Übersetzungen gefunden werden.
 
 ##### `dir`
 
@@ -373,7 +373,7 @@ starlight({
 
 Stellen CSS-Dateien zur Verfügung, um das Aussehen deines Starlight-Projekts anzupassen.
 
-Unterstützt lokale CSS-Dateien relativ zum Stammverzeichnis deines Projekts, z.B. `'./src/custom.css'`, und CSS, die du als npm-Modul installiert hast, z.B. `'@fontsource/roboto'`.
+Unterstützt lokale CSS-Dateien relativ zum Stammverzeichnis deines Projekts, z.&nbsp;B. `'./src/custom.css'`, und CSS, die du als npm-Modul installiert hast, z.&nbsp;B. `'@fontsource/roboto'`.
 
 ```js
 starlight({

--- a/docs/src/content/docs/de/reference/route-data.mdx
+++ b/docs/src/content/docs/de/reference/route-data.mdx
@@ -43,7 +43,7 @@ Schreibrichtung der Seite.
 
 **Typ:** `string`
 
-BCP-47-Sprachkennzeichen für das Gebietsschema dieser Seite, z.B. `de`, `zh-CN` oder `pt-BR`.
+BCP-47-Sprachkennzeichen für das Gebietsschema dieser Seite, z.&nbsp;B. `de`, `zh-CN` oder `pt-BR`.
 
 ### `locale`
 
@@ -61,8 +61,8 @@ Der Seitentitel für das Gebietsschema dieser Seite.
 
 **Typ:** `string`
 
-Der Wert für das Attribut `href` des Seitentitels, der auf die Homepage zurückverweist, z. B. `/`.
-Bei mehrsprachigen Websites wird hier das aktuelle Gebietsschema angegeben, z. B. `/en/` oder `/zh-cn/`.
+Der Wert für das Attribut `href` des Seitentitels, der auf die Homepage zurückverweist, z.&nbsp;B. `/`.
+Bei mehrsprachigen Websites wird hier das aktuelle Gebietsschema angegeben, z.&nbsp;B. `/en/` oder `/zh-cn/`.
 
 ### `slug`
 

--- a/docs/src/content/docs/de/resources/community-content.mdx
+++ b/docs/src/content/docs/de/resources/community-content.mdx
@@ -49,7 +49,7 @@ Hier findest du eine Sammlung von Beiträgen und Artikeln, in denen du mehr übe
 
 ## Beispiele und Leitfäden
 
-Beispiele sind in der Regel kurze, konzentrierte Anleitungen, die den Leser durch ein funktionierendes Beispiel für eine bestimmte Aufgabe führen. Beispiele sind eine gute Möglichkeit, deinem Starlight-Projekt neue Funktionen oder Verhaltensweisen hinzuzufügen, indem du Schritt-für-Schritt-Anweisungen befolgst! Andere Anleitungen erklären Konzepte, die sich auf einen bestimmten Inhaltsbereich beziehen, z. B. die Verwendung von Bildern oder das Arbeiten mit MDX.
+Beispiele sind in der Regel kurze, konzentrierte Anleitungen, die den Leser durch ein funktionierendes Beispiel für eine bestimmte Aufgabe führen. Beispiele sind eine gute Möglichkeit, deinem Starlight-Projekt neue Funktionen oder Verhaltensweisen hinzuzufügen, indem du Schritt-für-Schritt-Anweisungen befolgst! Andere Anleitungen erklären Konzepte, die sich auf einen bestimmten Inhaltsbereich beziehen, z.&nbsp;B. die Verwendung von Bildern oder das Arbeiten mit MDX.
 
 Erkunde die von der Community erstellten Inhalte, die von Starlight-Benutzern gepflegt werden:
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

This PR replaces all `z.B.` and `z. B.` with the consistent and recommended spelling notation[^1], `z.&nbsp;B.`.
Therefore the i18nIgnore, because this should not mark pages as completed in any way.
Request review from native speaker (@delucis?)!

[^1]: Wiktionary: https://de.wiktionary.org/wiki/z._B.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
