### PR TITLE
[i18nIgnore] docs: disable last update dates for custom 404s

### DIFF
--- a/docs/src/content/docs/404.md
+++ b/docs/src/content/docs/404.md
@@ -2,6 +2,7 @@
 title: Not found
 template: splash
 editUrl: false
+lastUpdated: false
 hero:
   title: '404'
   tagline: <strong>Houston, we have a problem.</strong> We couldn’t find that page.<br>Check the URL or try using the search bar.

--- a/docs/src/content/docs/da/404.md
+++ b/docs/src/content/docs/da/404.md
@@ -2,6 +2,7 @@
 title: Ikke Fundet
 template: splash
 editUrl: false
+lastUpdated: false
 hero:
   title: '404'
   tagline: <strong>Houston, vi har et problem.</strong> Vi kunne ikke finde den side.<br>Check URL'en eller prøv at bruge søgefeltet.

--- a/docs/src/content/docs/de/404.md
+++ b/docs/src/content/docs/de/404.md
@@ -2,6 +2,7 @@
 title: Nicht gefunden
 template: splash
 editUrl: false
+lastUpdated: false
 hero:
   title: '404'
   tagline: <strong>Houston, wir haben ein Problem.</strong> Wir konnten diese Seite nicht finden.<br>Prüfe die URL oder verwende die Suchleiste.

--- a/docs/src/content/docs/es/404.md
+++ b/docs/src/content/docs/es/404.md
@@ -2,6 +2,7 @@
 title: No encontrada
 template: splash
 editUrl: false
+lastUpdated: false
 hero:
   title: '404'
   tagline: <strong>Houston, tenemos un problema.</strong> No pudimos encontrar esa página.<br>Verifica la URL o intenta usar la barra de búsqueda.

--- a/docs/src/content/docs/fr/404.md
+++ b/docs/src/content/docs/fr/404.md
@@ -2,6 +2,7 @@
 title: Page Introuvable
 template: splash
 editUrl: false
+lastUpdated: false
 hero:
   title: '404'
   tagline: <strong>Houston, nous avons un problème.</strong> Nous n’avons pas pu trouver cette page.<br>Vérifiez l’URL ou essayez la barre de recherche.

--- a/docs/src/content/docs/hi/404.md
+++ b/docs/src/content/docs/hi/404.md
@@ -2,6 +2,7 @@
 title: पेज नहीं मिला
 template: splash
 editUrl: false
+lastUpdated: false
 hero:
   title: '404'
   tagline: <strong>Houston, हमें एक समस्या है।</strong> हमें वह पेज नहीं मिला.<br> URL जांचें या खोज बार का उपयोग करने का प्रयास करें।

--- a/docs/src/content/docs/id/404.md
+++ b/docs/src/content/docs/id/404.md
@@ -2,6 +2,7 @@
 title: Halaman tidak ditemukan
 template: splash
 editUrl: false
+lastUpdated: false
 hero:
   title: '404'
   tagline: <strong>Houston, kita ada masalah.</strong> Halaman yang kita cari tidak ada.<br>Tolong cek kolom URL atau gunakan fitur pencarian.

--- a/docs/src/content/docs/it/404.md
+++ b/docs/src/content/docs/it/404.md
@@ -2,6 +2,7 @@
 title: Non trovato
 template: splash
 editUrl: false
+lastUpdated: false
 hero:
   title: '404'
   tagline: <strong>Houston, abbiamo un problema.</strong> Non siamo riusciti a trovare quella pagina.<br>Controlla l'URL o prova a utilizzare la barra di ricerca.

--- a/docs/src/content/docs/ja/404.md
+++ b/docs/src/content/docs/ja/404.md
@@ -2,6 +2,7 @@
 title: 見つかりませんでした
 template: splash
 editUrl: false
+lastUpdated: false
 hero:
   title: '404'
   tagline: <strong>Houston、問題が生じました。</strong>ページが見つかりませんでした。<br>URLを確認するか、検索バーを使用してみてください。

--- a/docs/src/content/docs/ko/404.md
+++ b/docs/src/content/docs/ko/404.md
@@ -2,6 +2,7 @@
 title: 페이지를 찾을 수 없습니다
 template: splash
 editUrl: false
+lastUpdated: false
 hero:
   title: '404'
   tagline: <strong>Houston, 문제가 생겼어요.</strong> 요청한 페이지를 찾을 수 없어요.<br>URL을 다시 한번 확인하거나 검색창을 사용해보세요.

--- a/docs/src/content/docs/pt-br/404.md
+++ b/docs/src/content/docs/pt-br/404.md
@@ -2,6 +2,7 @@
 title: Não encontrado
 template: splash
 editUrl: false
+lastUpdated: false
 hero:
   title: '404'
   tagline: <strong>Houston, temos um problema.</strong> Não conseguimos encontrar essa página.<br>Verifique a URL ou tente utilizar a barra de pesquisa.

--- a/docs/src/content/docs/pt-pt/404.md
+++ b/docs/src/content/docs/pt-pt/404.md
@@ -2,6 +2,7 @@
 title: Não encontrado
 template: splash
 editUrl: false
+lastUpdated: false
 hero:
   title: '404'
   tagline: <strong>Houston, temos um problema.</strong> Não conseguimos encontrar esta página.<br>Verifique se o URL está correto ou tente utilizar a barra de pesquisa.

--- a/docs/src/content/docs/ru/404.md
+++ b/docs/src/content/docs/ru/404.md
@@ -2,6 +2,7 @@
 title: Не найдено
 template: splash
 editUrl: false
+lastUpdated: false
 hero:
   title: '404'
   tagline: <strong>Хьюстон, у нас проблемы.</strong> Мы не смогли найти эту страницу.<br>Проверьте URL или попробуйте использовать поиск.

--- a/docs/src/content/docs/tr/404.md
+++ b/docs/src/content/docs/tr/404.md
@@ -2,6 +2,7 @@
 title: Sayfa Bulunamadı
 template: splash
 editUrl: false
+lastUpdated: false
 hero:
   title: '404'
   tagline: <strong>Houston, bi' problem var.</strong> Bu sayfayı bulamadık.<br>URL'i kontrol et ya da arama çubuğunu kullanmayı dene.

--- a/docs/src/content/docs/uk/404.md
+++ b/docs/src/content/docs/uk/404.md
@@ -2,6 +2,7 @@
 title: Не знайдено
 template: splash
 editUrl: false
+lastUpdated: false
 hero:
   title: '404'
   tagline: <strong>Г'юстоне, у нас проблема.</strong> Ми не змогли знайти цю сторінку.<br>Перевірте URL або спробуйте скористатися пошуком.

--- a/docs/src/content/docs/zh-cn/404.md
+++ b/docs/src/content/docs/zh-cn/404.md
@@ -2,6 +2,7 @@
 title: 页面未找到
 template: splash
 editUrl: false
+lastUpdated: false
 hero:
   title: '404'
   tagline: <strong>休斯顿，我们遇到了一个问题。</strong>我们找不到该页面。<br>请检查 URL 或尝试使用搜索栏。


### PR DESCRIPTION
#### Description

As discussed on Discord, this PR disables the last update dates for custom 404 pages. We had last update dates disabled for a long time and when finally enabling them, we probably forgot to disable them for custom 404 pages.