### PR TITLE
i18n(de): Update route-data.mdx

### DIFF
--- a/docs/src/content/docs/de/reference/route-data.mdx
+++ b/docs/src/content/docs/de/reference/route-data.mdx
@@ -81,7 +81,7 @@ Der Slug für diese Seite oder die eindeutige ID für diese Seite, die auf dem D
 
 ### `isFallback`
 
-**Typ:** `true | undefined`
+**Typ:** `boolean | undefined`
 
 `true`, wenn diese Seite in der aktuellen Sprache unübersetzt ist und Fallback-Inhalte aus dem Standardgebiets&shy;schema verwendet.
 Wird nur in mehrsprachigen Websites verwendet.


### PR DESCRIPTION
This PR updates the German translation of `reference/route-data.mdx` with the changes from #3046.
I'm not sure why this change is not visible in the i18n tracker, but I'm glad I found the missing translation nonetheless! 🙌 