### PR TITLE
Add constants to exports

### DIFF
--- a/packages/starlight/package.json
+++ b/packages/starlight/package.json
@@ -28,6 +28,7 @@
   "exports": {
     ".": "./index.ts",
     "./locals": "./locals.ts",
+    "./constants": "./constants.ts",
     "./components": "./components.ts",
     "./components/LanguageSelect.astro": {
       "types": "./components/LanguageSelect.astro.tsx",


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Adds constants to exports.
- Overriding PageTitle component was problematic because I could not find a good way to import constants from the Starlight package.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
