### PR TITLE
Ensure layer order in custom pages

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -70,6 +70,23 @@ export default defineConfig({
 			customCss: ['./src/assets/landing.css'],
 			locales,
 			sidebar: [
+				// TODO(HiDeoo) Remove this sidebar group
+				{
+					label: 'Tests',
+					items: [
+						{ link: '/tests/test1/', label: 'Test 1', badge: { text: 'OK', variant: 'success' } },
+						{
+							link: '/tests/test2/',
+							label: 'Test 2',
+							badge: { text: 'Broken', variant: 'danger' },
+						},
+						{
+							link: '/tests/test3/',
+							label: 'Test 3',
+							badge: { text: 'Broken', variant: 'danger' },
+						},
+					],
+				},
 				{
 					label: 'Start Here',
 					translations: {

--- a/docs/src/pages/tests/test1.astro
+++ b/docs/src/pages/tests/test1.astro
@@ -1,0 +1,22 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import { LinkButton } from '@astrojs/starlight/components';
+import AnchorHeading from '@astrojs/starlight/components/AnchorHeading.astro';
+
+// TODO(HiDeoo) Remove this file
+---
+
+<StarlightPage frontmatter={{ title: 'Test 1' }}>
+	<AnchorHeading level="2" id="test">Test</AnchorHeading>
+
+	<p>
+		<a href="https://starlight.astro.build/">Read more in the Starlight docs</a>
+	</p>
+
+	<p>
+		<LinkButton href="/getting-started/">Get started</LinkButton>
+		<LinkButton href="/reference/configuration/" variant="secondary">
+			Configuration Reference
+		</LinkButton>
+	</p>
+</StarlightPage>

--- a/docs/src/pages/tests/test2.astro
+++ b/docs/src/pages/tests/test2.astro
@@ -1,0 +1,22 @@
+---
+import { LinkButton } from '@astrojs/starlight/components';
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import AnchorHeading from '@astrojs/starlight/components/AnchorHeading.astro';
+
+// TODO(HiDeoo) Remove this file
+---
+
+<StarlightPage frontmatter={{ title: 'Test 2' }}>
+	<AnchorHeading level="2" id="test">Test</AnchorHeading>
+
+	<p>
+		<a href="https://starlight.astro.build/">Read more in the Starlight docs</a>
+	</p>
+
+	<p>
+		<LinkButton href="/getting-started/">Get started</LinkButton>
+		<LinkButton href="/reference/configuration/" variant="secondary">
+			Configuration Reference
+		</LinkButton>
+	</p>
+</StarlightPage>

--- a/docs/src/pages/tests/test3.astro
+++ b/docs/src/pages/tests/test3.astro
@@ -1,0 +1,22 @@
+---
+import AnchorHeading from '@astrojs/starlight/components/AnchorHeading.astro';
+import { LinkButton } from '@astrojs/starlight/components';
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+
+// TODO(HiDeoo) Remove this file
+---
+
+<StarlightPage frontmatter={{ title: 'Test 3' }}>
+	<AnchorHeading level="2" id="test">Test</AnchorHeading>
+
+	<p>
+		<a href="https://starlight.astro.build/">Read more in the Starlight docs</a>
+	</p>
+
+	<p>
+		<LinkButton href="/getting-started/">Get started</LinkButton>
+		<LinkButton href="/reference/configuration/" variant="secondary">
+			Configuration Reference
+		</LinkButton>
+	</p>
+</StarlightPage>

--- a/packages/starlight/components.ts
+++ b/packages/starlight/components.ts
@@ -1,3 +1,6 @@
+// Ensure proper cascade layers order by importing user and Starlight CSS layer definitions first.
+import './utils/css-layers';
+
 export { default as Aside } from './user-components/Aside.astro';
 export { default as Badge } from './user-components/Badge.astro';
 export { default as Card } from './user-components/Card.astro';

--- a/packages/starlight/components/AnchorHeading.astro
+++ b/packages/starlight/components/AnchorHeading.astro
@@ -1,4 +1,7 @@
 ---
+// Ensure proper cascade layers order by importing user and Starlight CSS layer definitions first.
+import '../utils/css-layers';
+
 import type { HTMLAttributes } from 'astro/types';
 import { transform } from 'ultrahtml';
 import sanitize from 'ultrahtml/transformers/sanitize';

--- a/packages/starlight/components/Page.astro
+++ b/packages/starlight/components/Page.astro
@@ -1,9 +1,6 @@
 ---
-// Important that this is the first import so it can override cascade layers order.
-import 'virtual:starlight/user-css';
-
-// Starlight nested cascade layers definitions which specify the default order of internal layers.
-import '../style/layers.css';
+// Ensure proper cascade layers order by importing user and Starlight CSS layer definitions first.
+import '../utils/css-layers';
 
 // Built-in CSS styles.
 import '../style/props.css';

--- a/packages/starlight/utils/css-layers.ts
+++ b/packages/starlight/utils/css-layers.ts
@@ -1,0 +1,10 @@
+/**
+ * This file is meant to be imported first in the various Starlight entry points to ensure a
+ * specific order of CSS cascade layers.
+ */
+
+// Important that this is the first import so it can override cascade layers order.
+import 'virtual:starlight/user-css';
+
+// Starlight nested cascade layers definitions which specify the default order of internal layers.
+import '../style/layers.css';


### PR DESCRIPTION
#### Description

In a Starlight content page, we have full control over the CSS import order and [we are making sure](https://github.com/withastro/starlight/blob/6babbc1b1c2a175b31c859b22ad0ce1181124323/packages/starlight/components/Page.astro#L2-L6) that CSS files are imported in the correct order to properly support cascade layers.

However, in custom pages using `<StarlightPage>`, due to how [import order](https://docs.astro.build/en/guides/styling/#import-order) for stylesheets works in Astro, we are not enforcing such order.

This means that the same custom page can ends up with broken styles depending on the order in which components are imported.

For example, the following custom page work as expected as `<StarlightPage>` is imported first which will import `<Page>` which will import the CSS files linked previously:

```astro
---
import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
import AnchorHeading from '@astrojs/starlight/components/AnchorHeading.astro';
import { Aside } from '@astrojs/starlight/components';
---
```

However, having the `<AnchorHeading>` or `<Aside>` component imported first will break the expected order as these components include styles using layers which will end up being ordered by order of usage/import.

To prevent this issue in custom pages, this PR moves the user and Starlight laer definitions to a new file which is now imported first in the `<AnchorHeading>` and the `components.ts` barrel file.

To reproduce the issue locally, comment the changes in `packages/starlight/components.ts` and `packages/starlight/components/AnchorHeading.astro` and visit the test pages included in this PR at [`http://localhost:4321/tests/test2/`](http://localhost:4321/tests/test2/) and [`http://localhost:4321/tests/test3/`](http://localhost:4321/tests/test3/). You should see the styles broken in both pages. After applying the changes, the styles should be fixed.