### PR TITLE
Prevent heading anchor links on non-Starlight content

### DIFF
--- a/.changeset/pink-cameras-perform.md
+++ b/.changeset/pink-cameras-perform.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes an issue where all headings in Markdown and MDX content were rendered with a [clickable anchor link](https://starlight.astro.build/reference/configuration/#headinglinks), even in non-Starlight pages.

--- a/packages/starlight/__e2e__/components.test.ts
+++ b/packages/starlight/__e2e__/components.test.ts
@@ -391,6 +391,21 @@ test.describe('anchor headings', () => {
 
 		expect(markdownHtml).toEqual(componentHtml);
 	});
+
+	test('does not render headings anchor links for individual Markdown pages and entries not part of the `docs` collection', async ({
+		getProdServer,
+		page,
+	}) => {
+		const starlight = await getProdServer();
+
+		// Individual Markdown page
+		await starlight.goto('/markdown-page');
+		await expect(page.locator('.sl-anchor-link')).not.toBeAttached();
+
+		// Content entry from the `reviews` content collection
+		await starlight.goto('/reviews/alice');
+		await expect(page.locator('.sl-anchor-link')).not.toBeAttached();
+	});
 });
 
 test.describe('head propagation', () => {

--- a/packages/starlight/__e2e__/fixtures/basics/src/content.config.ts
+++ b/packages/starlight/__e2e__/fixtures/basics/src/content.config.ts
@@ -1,7 +1,13 @@
-import { defineCollection } from 'astro:content';
+import { defineCollection, z } from 'astro:content';
 import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
+import { glob } from 'astro/loaders';
 
 export const collections = {
 	docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+	// A collection not handled by Starlight.
+	reviews: defineCollection({
+		loader: glob({ base: './src/content/reviews', pattern: `**/[^_]*.{md,mdx}` }),
+		schema: z.object({ title: z.string() }),
+	}),
 };

--- a/packages/starlight/__e2e__/fixtures/basics/src/content/reviews/alice.mdx
+++ b/packages/starlight/__e2e__/fixtures/basics/src/content/reviews/alice.mdx
@@ -1,0 +1,12 @@
+---
+title: Review from Alice
+---
+
+# Review from Alice
+
+This is a review from Alice.
+
+## Description
+
+This content collection entry is not part of the Starlight `docs` collection.
+It is used to test that anchor links for headings are not generated for non-docs collection entries.

--- a/packages/starlight/__e2e__/fixtures/basics/src/pages/markdown-page.md
+++ b/packages/starlight/__e2e__/fixtures/basics/src/pages/markdown-page.md
@@ -1,0 +1,10 @@
+---
+title: Individual Markdown Page
+---
+
+# Individual Markdown Page
+
+## Description
+
+This page is an [individual Markdown page](https://docs.astro.build/en/guides/markdown-content/#individual-markdown-pages).
+It is used to test that anchor links for headings are not generated for individual Markdown pages.

--- a/packages/starlight/__e2e__/fixtures/basics/src/pages/reviews/[...review].astro
+++ b/packages/starlight/__e2e__/fixtures/basics/src/pages/reviews/[...review].astro
@@ -1,0 +1,21 @@
+---
+import { getEntry, render } from 'astro:content';
+
+/**
+ * This route is used to test that anchor links for headings are not generated for non-docs
+ * collection entries.
+ */
+
+export function getStaticPaths() {
+	return [{ params: { review: 'alice' } }];
+}
+
+// @ts-expect-error - we don't generate types for this test fixture before type-checking the entire
+// project.
+const entry = await getEntry('reviews', 'alice');
+if (!entry) throw new Error('Could not find Alice review entry.');
+
+const { Content } = await render(entry);
+---
+
+<Content />

--- a/packages/starlight/__tests__/remark-rehype/anchor-links.test.ts
+++ b/packages/starlight/__tests__/remark-rehype/anchor-links.test.ts
@@ -30,7 +30,10 @@ const processor = await createMarkdownProcessor({
 	rehypePlugins: [
 		...starlightAutolinkHeadings({
 			starlightConfig,
-			astroConfig: { experimental: { headingIdCompat: false } },
+			astroConfig: {
+				srcDir: astroConfig.srcDir,
+				experimental: { headingIdCompat: false },
+			},
 			useTranslations,
 			absolutePathToLang,
 		}),

--- a/packages/starlight/integrations/heading-links.ts
+++ b/packages/starlight/integrations/heading-links.ts
@@ -101,7 +101,7 @@ export const starlightAutolinkHeadings = ({
 		: [];
 
 /**
- * File path sepators seems to be inconsistent on Windows when the rehype plugin is used on
+ * File path separators seems to be inconsistent on Windows when the rehype plugin is used on
  * Markdown vs MDX files.
  * For the time being, we normalize the path to unix style path.
  */

--- a/packages/starlight/integrations/heading-links.ts
+++ b/packages/starlight/integrations/heading-links.ts
@@ -6,7 +6,7 @@ import { h } from 'hastscript';
 import type { Transformer } from 'unified';
 import { SKIP, visit } from 'unist-util-visit';
 import type { HookParameters, StarlightConfig } from '../types';
-import { getCollectionPath } from '../utils/collection';
+import { resolveCollectionPath } from '../utils/collection';
 
 const AnchorLinkIcon = h(
 	'span',
@@ -93,7 +93,7 @@ export const starlightAutolinkHeadings = ({
 					{ experimentalHeadingIdCompat: astroConfig.experimental?.headingIdCompat },
 				],
 				rehypeAutolinkHeadings(
-					normalizePath(getCollectionPath('docs', astroConfig.srcDir)),
+					normalizePath(resolveCollectionPath('docs', astroConfig.srcDir)),
 					useTranslations,
 					absolutePathToLang
 				),


### PR DESCRIPTION
#### Description

- Closes #3175

In Starlight [`0.34.0`](https://github.com/withastro/starlight/releases/tag/%40astrojs%2Fstarlight%400.34.0), support for generating [clickable anchor links for headings was added](https://github.com/withastro/starlight/pull/3033). For Markdown and MDX content, a rehype plugin is used to generate the links.

When the feature is not disabled, this plugin runs unconditionally, which means that these links are generated for non-Starlight content like [individual Markdown page](https://docs.astro.build/en/guides/markdown-content/#individual-markdown-pages) or content not from the Starlight `docs` content collection.

This PR prevents this behavior by checking if the virtual file path is part of the Starlight `docs` content collection first, and bails if it is not.

For testing, I relied on E2E tests as it seems that on Windows, file path separators are inconsistent when the rehype plugin is used on Markdown vs MDX files. I'll investigate and open a separate issue/PR for that on the Astro repo.

Here is a preview of the changes before and after the fix for an individual Markdown page:

| Before          | After           |
| --------------- | --------------- |
| <img width="235" alt="SCR-20250506-pgpd" src="https://github.com/user-attachments/assets/cab4ef3f-17b1-49d4-b913-9fd57de0d6f0" /> | <img width="235" alt="SCR-20250506-pgre" src="https://github.com/user-attachments/assets/2f85d82d-124e-4b3a-822b-ee121910e403" /> |
