### PR TITLE
docs: add Tailwind instructions on how to use multiple configs

### DIFF
--- a/docs/src/content/docs/guides/css-and-tailwind.mdx
+++ b/docs/src/content/docs/guides/css-and-tailwind.mdx
@@ -210,7 +210,7 @@ If you already have a Starlight site and want to add Tailwind CSS, follow these 
 
 ### Add site-wide Tailwind support to an existing project
 
-If you are using [custom pages](/guides/pages/#custom-pages) with you Starlight site, or if you are using [Starlight at a subpath](/manual-setup/#use-starlight-at-a-subpath), and want to add site-wide Tailwind support with different Tailwind CSS configurations, follow these steps.
+If you are using [custom pages](/guides/pages/#custom-pages) with your Starlight site, or if you are using [Starlight at a subpath](/manual-setup/#use-starlight-at-a-subpath), and want to add site-wide Tailwind support with different Tailwind CSS configurations, follow these steps.
 
 <Steps>
 

--- a/docs/src/content/docs/guides/css-and-tailwind.mdx
+++ b/docs/src/content/docs/guides/css-and-tailwind.mdx
@@ -71,6 +71,8 @@ Any styles in the `my-overrides` layer would take precedence over Starlight’s 
 Tailwind CSS support in Astro projects is provided by the [Tailwind Vite plugin](https://tailwindcss.com/docs/installation/using-vite).
 Starlight provides complementary CSS to help configure Tailwind for compatibility with Starlight’s styles.
 
+You can [create a new project with Tailwind](#create-a-new-project-with-tailwind), [add Tailwind to an existing project](#create-a-new-project-with-tailwind), or [add site-wide Tailwind support to an existing project with different Tailwind CSS configurations](#add-site-wide-tailwind-support-to-an-existing-project) when using custom pages or Starlight at a subpath.
+
 The Starlight Tailwind CSS applies the following configuration:
 
 - Configures Tailwind’s `dark:` variants to work with Starlight’s dark mode.
@@ -197,6 +199,81 @@ If you already have a Starlight site and want to add Tailwind CSS, follow these 
     			customCss: [
     				// Path to your Tailwind base styles:
     				'./src/styles/global.css',
+    			],
+    		}),
+    	],
+    	vite: { plugins: [tailwindcss()] },
+    });
+    ```
+
+</Steps>
+
+### Add site-wide Tailwind support to an existing project
+
+If you are using [custom pages](/guides/pages/#custom-pages) with you Starlight site, or if you are using [Starlight at a subpath](/manual-setup/#use-starlight-at-a-subpath), and want to add site-wide Tailwind support with different Tailwind CSS configurations, follow these steps.
+
+<Steps>
+
+1.  [Enable Tailwind support](https://docs.astro.build/en/guides/styling/#add-tailwind-4) in your Astro project if you have not already done so.
+
+    The `src/styles/global.css` file scaffolded during this process will be used to provide Tailwind support for all your non-Starlight pages.
+
+2.  Install Starlight’s Tailwind compatibility package:
+
+    <Tabs syncKey="pkg">
+
+    <TabItem label="npm">
+
+    ```sh
+    npm install @astrojs/starlight-tailwind
+    ```
+
+    </TabItem>
+
+    <TabItem label="pnpm">
+
+    ```sh
+    pnpm add @astrojs/starlight-tailwind
+    ```
+
+    </TabItem>
+
+    <TabItem label="Yarn">
+
+    ```sh
+    yarn add @astrojs/starlight-tailwind
+    ```
+
+    </TabItem>
+
+    </Tabs>
+
+3.  Create a new Tailwind CSS file in `src/styles/starlight.css` which will be used to provide Tailwind support for all your Starlight pages.
+
+    ```css
+    /* src/styles/starlight.css */
+    @layer base, starlight, theme, components, utilities;
+
+    @import '@astrojs/starlight-tailwind';
+    @import 'tailwindcss/theme.css' layer(theme);
+    @import 'tailwindcss/utilities.css' layer(utilities);
+    ```
+
+4.  Update the Starlight config to add this newly created Tailwind CSS file as the first item in the `customCss` array:
+
+    ```js ins={11-12}
+    // astro.config.mjs
+    import { defineConfig } from 'astro/config';
+    import starlight from '@astrojs/starlight';
+    import tailwindcss from '@tailwindcss/vite';
+
+    export default defineConfig({
+    	integrations: [
+    		starlight({
+    			title: 'Docs with Tailwind',
+    			customCss: [
+    				// Path to your Tailwind base styles for Starlight:
+    				'./src/styles/starlight.css',
     			],
     		}),
     	],


### PR DESCRIPTION
#### Description

This PR updates the Tailwind instructions to help with issue 6 in https://github.com/withastro/starlight/issues/3162:

> When using custom pages or Starlight at a subpath and want to use Tailwind on both your main site/custom pages and Starlight, you propably want to use a default Tailwind setup for your main website/custom pages and a different one for Starlight which would use the Starlight’s Tailwind compatibility package.

1. My initial assessment was only focusing on the case of using Starlight at a subpath.
2. My initial idea was to add a small sentence in the existing Tailwind instructions, e.g.:

   > If you are using [Starlight at a subpath](https://starlight.astro.build/manual-setup/#use-starlight-at-a-subpath), you can use a different [Tailwind CSS file](https://docs.astro.build/en/guides/styling/#add-tailwind-4) for your main website often imported in a layout component.

3. After discussing the topic during Talking and Doc'ing, the idea of creating a entirely new sub-section "Add site-wide Tailwind support with Starlight at a subpath" was identified as a better approach. Even though it was vaguely similar to the existing ["Add Tailwind to an existing project" section](https://starlight.astro.build/guides/css-and-tailwind/#add-tailwind-to-an-existing-project), it gives the user better instructions, and in the "Tailwind CSS" intro section, we can link to the various possible setups.

4. When working on the PR and checking various support threads, I realized that this setup may not only be useful for Starlight at a subpath, but also for users who want to use [custom pages](https://starlight.astro.build/guides/pages/#custom-pages).

This PR keeps the new idea of creating a new sub-section but tries to cover both use cases: custom pages and Starlight at a subpath.

Other ideas discarded during T&D:

- Not re-using `src/styles/global.css` in our "Add Tailwind to an existing project" section but instead creating a new `src/styles/starlight.css` file so that it's more obvious that this file is only used for Starlight and the other one is only used for the main site/custom pages.

  This was discarded because `src/styles/global.css` is automatically scaffolded by Astro and this use-case is still a small percentage of users. That would mean that most people would end up with an `src/styles/global.css` file that they don't need.