### PR TITLE
Increase `maxBuffer` in `getAllNewestCommitDate`'s `spawnSync` usage

### DIFF
--- a/.changeset/slow-rivers-attack.md
+++ b/.changeset/slow-rivers-attack.md
@@ -2,6 +2,4 @@
 "@astrojs/starlight": patch
 ---
 
-Increased `maxBuffer` in `getAllNewestCommitDate`'s `spawnSync` usage.
-
-This supports larger Git commit histories when using Starlight's [`lastUpdated`](https://starlight.astro.build/reference/configuration/#lastupdated) feature.
+Increases `maxBuffer` for an internal `spawnSync()` call to support larger Git commit histories when using Starlight's [`lastUpdated`](https://starlight.astro.build/reference/configuration/#lastupdated) feature.

--- a/.changeset/slow-rivers-attack.md
+++ b/.changeset/slow-rivers-attack.md
@@ -1,0 +1,7 @@
+---
+"@astrojs/starlight": patch
+---
+
+Increased `maxBuffer` in `getAllNewestCommitDate`'s `spawnSync` usage.
+
+This supports larger Git commit histories when using Starlight's [`lastUpdated`](https://starlight.astro.build/reference/configuration/#lastupdated) feature.

--- a/packages/starlight/utils/git.ts
+++ b/packages/starlight/utils/git.ts
@@ -72,6 +72,7 @@ export function getAllNewestCommitDate(rootPath: string, docsPath: string): [str
 		{
 			cwd: repoRoot,
 			encoding: 'utf-8',
+			maxBuffer: 10 * 1024 * 1024,
 		}
 	);
 

--- a/packages/starlight/utils/git.ts
+++ b/packages/starlight/utils/git.ts
@@ -72,6 +72,12 @@ export function getAllNewestCommitDate(rootPath: string, docsPath: string): [str
 		{
 			cwd: repoRoot,
 			encoding: 'utf-8',
+			// The default `maxBuffer` for `spawnSync` is 1024 * 1024 bytes, a.k.a 1 MB. In big projects,
+			// the full git history can be larger than this, so we increase this to ~10 MB. For example,
+			// Cloudflare passed 1 MB with ~4,800 pages and ~17,000 commits. If we get reports of others
+			// hitting ENOBUFS errors here in the future, we may want to switch to streaming the git log
+			// with `spawn` instead.
+			// See https://github.com/withastro/starlight/issues/3154
 			maxBuffer: 10 * 1024 * 1024,
 		}
 	);


### PR DESCRIPTION
#### Description

Closes https://github.com/withastro/starlight/issues/3154

This could technically be tested, possibly by mocking `execSync` to return a >1MB (the default `maxBuffer` value) output but this shouldn't be a user-visible change unless they were already hitting the limit. 