### PR TITLE
Fix missing head tags

### DIFF
--- a/.changeset/orange-pianos-juggle.md
+++ b/.changeset/orange-pianos-juggle.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes a regression in Starlight version `0.33.0` that caused the description and links to language alternates for multilingual websites to be missing from the` <head>` of the page.

--- a/packages/starlight/__tests__/head/head.test.ts
+++ b/packages/starlight/__tests__/head/head.test.ts
@@ -6,7 +6,17 @@ import type { HeadConfig } from '../../schemas/head';
 
 vi.mock('astro:content', async () =>
 	(await import('../test-utils')).mockedAstroContent({
-		docs: [['index.mdx', { title: 'Home Page' }]],
+		docs: [
+			['index.mdx', { title: 'Home Page' }],
+			[
+				'environmental-impact.md',
+				{
+					title: 'Eco-friendly docs',
+					description:
+						'Learn how Starlight can help you build greener documentation sites and reduce your carbon footprint.',
+				},
+			],
+		],
 	})
 );
 
@@ -20,6 +30,31 @@ test('includes custom tags defined in the Starlight configuration', () => {
 		},
 		content: '',
 		tag: 'script',
+	});
+});
+
+test('includes description based on Starlight `description` configuration', () => {
+	const head = getTestHead();
+	expect(head).toContainEqual({
+		tag: 'meta',
+		attrs: {
+			name: 'description',
+			content: 'Docs with a custom head',
+		},
+		content: '',
+	});
+});
+
+test('includes description based on page `description` frontmatter field if provided', () => {
+	const head = getTestHead([], routes[1]!);
+	expect(head).toContainEqual({
+		tag: 'meta',
+		attrs: {
+			name: 'description',
+			content:
+				'Learn how Starlight can help you build greener documentation sites and reduce your carbon footprint.',
+		},
+		content: '',
 	});
 });
 
@@ -151,8 +186,7 @@ test('places the default favicon below any user provided icons', () => {
 	expect(defaultFaviconIndex).toBeGreaterThan(userFaviconIndex);
 });
 
-function getTestHead(heads: HeadConfig = []): HeadConfig {
-	const route = routes[0]!;
+function getTestHead(heads: HeadConfig = [], route = routes[0]!): HeadConfig {
 	return generateRouteData({
 		props: {
 			...route,

--- a/packages/starlight/__tests__/head/vitest.config.ts
+++ b/packages/starlight/__tests__/head/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineVitestConfig } from '../test-config';
 
 export default defineVitestConfig({
 	title: 'Docs With Custom Head',
+	description: 'Docs with a custom head',
 	head: [
 		{ tag: 'link', attrs: { rel: 'canonical', href: 'https://example.com/test' } },
 		{ tag: 'link', attrs: { rel: 'stylesheet', href: 'primary.css' } },

--- a/packages/starlight/__tests__/i18n/head.test.ts
+++ b/packages/starlight/__tests__/i18n/head.test.ts
@@ -1,0 +1,30 @@
+import { expect, test, vi } from 'vitest';
+import config from 'virtual:starlight/user-config';
+import { getRouteDataTestContext } from '../test-utils';
+import { generateRouteData } from '../../utils/routing/data';
+import { routes } from '../../utils/routing';
+
+vi.mock('astro:content', async () =>
+	(await import('../test-utils')).mockedAstroContent({
+		docs: [['index.mdx', { title: 'Home Page' }]],
+	})
+);
+
+test('includes links to language alternates', () => {
+	const route = routes[0]!;
+	const { head } = generateRouteData({
+		props: { ...route, headings: [] },
+		context: getRouteDataTestContext(),
+	});
+	for (const [locale, localeConfig] of Object.entries(config.locales!)) {
+		expect(head).toContainEqual({
+			tag: 'link',
+			attrs: {
+				rel: 'alternate',
+				href: `https://example.com/${locale}/`,
+				hreflang: localeConfig?.lang,
+			},
+			content: '',
+		});
+	}
+});

--- a/packages/starlight/utils/head.ts
+++ b/packages/starlight/utils/head.ts
@@ -5,6 +5,7 @@ import { type HeadConfig, HeadConfigSchema, type HeadUserConfig } from '../schem
 import type { PageProps, RouteDataContext } from './routing/data';
 import { fileWithBase } from './base';
 import { formatCanonical } from './canonical';
+import { localizedUrl } from './localizedUrl';
 
 const HeadSchema = HeadConfigSchema();
 
@@ -60,6 +61,28 @@ export function getHead(
 			attrs: { name: 'twitter:card', content: 'summary_large_image' },
 		},
 	];
+
+	if (description)
+		headDefaults.push({
+			tag: 'meta',
+			attrs: { name: 'description', content: description },
+		});
+
+	// Link to language alternates.
+	if (canonical && config.isMultilingual) {
+		for (const locale in config.locales) {
+			const localeOpts = config.locales[locale];
+			if (!localeOpts) continue;
+			headDefaults.push({
+				tag: 'link',
+				attrs: {
+					rel: 'alternate',
+					hreflang: localeOpts.lang,
+					href: localizedUrl(canonical, locale, project.trailingSlash).href,
+				},
+			});
+		}
+	}
 
 	// Link to sitemap, but only when `site` is set.
 	if (context.site) {


### PR DESCRIPTION
#### Description

This PR fixes a regression in #2927 where I entirely skipped over [the logic](https://github.com/withastro/starlight/blob/f493361d7b64a3279980e0f046c3a52196ab94e0/packages/starlight/components/Head.astro#L53-L73) to include the description and links to language alternates for multilingual websites to the` <head>` of the page.
