### PR TITLE
docs: update Tailwind manual installation instructions

### DIFF
--- a/docs/src/content/docs/guides/css-and-tailwind.mdx
+++ b/docs/src/content/docs/guides/css-and-tailwind.mdx
@@ -182,7 +182,7 @@ If you already have a Starlight site and want to add Tailwind CSS, follow these 
     @import 'tailwindcss/utilities.css' layer(utilities);
     ```
 
-4.  Update the Starlight config to use the Tailwind CSS file:
+4.  Update the Starlight config to add the Tailwind CSS file at the first position of the `customCss` array:
 
     ```js ins={11-12}
     // astro.config.mjs

--- a/docs/src/content/docs/guides/css-and-tailwind.mdx
+++ b/docs/src/content/docs/guides/css-and-tailwind.mdx
@@ -182,7 +182,7 @@ If you already have a Starlight site and want to add Tailwind CSS, follow these 
     @import 'tailwindcss/utilities.css' layer(utilities);
     ```
 
-4.  Update the Starlight config to add the Tailwind CSS file at the first position of the `customCss` array:
+4.  Update the Starlight config to add the Tailwind CSS file as the first item in the `customCss` array:
 
     ```js ins={11-12}
     // astro.config.mjs


### PR DESCRIPTION
#### Description

This PR updates the instructions to add Tailwind to an existing project to help with issue 5 in https://github.com/withastro/starlight/issues/3162:

> A few users have [already run](https://discord.com/channels/830184174198718474/1367098187491577928/1367114336870338570) in this issue where their `./src/styles/global.css` was not being the first element in the [`customCss`](https://starlight.astro.build/reference/configuration/#customcss) array which can definitely cause unexpected behavior.

As discussed in the last Talking & Doc'ing session, this PR implements Sarah's suggestions:

- Avoid the "use" word in the instructions and describe what is being done instead.
- Use the reworded instructions from the previous point to add a mention about the position of the `global.css` file in the `customCss` array.
