### PR TITLE
Exclude E2E tests build output from formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,7 @@
 
 # Generated Directories
 **/dist
+**/build
 **/.astro
 **/__coverage__
 


### PR DESCRIPTION
#### Description

I noticed when running `pnpm format` locally that we are formatting some `astro build` output files [used in our E2E SSR tests](https://github.com/withastro/starlight/blob/ac03713632e931fe949ee467c82a6214e5888a23/packages/starlight/__e2e__/fixtures/ssr/astro.config.mjs#L15).

This PR adds the `build` output directory to the `.prettierignore` file so that we never format these files.

This should not have any impact on CI as we don't run these tests in the formatting workflow altho locally, it can save a few seconds of formatting time for people running the command if they have also run our E2E tests.