### PR TITLE
i18n(fr): update slot translation and update Astro Docs links

### DIFF
--- a/docs/src/content/docs/fr/guides/overriding-components.mdx
+++ b/docs/src/content/docs/fr/guides/overriding-components.mdx
@@ -67,7 +67,7 @@ Redéfinir les composants par défaut de Starlight peut être utile lorsque :
 
 ## Réutiliser un composant intégré
 
-Vous pouvez utiliser avec les composants par défaut de Starlight comme vous le feriez avec les vôtres : en les important et en les affichant dans vos propres composants personnalisés. Cela vous permet de conserver toute l'interface utilisateur de base de Starlight dans votre design, tout en ajoutant des éléments supplémentaires à côté.
+Vous pouvez utiliser les composants par défaut de Starlight de la même manière que les vôtres : en les important et en les affichant dans vos propres composants personnalisés. Cela vous permet de conserver toute l'interface utilisateur de base de Starlight dans votre design, tout en ajoutant des éléments supplémentaires à côté.
 
 L'exemple ci-dessous montre un composant personnalisé qui affiche un lien de courriel suivi du composant `SocialIcons` par défaut :
 
@@ -81,11 +81,11 @@ import Default from '@astrojs/starlight/components/SocialIcons.astro';
 <Default><slot /></Default>
 ```
 
-Lorsque vous affichez un composant intégré dans un composant personnalisé, ajoutez un élément [`<slot />`](https://docs.astro.build/fr/basics/astro-components/#les-emplacements-slots) à l'intérieur du composant par défaut. Cela permet de s'assurer que si le composant reçoit des éléments enfants, Astro sait où les afficher.
+Lorsque vous affichez un composant intégré dans un composant personnalisé, ajoutez un élément [`<slot />`](https://docs.astro.build/fr/basics/astro-components/#les-slots) à l'intérieur du composant par défaut. Cela permet de s'assurer que si le composant reçoit des éléments enfants, Astro sait où les afficher.
 
-Si vous réutilisez les composants [`PageFrame`](/fr/reference/overrides/#pageframe) ou [`TwoColumnContent`](/fr/reference/overrides/#twocolumncontent) qui contiennent des [emplacements (slots) nommés](https://docs.astro.build/fr/basics/astro-components/#les-emplacements-slots-nomm%C3%A9s), vous devez également [transférer](https://docs.astro.build/fr/basics/astro-components/#transf%C3%A9rer-les-emplacements) ces emplacements.
+Si vous réutilisez les composants [`PageFrame`](/fr/reference/overrides/#pageframe) ou [`TwoColumnContent`](/fr/reference/overrides/#twocolumncontent) qui contiennent des [slots nommés](https://docs.astro.build/fr/basics/astro-components/#les-slots-nomm%C3%A9s), vous devez également [transférer](https://docs.astro.build/fr/basics/astro-components/#transf%C3%A9rer-des-slots) ces slots.
 
-L'exemple ci-dessous montre un composant personnalisé qui réutilise le composant `TwoColumnContent` qui contient un emplacement supplémentaire nommé `right-sidebar` qui doit être transféré :
+L'exemple ci-dessous montre un composant personnalisé qui réutilise le composant `TwoColumnContent` qui contient un slot supplémentaire nommé `right-sidebar` qui doit être transféré :
 
 ```astro {8}
 ---
@@ -128,7 +128,7 @@ Pour en savoir plus sur les propriétés disponibles, consultez la [référence 
 
 Les redéfinitions de composants s'appliquent à toutes les pages. Cependant, vous pouvez les utiliser conditionnellement grâce aux valeurs de `starlightRoute` pour déterminer quand afficher votre interface utilisateur personnalisée, quand afficher l'interface utilisateur par défaut de Starlight, ou même quand afficher quelque chose de complètement différent.
 
-Dans l'exemple suivant, un composant redéfinissant le composant [`Footer`](/fr/reference/overrides/#footer) de Starlight affiche "Construit avec Starlight 🌟" sur la page d'accueil uniquement, et affiche sinon le pied de page par défaut sur toutes les autres pages :
+Dans l'exemple suivant, un composant redéfinissant le composant [`Footer`](/fr/reference/overrides/#footer) de Starlight affiche « Construit avec Starlight 🌟 » sur la page d'accueil uniquement, et affiche sinon le pied de page par défaut sur toutes les autres pages :
 
 ```astro
 ---

--- a/docs/src/content/docs/fr/reference/frontmatter.md
+++ b/docs/src/content/docs/fr/reference/frontmatter.md
@@ -90,7 +90,7 @@ tableOfContents: false
 
 Définit le modèle de mise en page pour cette page.
 Les pages utilisent la mise en page `'doc'`' par défaut.
-La valeur `'splash''` permet d'utiliser une mise en page plus large, sans barres latérales, conçue pour les pages d'atterrissage.
+La valeur `'splash'` permet d'utiliser une mise en page plus large, sans barres latérales, conçue pour les pages d'atterrissage.
 
 ### `hero`
 
@@ -159,7 +159,7 @@ interface HeroConfig {
         alt?: string;
       }
     | {
-        // HTML brut à utiliser dans l'emplacement (slot) de l'image.
+        // HTML brut à utiliser dans le slot de l'image.
         // Peut être une balise `<img>` personnalisée ou une balise `<svg>` en ligne.
         html: string;
       };

--- a/docs/src/content/docs/fr/reference/overrides.md
+++ b/docs/src/content/docs/fr/reference/overrides.md
@@ -55,10 +55,10 @@ Lorsque cela est possible, préférez redéfinir un composant de plus bas niveau
 #### `PageFrame`
 
 **Composant par défaut :** [`PageFrame.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/PageFrame.astro)  
-**Emplacements (slots) nommés :** `header`, `sidebar`
+**Slots nommés :** `header`, `sidebar`
 
 Composant de mise en page contenant la plupart du contenu de la page.
-L'implémentation par défaut configure la mise en page de l'en-tête, de la barre latérale et du contenu principal et inclut des emplacements (slots) nommés `header` et `sidebar` en plus de l'emplacement par défaut pour le contenu principal.
+L'implémentation par défaut configure la mise en page de l'en-tête, de la barre latérale et du contenu principal et inclut des slots nommés `header` et `sidebar` en plus du slot par défaut pour le contenu principal.
 Il affiche également [`<MobileMenuToggle />`](#mobilemenutoggle) qui prend en charge l'affichage de la barre latérale de navigation sur petits écrans (mobiles).
 
 #### `MobileMenuToggle`
@@ -70,7 +70,7 @@ Composant utilisé à l'intérieur de [`<PageFrame>`](#pageframe) qui est respon
 #### `TwoColumnContent`
 
 **Composant par défaut :** [`TwoColumnContent.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/TwoColumnContent.astro)  
-**Emplacement (slot) nommé :** `right-sidebar`
+**Slot nommé :** `right-sidebar`
 
 Composant de mise en page enveloppant le contenu principal de la page et la barre latérale de droite (table des matières).
 L'implémentation par défaut prend en charge le changement entre une mise en page à une seule colonne pour petits écrans et une mise en page à deux colonnes pour écrans plus larges.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

* Updates `overriding-components.mdx` to fix Astro Docs links (see https://github.com/withastro/docs/pull/11658)
* Updates some files referring to `slot` following up https://github.com/withastro/docs/pull/11593 (ie. `slot` is an Astro feature and the tag can't be translated so we keep it untranslated when referring to it)
* A rewording in a file where I'll left a comment to explain why.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
