### PR TITLE
Fix credit icon color regression

### DIFF
--- a/.changeset/metal-chefs-shout.md
+++ b/.changeset/metal-chefs-shout.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes a regression of the Starlight icon color when using the [`credits`](https://starlight.astro.build/reference/configuration/#credits) configuration option.

--- a/packages/starlight/components/Footer.astro
+++ b/packages/starlight/components/Footer.astro
@@ -48,11 +48,14 @@ import { Icon } from '../components';
 			text-decoration: none;
 			color: var(--sl-color-gray-3);
 		}
-		.kudos :global(svg) {
-			color: var(--sl-color-orange);
-		}
 		.kudos:hover {
 			color: var(--sl-color-white);
+		}
+	}
+
+	@layer starlight.components {
+		.kudos :global(svg) {
+			color: var(--sl-color-orange);
 		}
 	}
 </style>


### PR DESCRIPTION
#### Description

This PR fixes a tiny regression in the credit Starlight icon color introduced when switching to cascade layers.

| Before   | After    |
| -------- | -------- |
| <img width="153" alt="SCR-20250421-nppr" src="https://github.com/user-attachments/assets/4af9ee19-450c-4953-9261-7b9dd2474874" /> | <img width="153" alt="SCR-20250421-nprf" src="https://github.com/user-attachments/assets/c6fb421d-8d74-4e15-84d0-152162462b37" /> |

To fix this, the [same approach used in the `<Select>` component](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Select.astro#L89-L99) is applied by moving the rules to the `starlight.components` layer.