### PR TITLE
Fix double click selection issues for heading with a clickable anchor link

### DIFF
--- a/packages/starlight/style/anchor-links.css
+++ b/packages/starlight/style/anchor-links.css
@@ -91,6 +91,9 @@ how we do it.
 		/* Prevent double or triple clicks from potentially selecting the anchor link a11y text. */
 		-webkit-user-select: none;
 		user-select: none;
+		/* Prevent double clicks on the last word (or single word) of a heading to include an extra new
+     line in Chrome and Safari. */
+		display: inline-flex;
 	}
 
 	/* Increase clickable area for anchor links with a pseudo element that doesn’t impact layout. */


### PR DESCRIPTION
#### Description

This PR is a follow-up to #3140.

__This PR is a draft PR as I'd like to get some eyes on it with mutliple people testing it in multiple browsers during a Talking and Doc'ing session.__

Turns out that the issue was not entirely fixed:

- Use Chrome or Safari
- Double click the last word (or single word for a heading with only 1 word) of a heading with a clickable anchor link
- Copy the selected text

The clipboard will contain an extra new line character at the end of the copied text.

- My [initial fix in Astro Docs](https://github.com/withastro/docs/pull/8015) was also not entirely correct as the issue only happens when the anchor link is after the heading, but on larger displays, in Astro Docs, the anchor link is currently before the heading. To reproduce the issue in Astro Docs, you need to resize the window to make the anchor link appear after the heading.
- My testing method was bad: I double clicked a word, copied it to my clipboard, pressed `Cmd + T` to open a new tab and focus the address bar, and pasted the text there. This is not a good test as the address bar will trim any trailing new line characters. To properly test this, I should have pasted the text in a text editor.

After quite a bit of trial and error, one of the solution I found was to change the `display` property of the link to `inline-flex` (`inline-block` does not work, don't ask me why) which should not have any side effects.