### PR TITLE
Fix E2E tests compatibility with Node.js 23+

### DIFF
--- a/packages/starlight/__e2e__/test-utils.ts
+++ b/packages/starlight/__e2e__/test-utils.ts
@@ -77,10 +77,13 @@ export function testFactory(fixturePath: string) {
 
 // A Playwright test fixture accessible from within all tests.
 class StarlightPage {
-	constructor(
-		private readonly server: Server,
-		private readonly page: Page
-	) {}
+	private readonly server: Server;
+	private readonly page: Page;
+
+	constructor(server: Server, page: Page) {
+		this.server = server;
+		this.page = page;
+	}
 
 	// Navigate to a URL relative to the server used during a test run and return the resource response.
 	goto(url: string) {


### PR DESCRIPTION
#### Description

Initially [spotted by Chris](https://discord.com/channels/830184174198718474/1141080502443446373/1359968759703671077), E2E tests are failing with Node.js 23+. This is due to the new [type stripping](https://nodejs.org/api/all.html#all_typescript_type-stripping) which is automatically triggered by Playwright when using `.ts` test files and some TypeScript code in our tests not supported by the new Node.js type stripping.

This is [not a Playwright issue](https://github.com/microsoft/playwright/issues/34263#issuecomment-2579949362) and the recommendation would be to either refactor this code, or use a flag like `--no-experimental-strip-types`. Using the flag approach is not really feasible in our case, as we don't really enforce a specific Node.js version for running E2E tests, e.g. we run them against Node.js 18 on CI but a maintainer could use a more recent version locally and specifying an unknown Node.js flag results in an error. We could use a script which dynamically detects the Node.js version and sets the flag accordingly, but this is getting out of hand for only a few lines of code.

This PR refactors the affected code to be compatible with the new Node.js type stripping. The only affected code is a usage of [TypeScript Parameter Properties](https://www.typescriptlang.org/docs/handbook/2/classes.html#parameter-properties) which is [unsupported by Node.js type stripping](https://nodejs.org/docs/latest-v23.x/api/typescript.html#typescript-features) as it requires a transformation step.

The PR refactors the affected code to remove this syntax.

Here are screenshots of the E2E tests running on Node.js `v24.0.1` before and after the fix:

| Before   | After    |
| -------- | -------- |
| <img width="688" alt="SCR-20250513-kyyf" src="https://github.com/user-attachments/assets/02a5f74a-3237-4cd7-a5fc-08b5a9507150" /> | <img width="1316" alt="SCR-20250513-kzcc" src="https://github.com/user-attachments/assets/f15f1088-b8ce-45c8-9d51-fc5e3e7120f8" /> |
