### PR TITLE
FileTree: Fix hover styles on highlighted directory

### DIFF
--- a/.changeset/eight-rocks-rule.md
+++ b/.changeset/eight-rocks-rule.md
@@ -2,4 +2,4 @@
 '@astrojs/starlight': patch
 ---
 
-Fix hover styles for highlighted directory in FileTree component.
+Fixes hover styles for highlighted directory in FileTree component.

--- a/.changeset/eight-rocks-rule.md
+++ b/.changeset/eight-rocks-rule.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fix hover styles for highlighted directory in FileTree component.

--- a/packages/starlight/user-components/FileTree.astro
+++ b/packages/starlight/user-components/FileTree.astro
@@ -56,6 +56,7 @@ const html = processFileTree(fileTreeHtml, Astro.locals.t('fileTree.directory'))
 		}
 
 		starlight-file-tree :global(.directory > details > summary:hover .highlight .tree-icon) {
+			color: var(--sl-color-text-invert);
 			fill: currentColor;
 		}
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #3147
- Fixes hover styles on highlighted directory. Previously, the folder icon became the same color as the background on hover

Before:
![before-image](https://github.com/user-attachments/assets/fafc0f20-27c2-414a-9686-ed28542c8a59)

After:
![after-image](https://github.com/user-attachments/assets/c6f7a11b-410b-4102-b738-e1fe8cc9732a)


<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
