### PR TITLE
Reset border styles in Tailwind compatibility package

### DIFF
--- a/.changeset/dull-penguins-pump.md
+++ b/.changeset/dull-penguins-pump.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight-tailwind': patch
+---
+
+Fixes an issue where all border styles were not reset by the Starlight’s Tailwind compatibility package like in [Tailwind base styles](https://tailwindcss.com/docs/preflight#border-styles-are-reset).

--- a/packages/tailwind/__tests__/tailwind.test.ts
+++ b/packages/tailwind/__tests__/tailwind.test.ts
@@ -14,6 +14,10 @@ test('generates base and utilities CSS layers and defines default theme values',
 		"@layer theme;
 
 		@layer base {
+		  *, :after, :before {
+		    border: 0 solid;
+		  }
+
 		  html, :host {
 		    font-family: var(--font-sans);
 		  }

--- a/packages/tailwind/tailwind.css
+++ b/packages/tailwind/tailwind.css
@@ -29,6 +29,12 @@
 
 @layer base {
 	/* Restore crucial styles from Tailwind Preflight: https://tailwindcss.com/docs/preflight */
+	/* Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116) */
+	*,
+	::after,
+	::before {
+		border: 0 solid;
+	}
 	/* Keep base font-family styles even in non-Starlight pages. */
 	html,
 	:host {


### PR DESCRIPTION
#### Description

The Starlight Tailwind compatibility package restores only some crucial styles from Tailwind Preflight instead of using it entirely.

This previous version of the Tailwind compatibility package [used to restore](https://github.com/withastro/starlight/blob/421f8a76482ff0969e52faca80e3ef66831b0b42/packages/tailwind/index.ts#L64-L69) a rule resetting all border styles to allow adding a border to an element by just adding a border-width.

The new version is no longer restoring this rule (which [still exists in Tailwind v4](https://github.com/tailwindlabs/tailwindcss/blob/main/packages/tailwindcss/preflight.css#L15)) which could cause updating users to have default borders on their buttons. This PR adds it back to the compatibility package.

For example, this issue was initially reported while updating the Cloudflare Docs, here is how it looks with Tailwind v4 without the fix and with the fix:

| Before          | After |
| --------------- | ----- |
| <img width="186" alt="SCR-20250417-issh" src="https://github.com/user-attachments/assets/633cdc26-7472-485d-a48c-1caff4d634f0" /> | <img width="186" alt="SCR-20250417-itin" src="https://github.com/user-attachments/assets/e1b6fbaa-0fd2-4b02-81d1-0ba13e58920c" />  |
