### PR TITLE
fix(styles): improve last-child selector for list items in markdown.

### DIFF
--- a/packages/starlight/style/markdown.css
+++ b/packages/starlight/style/markdown.css
@@ -26,7 +26,7 @@
 	.sl-markdown-content
 	li
 	> :is(
-		:last-child:not(
+		:last-child:not(:only-child):not(
 				li,
 				ul,
 				ol,
@@ -41,6 +41,23 @@
 				script,
 				:where(.not-content *)
 			),
+
+    /* < Li>is the last one in the list, even if there is only one<p>, it still takes effect*/
+    :last-child:where(li:last-child > :last-child):not(
+        li,
+        ul,
+        ol,
+        a,
+        strong,
+        em,
+        del,
+        span,
+        input,
+        code,
+        br,
+        script,
+        :where(.not-content *)),
+
 			/**
 			 * For list items ending with 1 or multiple script elements (`:has(~ script:last-child)`), we
 			 * need to style the last non-script element (`:not(script)`) that doesn't have a subsequent


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #3146
- What does this PR change? Give us a brief description.
 If the li elements do not have any sub-elements, this shouldn't add this margin-bottom.

- Did you change something visual? A before/after screenshot can be helpful.
![image](https://github.com/user-attachments/assets/39973eb9-c1ab-4d12-b74c-f520dd4ed46a)


