### PR TITLE
feat: update environment comparisons data

### DIFF
--- a/docs/src/content/docs/environmental-impact.md
+++ b/docs/src/content/docs/environmental-impact.md
@@ -91,31 +91,37 @@ These tests with the [Website Carbon Calculator][wcc] compare similar pages buil
 
 | Framework                   | CO₂ per page visit | Rating |
 | --------------------------- | ------------------ | :----: |
+| [Zola][zo-carbon]           | 0.00g              |   A+   |
 | [Starlight][sl-carbon]      | 0.01g              |   A+   |
-| [Read the Docs][rtd-carbon] | 0.05g              |   A+   |
-| [Sphinx][sx-carbon]         | 0.06g              |   A+   |
+| [Read the Docs][rtd-carbon] | 0.07g              |   A+   |
+| [Sphinx][sx-carbon]         | 0.07g              |   A+   |
 | [VitePress][vp-carbon]      | 0.07g              |   A+   |
-| [Docus][dc-carbon]          | 0.09g              |   A+   |
-| [docsify][dy-carbon]        | 0.10g              |   A    |
-| [Nextra][nx-carbon]         | 0.11g              |   A    |
-| [MkDocs][mk-carbon]         | 0.19g              |   B    |
-| [Docusaurus][ds-carbon]     | 0.21g              |   B    |
-| [GitBook][gb-carbon]        | 0.43g              |   C    |
-| [Mintlify][mt-carbon]       | 1.22g              |   F    |
+| [Docus][dc-carbon]          | 0.10g              |   A    |
+| [docsify][dy-carbon]        | 0.11g              |   A    |
+| [mdBook][md-carbon]         | 0.13g              |   A    |
+| [MkDocs][mk-carbon]         | 0.15g              |   A    |
+| [Fumadocs][fs-carbon]       | 0.16g              |   A    |
+| [Nextra][nx-carbon]         | 0.16g              |   A    |
+| [Docusaurus][ds-carbon]     | 0.25g              |   B    |
+| [Mintlify][mt-carbon]       | 0.99g              |   F    |
+| [GitBook][gb-carbon]        | 1.19g              |   F    |
 
-<small>Data collected on 22 July 2024. Click a link to see up-to-date figures.</small>
+<small>Data collected on 12 April 2025. Click a link to see up-to-date figures.</small>
 
 [sl-carbon]: https://www.websitecarbon.com/website/starlight-astro-build-getting-started/
 [vp-carbon]: https://www.websitecarbon.com/website/vitepress-dev-guide-what-is-vitepress/
 [dc-carbon]: https://www.websitecarbon.com/website/docus-dev-introduction-getting-started/
 [sx-carbon]: https://www.websitecarbon.com/website/sphinx-doc-org-en-master-usage-quickstart-html/
 [mk-carbon]: https://www.websitecarbon.com/website/mkdocs-org-getting-started/
+[md-carbon]: https://www.websitecarbon.com/website/rust-lang-github-io-mdbook/
 [nx-carbon]: https://www.websitecarbon.com/website/nextra-site-docs-docs-theme-start/
+[fs-carbon]: https://www.websitecarbon.com/website/fumadocs-vercel-app-docs-ui/
 [dy-carbon]: https://www.websitecarbon.com/website/docsify-js-org/
 [ds-carbon]: https://www.websitecarbon.com/website/docusaurus-io-docs/
 [rtd-carbon]: https://www.websitecarbon.com/website/docs-readthedocs-io-en-stable-index-html/
 [gb-carbon]: https://www.websitecarbon.com/website/docs-gitbook-com/
 [mt-carbon]: https://www.websitecarbon.com/website/mintlify-com-docs-quickstart/
+[zo-carbon]: https://www.websitecarbon.com/website/getzola-org-documentation-getting-started-overview/
 
 ## More resources
 

--- a/docs/src/content/docs/environmental-impact.md
+++ b/docs/src/content/docs/environmental-impact.md
@@ -91,7 +91,6 @@ These tests with the [Website Carbon Calculator][wcc] compare similar pages buil
 
 | Framework                   | CO₂ per page visit | Rating |
 | --------------------------- | ------------------ | :----: |
-| [Zola][zo-carbon]           | 0.00g              |   A+   |
 | [Starlight][sl-carbon]      | 0.01g              |   A+   |
 | [Read the Docs][rtd-carbon] | 0.07g              |   A+   |
 | [Sphinx][sx-carbon]         | 0.07g              |   A+   |
@@ -121,7 +120,6 @@ These tests with the [Website Carbon Calculator][wcc] compare similar pages buil
 [rtd-carbon]: https://www.websitecarbon.com/website/docs-readthedocs-io-en-stable-index-html/
 [gb-carbon]: https://www.websitecarbon.com/website/docs-gitbook-com/
 [mt-carbon]: https://www.websitecarbon.com/website/mintlify-com-docs-quickstart/
-[zo-carbon]: https://www.websitecarbon.com/website/getzola-org-documentation-getting-started-overview/
 
 ## More resources
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

This PR updates the comparison data of different docs frameworks visible on [the environmental impact page](https://starlight.astro.build/environmental-impact/#comparisons) with up-to-date 12. April 2025 data fetches.

There are some things to consider:

- [ ] Shall we include all these frameworks or leave some out to make the table smaller? If we drop some, which ones?
- [ ] Either the Zola calculation is bugged or really respectable, which is very plausible cause it's built with Rust :)

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
