### PR TITLE
i18n(fr): update the translation of `preset` consistently

### DIFF
--- a/docs/src/content/docs/fr/components/using-components.mdx
+++ b/docs/src/content/docs/fr/components/using-components.mdx
@@ -39,7 +39,7 @@ Pour en savoir plus sur [l'utilisation de composants avec MDX](https://docs.astr
 
 Ajoutez la prise en charge de la rédaction de contenu avec Markdoc en suivant notre [guide de configuration Markdoc](/fr/guides/authoring-content/#markdoc).
 
-En utilisant la préconfiguration Markdoc de Starlight, vous pouvez utiliser les composants intégrés à Starlight avec la syntaxe de balises `{% %}` de Markdoc.
+En utilisant le préréglage Markdoc de Starlight, vous pouvez utiliser les composants intégrés à Starlight avec la syntaxe de balises `{% %}` de Markdoc.
 À la différence du format MDX, les composants dans les fichiers Markdoc n'ont pas besoin d'être importés.
 L'exemple suivant affiche le [composant de carte](/fr/components/cards/) de Starlight dans un fichier Markdoc :
 
@@ -59,7 +59,7 @@ Consultez la [documentation de l'intégration Astro Markdoc](https://docs.astro.
 ## Composants intégrés
 
 Starlight fournit des composants intégrés par défaut pour des cas d'utilisation courants à une documentation.
-Ces composants sont disponibles dans le paquet `@astrojs/starlight/components` dans les fichiers MDX et dans la [préconfiguration Markdoc de Starlight](/fr/guides/authoring-content/#markdoc) dans les fichiers Markdoc.
+Ces composants sont disponibles dans le paquet `@astrojs/starlight/components` dans les fichiers MDX et dans le [préréglage Markdoc de Starlight](/fr/guides/authoring-content/#markdoc) dans les fichiers Markdoc.
 
 Utilisez la barre latérale pour obtenir une liste des composants disponibles et savoir comment les utiliser.
 

--- a/docs/src/content/docs/fr/guides/authoring-content.mdx
+++ b/docs/src/content/docs/fr/guides/authoring-content.mdx
@@ -537,7 +537,7 @@ Starlight utilise le moteur de rendu Markdown et MDX d'Astro basé sur remark et
 
 ## Markdoc
 
-Starlight supporte la création de contenu en Markdoc en utilisant l'intégration expérimentale [Astro Markdoc](https://docs.astro.build/fr/guides/integrations-guide/markdoc/) et la préconfiguration Markdoc de Starlight.
+Starlight supporte la création de contenu en Markdoc en utilisant l'intégration expérimentale [Astro Markdoc](https://docs.astro.build/fr/guides/integrations-guide/markdoc/) et le préréglage Markdoc de Starlight.
 
 ### Créer un nouveau projet avec Markdoc
 
@@ -605,7 +605,7 @@ Si vous disposez déjà d'un site Starlight et que vous souhaitez ajouter Markdo
 
     </Tabs>
 
-2.  Installez la préconfiguration Markdoc de Starlight :
+2.  Installez le préréglage Markdoc de Starlight :
 
     <Tabs syncKey="pkg">
 
@@ -635,7 +635,7 @@ Si vous disposez déjà d'un site Starlight et que vous souhaitez ajouter Markdo
 
     </Tabs>
 
-3.  Créez une configuration Markdoc dans le fichier `markdoc.config.mjs` et utilisez la préconfiguration Markdoc de Starlight :
+3.  Créez une configuration Markdoc dans le fichier `markdoc.config.mjs` et utilisez le préréglage Markdoc de Starlight :
 
     ```js
     import { defineMarkdocConfig } from '@astrojs/markdoc/config';
@@ -650,9 +650,9 @@ Si vous disposez déjà d'un site Starlight et que vous souhaitez ajouter Markdo
 
 Pour en savoir plus sur la syntaxe et les fonctionnalités de Markdoc, consultez la [documentation Markdoc](https://markdoc.dev/docs/syntax) ou le [guide de l'intégration Astro Markdoc](https://docs.astro.build/fr/guides/integrations-guide/markdoc/).
 
-### Paramétrage de la préconfiguration Markdoc
+### Configuration du préréglage Markdoc
 
-La préconfiguration `starlightMarkdoc()` accepte les options de configuration suivantes :
+Le préréglage `starlightMarkdoc()` accepte les options de configuration suivantes :
 
 #### `headingLinks`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

As discussed in https://github.com/withastro/starlight/pull/3126#discussion_r2049081828, this updates the French translation for `preset` (`préconfiguration` > `préréglage`) to avoid repeats in French when we have both `configuration` and `preset` in the same sentence.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
