### PR TITLE
i18n(fr): update `environmental-impact.md`

### DIFF
--- a/docs/src/content/docs/fr/environmental-impact.md
+++ b/docs/src/content/docs/fr/environmental-impact.md
@@ -1,32 +1,32 @@
 ---
-title: Documents écologiques
+title: Documentations écologiques
 description: Découvrez comment Starlight peut vous aider à créer des documentations plus écologiques et à réduire votre empreinte carbone.
 ---
 
 Les estimations de l'impact climatique de l'industrie du web varient entre [2 %][sf] et [4 % des émissions mondiales de carbone][bbc], ce qui équivaut à peu près aux émissions de l'industrie du transport aérien.
-Le calcul de l'impact écologique d'un site web repose sur de nombreux facteurs complexes, mais ce guide contient quelques conseils pour réduire l'empreinte écologique de votre site documentaire.
+Le calcul de l'impact écologique d'un site web repose sur de nombreux facteurs complexes, mais ce guide contient quelques conseils pour réduire l'empreinte écologique de votre site de documentation.
 
 La bonne nouvelle, c'est que le choix de Starlight est un excellent début.
-Selon le Website Carbon Calculator, ce site est [plus propre que 99 % des pages web testées][sl-carbon], produisant 0,01 g de CO₂ par page visitée.
+Selon le Website Carbon Calculator, ce site est [plus propre que 98 % des pages web testées][sl-carbon], produisant 0,01 g de CO₂ par page visitée.
 
 ## Poids de la page
 
 Plus une page web transfère de données, plus elle nécessite de ressources énergétiques.
 En avril 2023, la page web médiane demandait à l'utilisateur de télécharger plus de 2 000 Ko selon les [données de l'archive HTTP][http].
 
-Starlight construit des pages aussi légères que possible.
+Starlight crée des pages aussi légères que possible.
 Par exemple, lors de sa première visite, un utilisateur téléchargera moins de 50 Ko de données compressées, soit seulement 2,5 % de la médiane des archives HTTP.
 Avec une bonne stratégie de mise en cache, les navigations suivantes peuvent télécharger jusqu'à 10 Ko.
 
 ### Images
 
 Bien que Starlight fournisse une bonne base de référence, les images que vous ajoutez à vos pages de documentation peuvent rapidement augmenter le poids de vos pages.
-Starlight utilise le [support d'actifs optimisés][assets] d'Astro pour optimiser les images locales dans vos fichiers Markdown et MDX.
+Starlight utilise la [prise en charge des ressources optimisées][assets] d'Astro pour optimiser les images locales dans vos fichiers Markdown et MDX.
 
 ### Composants d'interface utilisateur
 
-Les composants construits avec des frameworks d'interface utilisateur tels que React ou Vue peuvent facilement ajouter de grandes quantités de JavaScript à une page.
-Starlight étant construit sur Astro, les composants de ce type chargent **zéro JavaScript côté client par défaut** grâce à [Astro Islands][islands].
+Les composants créés avec des frameworks d'interface utilisateur tels que React ou Vue peuvent facilement ajouter de grandes quantités de JavaScript à une page.
+Starlight étant construit sur Astro, les composants de ce type chargent **zéro JavaScript côté client par défaut** grâce aux [îlots d'Astro][islands].
 
 ### Mise en cache
 
@@ -35,7 +35,7 @@ Une bonne stratégie de mise en cache permet à l'utilisateur d'obtenir un nouve
 
 La façon la plus courante de configurer la mise en cache est d'utiliser l'en-tête HTTP [`Cache-Control`][cache].
 Lorsque vous utilisez Starlight, vous pouvez définir une longue durée de mise en cache pour tout ce qui se trouve dans le répertoire `/_astro/`.
-Ce répertoire contient des fichiers CSS, JavaScript, et d'autres actifs intégrés qui peuvent être mis en cache pour toujours, réduisant ainsi les téléchargements inutiles :
+Ce répertoire contient des fichiers CSS, JavaScript, et d'autres ressources intégrées qui peuvent être mises en cache pour toujours, réduisant ainsi les téléchargements inutiles :
 
 ```
 Cache-Control: public, max-age=604800, immutable


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Updates the French translation of `environment-impact` with changes from #3216 + small edits kinda related to https://github.com/withastro/docs/pull/11593:
* translate `Astro Island`
* replace `construits` with `créés` in some places to vary the wording (and it sounds better in French)
* replace `documentaire` with `documentation` (not the same meaning)
* replace `documents` with `documentation` (I think this a translation error because of `docs` in the English version)
* replace `actif` with `ressource`: `actif` is a word [that comes from the financial field](https://www.culture.fr/franceterme/Resultats-de-recherche?q=asset&domaine=0) and while this is put forward because of the crypto world, I believe this is a translation error. We usually use [`ressource`](https://fr.wiktionary.org/wiki/asset).

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
