### PR TITLE
Fix double/triple click selection issues for heading with a clickable anchor link

### DIFF
--- a/.changeset/clean-yaks-drive.md
+++ b/.changeset/clean-yaks-drive.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes a text selection issue for heading with a clickable anchor link when using double or triple click to select text.

--- a/packages/starlight/style/anchor-links.css
+++ b/packages/starlight/style/anchor-links.css
@@ -88,6 +88,9 @@ how we do it.
 		position: relative;
 		/* Move the anchor link over the heading element’s end-of-line padding. */
 		margin-inline-start: calc(-1 * var(--sl-anchor-icon-size));
+		/* Prevent double or triple clicks from potentially selecting the anchor link a11y text. */
+		-webkit-user-select: none;
+		user-select: none;
 	}
 
 	/* Increase clickable area for anchor links with a pseudo element that doesn’t impact layout. */


### PR DESCRIPTION
#### Description

This PR is a bit of a blast from the past, as it fixes an issue I initially [spotted](https://github.com/withastro/docs/issues/8001) in Astro Docs almost a year ago when copying headings with either double click (select a word) or triple click (select a paragraph/logical unit) with a different behavior between browsers.

##### Chrome

Double clicking and copying a heading with a single word or the last word of a multiple words heading will inject `Section` in the clipboard text.

For example, going to [this page](https://starlight.astro.build/components/icons/) and double clicking and copying the heading `Usage` will copy `UsageSection` instead of `Usage`. Double clicking and copying the word `icons` in the heading `Customize icons` will copy `iconsSection` instead of `icons`.

Triple clicking is working as expected.

##### Firefox

Triple clicking a heading and copying will inject the entire heading anchor link screen reader text in the clipboard text.

For example, going to [this page](https://starlight.astro.build/components/icons/) and triple clicking and copying the heading `Customize icons` will copy `Customize iconsSection titled “Customize icons”` instead of `Customize icons`.

##### Safari

Double clicking and copying a heading with a single word or the last word of a multiple words heading will inject `Section` in the clipboard text.

For example, going to [this page](https://starlight.astro.build/components/icons/) and double clicking and copying the heading `Usage` will copy `UsageSection` instead of `Usage`. Double clicking and copying the word `icons` in the heading `Customize icons` will copy `iconsSection` instead of `icons`.

Triple clicking is working as expected.

#### Changes

The good thing is that I also fixed the issue in https://github.com/withastro/docs/pull/8015 at the time. This PR uses the same approach to fix the issue in Starlight. The original PR contains a breakdown of various approaches I tried and why I used the one I did so I'm not going to repeat it here.