### PR TITLE
Added slot to Footer for easier customization.

### DIFF
--- a/.changeset/shy-mugs-obey.md
+++ b/.changeset/shy-mugs-obey.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Adds slot to Footer component for easier customization

--- a/packages/starlight/components/Footer.astro
+++ b/packages/starlight/components/Footer.astro
@@ -12,6 +12,7 @@ import { Icon } from '../components';
 		<LastUpdated />
 	</div>
 	<Pagination />
+	<slot />
 
 	{
 		config.credits && (


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

In reference to https://github.com/withastro/starlight/discussions/3115, this PR adds a `<slot />` to the `Footer` component making it easier to customize the Footer without having to recreate the whole component.

For example, consider a custom Footer component like:

```
---
import Default from '@astrojs/starlight/components/Footer.astro';
---

<Default>
    <div class="github">
        <span>Show your support! Star us on GitHub ⭐️</span>
        <a class="github-button" href="https://github.com/oramasearch/orama" data-color-scheme="no-preference: light; light: light; dark: light;" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star oramasearch/orama on GitHub">Star</a>
    </div>
</Default>

<style>
	.github {
		align-items: center;
		justify-content: center;
		gap: 0.5em;
		margin: 2rem auto;
		font-size: var(--sl-text-sm);
		text-decoration: none;
		display: flex;
		flex-direction: column;
	}
	.github span {
		font-size: var(--sl-text-sm);
		cursor: default;
	}
</style>
```

You can contrast this approach to [its current approach](https://github.com/oramasearch/orama/blob/main/packages/docs/src/components/Footer.astro) which duplicates a lot making upgrades potentially more challenging.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
