### PR TITLE
Support Astro 5.9 new API renderMarkdown

### DIFF
--- a/packages/starlight/__tests__/remark-rehype/anchor-links.test.ts
+++ b/packages/starlight/__tests__/remark-rehype/anchor-links.test.ts
@@ -1,88 +1,69 @@
-import { createMarkdownProcessor, type MarkdownProcessor } from '@astrojs/markdown-remark';
 import { expect, test } from 'vitest';
-import { createTranslationSystemFromFs } from '../../utils/translations-fs';
-import { StarlightConfigSchema, type StarlightUserConfig } from '../../utils/user-config';
-import { absolutePathToLang as getAbsolutePathFromLang } from '../../integrations/shared/absolutePathToLang';
-import { starlightAutolinkHeadings } from '../../integrations/heading-links';
+import { createMarkdownTestHelper, type AstroMarkdownOptions } from './setupMarkdown';
 
-const starlightConfig = StarlightConfigSchema.parse({
-	title: 'Anchor Links Tests',
-	locales: { en: { label: 'English' }, fr: { label: 'French' } },
-	defaultLocale: 'en',
-} satisfies StarlightUserConfig);
-
-const astroConfig = {
-	root: new URL(import.meta.url),
-	srcDir: new URL('./_src/', import.meta.url),
-};
-
-const useTranslations = createTranslationSystemFromFs(
-	starlightConfig,
-	// Using non-existent `_src/` to ignore custom files in this test fixture.
-	{ srcDir: new URL('./_src/', import.meta.url) }
-);
-
-function absolutePathToLang(path: string) {
-	return getAbsolutePathFromLang(path, { astroConfig, starlightConfig });
-}
-
-const processor = await createMarkdownProcessor({
-	rehypePlugins: [
-		...starlightAutolinkHeadings({
-			starlightConfig,
-			astroConfig: {
-				srcDir: astroConfig.srcDir,
-				experimental: { headingIdCompat: false },
-			},
-			useTranslations,
-			absolutePathToLang,
-		}),
-	],
-});
-
-function renderMarkdown(
-	content: string,
-	options: { fileURL?: URL; processor?: MarkdownProcessor } = {}
-) {
-	return (options.processor ?? processor).render(
-		content,
-		// @ts-expect-error fileURL is part of MarkdownProcessor's options
-		{ fileURL: options.fileURL ?? new URL(`./_src/content/docs/index.md`, import.meta.url) }
-	);
-}
+const title = 'Anchor Links Tests';
+const astroMarkdownOptions: AstroMarkdownOptions = ['rehype'];
 
 test('generates anchor link markup', async () => {
-	const res = await renderMarkdown(`
+  const { renderMarkdown } = await createMarkdownTestHelper({
+    userConfig: { title },
+    astroMarkdownOptions,
+  });
+
+  const res = await renderMarkdown(`
 ## Some text
 `);
-	await expect(res.code).toMatchFileSnapshot('./snapshots/generates-anchor-link-markup.html');
+  await expect(res.code).toMatchFileSnapshot('./snapshots/generates-anchor-link-markup.html');
 });
 
 test('generates an accessible link label', async () => {
-	const res = await renderMarkdown(`
+  const { renderMarkdown } = await createMarkdownTestHelper({
+    userConfig: {
+      title,
+      defaultLocale: 'en',
+    },
+    astroMarkdownOptions,
+  });
+
+  const res = await renderMarkdown(`
 ## Some text
 `);
-	expect(res.code).includes('<span class="sr-only">Section titled “Some text”</span>');
+  expect(res.code).includes('<span class="sr-only">Section titled “Some text”</span>');
 });
 
 test('strips HTML markup in accessible link label', async () => {
-	const res = await renderMarkdown(`
+  const { renderMarkdown } = await createMarkdownTestHelper({
+    userConfig: {
+      title,
+    },
+    astroMarkdownOptions,
+  });
+
+  const res = await renderMarkdown(`
 ## Some _important nested \`HTML\`_
 `);
-	// Heading renders HTML
-	expect(res.code).includes('Some <em>important nested <code>HTML</code></em>');
-	// Visually hidden label renders plain text
-	expect(res.code).includes(
-		'<span class="sr-only">Section titled “Some important nested HTML”</span>'
-	);
+  // Heading renders HTML
+  expect(res.code).includes('Some <em>important nested <code>HTML</code></em>');
+  // Visually hidden label renders plain text
+  expect(res.code).includes(
+    '<span class="sr-only">Section titled “Some important nested HTML”</span>'
+  );
 });
 
 test('localizes accessible label for the current language', async () => {
-	const res = await renderMarkdown(
-		`
+  const { renderMarkdown } = await createMarkdownTestHelper({
+    userConfig: {
+      title,
+      defaultLocale: 'fr',
+    },
+    astroMarkdownOptions,
+  });
+
+  const res = await renderMarkdown(
+    `
 ## Some text
 `,
-		{ fileURL: new URL('./_src/content/docs/fr/index.md', import.meta.url) }
-	);
-	expect(res.code).includes('<span class="sr-only">Section intitulée « Some text »</span>');
+    { fileURL: new URL('./_src/content/docs/fr/index.md', import.meta.url) }
+  );
+  expect(res.code).includes('<span class="sr-only">Section intitulée « Some text »</span>');
 });

--- a/packages/starlight/__tests__/remark-rehype/asides.test.ts
+++ b/packages/starlight/__tests__/remark-rehype/asides.test.ts
@@ -1,142 +1,133 @@
-import { createMarkdownProcessor, type MarkdownProcessor } from '@astrojs/markdown-remark';
 import type { Root } from 'mdast';
 import { visit } from 'unist-util-visit';
 import { describe, expect, test } from 'vitest';
 import { starlightAsides, remarkDirectivesRestoration } from '../../integrations/asides';
-import { createTranslationSystemFromFs } from '../../utils/translations-fs';
+import { createMarkdownTestHelper, type AstroMarkdownOptions } from './setupMarkdown';
 import { StarlightConfigSchema, type StarlightUserConfig } from '../../utils/user-config';
-import { BuiltInDefaultLocale } from '../../utils/i18n';
+import { createTranslationSystemFromFs } from '../../utils/translations-fs';
 import { absolutePathToLang as getAbsolutePathFromLang } from '../../integrations/shared/absolutePathToLang';
 
-const starlightConfig = StarlightConfigSchema.parse({
-	title: 'Asides Tests',
-	locales: { en: { label: 'English' }, fr: { label: 'French' } },
-	defaultLocale: 'en',
-} satisfies StarlightUserConfig);
-
-const astroConfig = {
-	root: new URL(import.meta.url),
-	srcDir: new URL('./_src/', import.meta.url),
-};
-
-const useTranslations = createTranslationSystemFromFs(
-	starlightConfig,
-	// Using non-existent `_src/` to ignore custom files in this test fixture.
-	{ srcDir: new URL('./_src/', import.meta.url) }
-);
-
-function absolutePathToLang(path: string) {
-	return getAbsolutePathFromLang(path, { astroConfig, starlightConfig });
-}
-
-const processor = await createMarkdownProcessor({
-	remarkPlugins: [
-		...starlightAsides({
-			starlightConfig,
-			astroConfig,
-			useTranslations,
-			absolutePathToLang,
-		}),
-		// The restoration plugin is run after the asides and any other plugin that may have been
-		// injected by Starlight plugins.
-		remarkDirectivesRestoration,
-	],
-});
-
-function renderMarkdown(
-	content: string,
-	options: { fileURL?: URL; processor?: MarkdownProcessor } = {}
-) {
-	return (options.processor ?? processor).render(
-		content,
-		// @ts-expect-error fileURL is part of MarkdownProcessor's options
-		{ fileURL: options.fileURL ?? new URL(`./_src/content/docs/index.md`, import.meta.url) }
-	);
-}
+const title = 'Asides Tests';
+const astroMarkdownOptions: AstroMarkdownOptions = ['remark'];
 
 test('generates aside', async () => {
-	const res = await renderMarkdown(`
+  const { renderMarkdown } = await createMarkdownTestHelper({
+    userConfig: { title },
+    astroMarkdownOptions,
+  });
+
+  const res = await renderMarkdown(`
 :::note
 Some text
 :::
 `);
-	await expect(res.code).toMatchFileSnapshot('./snapshots/generates-aside.html');
+  await expect(res.code).toMatchFileSnapshot('./snapshots/generates-aside.html');
 });
 
-describe('default labels', () => {
-	test.each([
-		['note', 'Note'],
-		['tip', 'Tip'],
-		['caution', 'Caution'],
-		['danger', 'Danger'],
-	])('%s has label %s', async (type, label) => {
-		const res = await renderMarkdown(`
+describe('default labels', async () => {
+  const { renderMarkdown } = await createMarkdownTestHelper({
+    userConfig: { title },
+    astroMarkdownOptions,
+  });
+
+  test.each([
+    ['note', 'Note'],
+    ['tip', 'Tip'],
+    ['caution', 'Caution'],
+    ['danger', 'Danger'],
+  ])('%s has label %s', async (type, label) => {
+    const res = await renderMarkdown(`
 :::${type}
 Some text
 :::
 `);
-		expect(res.code).includes(`aria-label="${label}"`);
-		expect(res.code).includes(`</svg>${label}</p>`);
-	});
+    expect(res.code).includes(`aria-label="${label}"`);
+    expect(res.code).includes(`</svg>${label}</p>`);
+  });
 });
 
-describe('custom labels', () => {
-	test.each(['note', 'tip', 'caution', 'danger'])('%s with custom label', async (type) => {
-		const label = 'Custom Label';
-		const res = await renderMarkdown(`
+describe('custom labels', async () => {
+  const { renderMarkdown } = await createMarkdownTestHelper({
+    userConfig: { title },
+    astroMarkdownOptions,
+  });
+
+  test.each(['note', 'tip', 'caution', 'danger'])('%s with custom label', async (type) => {
+    const label = 'Custom Label';
+    const res = await renderMarkdown(`
 :::${type}[${label}]
 Some text
 :::
   `);
-		expect(res.code).includes(`aria-label="${label}"`);
-		expect(res.code).includes(`</svg>${label}</p>`);
-	});
+    expect(res.code).includes(`aria-label="${label}"`);
+    expect(res.code).includes(`</svg>${label}</p>`);
+  });
 });
 
-describe('custom labels with nested markdown', () => {
-	test.each(['note', 'tip', 'caution', 'danger'])('%s with custom code label', async (type) => {
-		const label = 'Custom `code` Label';
-		const labelWithoutMarkdown = 'Custom code Label';
-		const labelHtml = 'Custom <code>code</code> Label';
-		const res = await renderMarkdown(`
+describe('custom labels with nested markdown', async () => {
+  const { renderMarkdown } = await createMarkdownTestHelper({
+    userConfig: { title },
+    astroMarkdownOptions,
+  });
+
+  test.each(['note', 'tip', 'caution', 'danger'])('%s with custom code label', async (type) => {
+    const label = 'Custom `code` Label';
+    const labelWithoutMarkdown = 'Custom code Label';
+    const labelHtml = 'Custom <code>code</code> Label';
+    const res = await renderMarkdown(`
 :::${type}[${label}]
 Some text
 :::
   `);
-		expect(res.code).includes(`aria-label="${labelWithoutMarkdown}"`);
-		expect(res.code).includes(`</svg>${labelHtml}</p>`);
-	});
+    expect(res.code).includes(`aria-label="${labelWithoutMarkdown}"`);
+    expect(res.code).includes(`</svg>${labelHtml}</p>`);
+  });
 });
 
-describe('custom labels with doubly-nested markdown', () => {
-	test.each(['note', 'tip', 'caution', 'danger'])(
-		'%s with custom doubly-nested label',
-		async (type) => {
-			const label = 'Custom **strong with _emphasis_** Label';
-			const labelWithoutMarkdown = 'Custom strong with emphasis Label';
-			const labelHtml = 'Custom <strong>strong with <em>emphasis</em></strong> Label';
-			const res = await renderMarkdown(`
+describe('custom labels with doubly-nested markdown', async () => {
+  const { renderMarkdown } = await createMarkdownTestHelper({
+    userConfig: { title },
+    astroMarkdownOptions,
+  });
+
+  test.each(['note', 'tip', 'caution', 'danger'])(
+    '%s with custom doubly-nested label',
+    async (type) => {
+      const label = 'Custom **strong with _emphasis_** Label';
+      const labelWithoutMarkdown = 'Custom strong with emphasis Label';
+      const labelHtml = 'Custom <strong>strong with <em>emphasis</em></strong> Label';
+      const res = await renderMarkdown(`
 :::${type}[${label}]
 Some text
 :::
   `);
-			expect(res.code).includes(`aria-label="${labelWithoutMarkdown}"`);
-			expect(res.code).includes(`</svg>${labelHtml}</p>`);
-		}
-	);
+      expect(res.code).includes(`aria-label="${labelWithoutMarkdown}"`);
+      expect(res.code).includes(`</svg>${labelHtml}</p>`);
+    }
+  );
 });
 
 test('ignores unknown directive variants', async () => {
-	const res = await renderMarkdown(`
+  const { renderMarkdown } = await createMarkdownTestHelper({
+    userConfig: { title },
+    astroMarkdownOptions,
+  });
+
+  const res = await renderMarkdown(`
 :::unknown
 Some text
 :::
 `);
-	expect(res.code).toMatchInlineSnapshot('"<div><p>Some text</p></div>"');
+  expect(res.code).toMatchInlineSnapshot('"<div><p>Some text</p></div>"');
 });
 
 test('handles complex children', async () => {
-	const res = await renderMarkdown(`
+  const { renderMarkdown } = await createMarkdownTestHelper({
+    userConfig: { title },
+    astroMarkdownOptions,
+  });
+
+  const res = await renderMarkdown(`
 :::note
 Paragraph [link](/href/).
 
@@ -150,11 +141,16 @@ More.
 </details>
 :::
 `);
-	await expect(res.code).toMatchFileSnapshot('./snapshots/handles-complex-children.html');
+  await expect(res.code).toMatchFileSnapshot('./snapshots/handles-complex-children.html');
 });
 
 test('nested asides', async () => {
-	const res = await renderMarkdown(`
+  const { renderMarkdown } = await createMarkdownTestHelper({
+    userConfig: { title },
+    astroMarkdownOptions,
+  });
+
+  const res = await renderMarkdown(`
 ::::note
 Note contents.
 
@@ -164,11 +160,16 @@ Nested tip.
 
 ::::
 `);
-	await expect(res.code).toMatchFileSnapshot('./snapshots/nested-asides.html');
+  await expect(res.code).toMatchFileSnapshot('./snapshots/nested-asides.html');
 });
 
 test('nested asides with custom titles', async () => {
-	const res = await renderMarkdown(`
+  const { renderMarkdown } = await createMarkdownTestHelper({
+    userConfig: { title },
+    astroMarkdownOptions,
+  });
+
+  const res = await renderMarkdown(`
 :::::caution[Caution with a custom title]
 Nested caution.
 
@@ -183,154 +184,205 @@ Nested tip.
 
 :::::
 `);
-	const labels = [...res.code.matchAll(/aria-label="(?<label>[^"]+)"/g)].map(
-		(match) => match.groups?.label
-	);
-	expect(labels).toMatchInlineSnapshot(`
+  const labels = [...res.code.matchAll(/aria-label="(?<label>[^"]+)"/g)].map(
+    (match) => match.groups?.label
+  );
+  expect(labels).toMatchInlineSnapshot(`
 		[
 		  "Caution with a custom title",
 		  "Note",
 		  "Tip with a custom title",
 		]
 	`);
-	await expect(res.code).toMatchFileSnapshot('./snapshots/nested-asides-custom-titles.html');
+  await expect(res.code).toMatchFileSnapshot('./snapshots/nested-asides-custom-titles.html');
 });
 
-describe('translated labels in French', () => {
-	test.each([
-		['note', 'Note'],
-		['tip', 'Astuce'],
-		['caution', 'Attention'],
-		['danger', 'Danger'],
-	])('%s has label %s', async (type, label) => {
-		const res = await renderMarkdown(
-			`
+describe('translated labels in French', async () => {
+  const { renderMarkdown } = await createMarkdownTestHelper({
+    userConfig: {
+      title,
+      defaultLocale: 'fr',
+    },
+    astroMarkdownOptions,
+  });
+
+  test.each([
+    ['note', 'Note'],
+    ['tip', 'Astuce'],
+    ['caution', 'Attention'],
+    ['danger', 'Danger'],
+  ])('%s has label %s', async (type, label) => {
+    const res = await renderMarkdown(
+      `
 :::${type}
 Some text
 :::
 `,
-			{ fileURL: new URL('./_src/content/docs/fr/index.md', import.meta.url) }
-		);
-		expect(res.code).includes(`aria-label="${label}"`);
-		expect(res.code).includes(`</svg>${label}</p>`);
-	});
+      { fileURL: new URL('./_src/content/docs/fr/index.md', import.meta.url) }
+    );
+    expect(res.code).includes(`aria-label="${label}"`);
+    expect(res.code).includes(`</svg>${label}</p>`);
+  });
 });
 
 test('runs without locales config', async () => {
-	const processor = await createMarkdownProcessor({
-		remarkPlugins: [
-			...starlightAsides({
-				starlightConfig: {
-					// With no locales config, the default built-in locale is used.
-					defaultLocale: { ...BuiltInDefaultLocale, locale: 'en' },
-					locales: undefined,
-				},
-				astroConfig: {
-					root: new URL(import.meta.url),
-					srcDir: new URL('./_src/', import.meta.url),
-				},
-				useTranslations,
-				absolutePathToLang,
-			}),
-			remarkDirectivesRestoration,
-		],
-	});
-	const res = await renderMarkdown(':::note\nTest\n::', { processor });
-	expect(res.code.includes('aria-label=Note"'));
+  const { renderMarkdown } = await createMarkdownTestHelper({
+    userConfig: { title },
+    astroMarkdownOptions,
+  });
+
+  const res = await renderMarkdown(':::note\nTest\n::');
+  expect(res.code.includes('aria-label=Note"'));
 });
 
 test('transforms back unhandled text directives', async () => {
-	const res = await renderMarkdown(
-		`This is a:test of a sentence with a text:name[content]{key=val} directive.`
-	);
-	expect(res.code).toMatchInlineSnapshot(`
+  const { renderMarkdown } = await createMarkdownTestHelper({
+    userConfig: { title },
+    astroMarkdownOptions,
+  });
+
+  const res = await renderMarkdown(
+    `This is a:test of a sentence with a text:name[content]{key=val} directive.`
+  );
+  expect(res.code).toMatchInlineSnapshot(`
 		"<p>This is a:test of a sentence with a text:name[content]{key="val"} directive.</p>"
 	`);
 });
 
 test('transforms back unhandled leaf directives', async () => {
-	const res = await renderMarkdown(`::video[Title]{v=xxxxxxxxxxx}`);
-	expect(res.code).toMatchInlineSnapshot(`
+  const { renderMarkdown } = await createMarkdownTestHelper({
+    userConfig: { title },
+    astroMarkdownOptions,
+  });
+
+  const res = await renderMarkdown(`::video[Title]{v=xxxxxxxxxxx}`);
+  console.log(res.code)
+  expect(res.code).toMatchInlineSnapshot(`
 		"<p>::video[Title]{v="xxxxxxxxxxx"}</p>"
 	`);
 });
 
 test('does not add any whitespace character after any unhandled directive', async () => {
-	const res = await renderMarkdown(`## Environment variables (astro:env)`);
-	expect(res.code).toMatchInlineSnapshot(
-		`"<h2 id="environment-variables-astroenv">Environment variables (astro:env)</h2>"`
-	);
-	expect(res.code).not.toMatch(/\n/);
+  const { renderMarkdown } = await createMarkdownTestHelper({
+    userConfig: { title },
+    astroMarkdownOptions,
+  });
+
+  const res = await renderMarkdown(`## Environment variables (astro:env)`);
+  expect(res.code).toMatchInlineSnapshot(
+    `"<h2 id="environment-variables-astroenv">Environment variables (astro:env)</h2>"`
+  );
+  expect(res.code).not.toMatch(/\n/);
 });
 
 test('lets remark plugin injected by Starlight plugins handle text and leaf directives', async () => {
-	const processor = await createMarkdownProcessor({
-		remarkPlugins: [
-			...starlightAsides({
-				starlightConfig,
-				astroConfig: {
-					root: new URL(import.meta.url),
-					srcDir: new URL('./_src/', import.meta.url),
-				},
-				useTranslations,
-				absolutePathToLang,
-			}),
-			// A custom remark plugin injected by a Starlight plugin through an Astro integration would
-			// run before the restoration plugin.
-			function customRemarkPlugin() {
-				return function transformer(tree: Root) {
-					visit(tree, (node, index, parent) => {
-						if (node.type !== 'textDirective' || typeof index !== 'number' || !parent) return;
-						if (node.name === 'abbr') {
-							parent.children.splice(index, 1, { type: 'text', value: 'TEXT FROM REMARK PLUGIN' });
-						}
-					});
-				};
-			},
-			remarkDirectivesRestoration,
-		],
-	});
+  const starlightConfig = StarlightConfigSchema.parse({
+    title: 'Asides Tests',
+    locales: { en: { label: 'English' }, fr: { label: 'French' } },
+    defaultLocale: 'en',
+  } satisfies StarlightUserConfig);
 
-	const res = await renderMarkdown(
-		`This is a:test of a sentence with a :abbr[SL]{name="Starlight"} directive handled by another remark plugin and some other text:name[content]{key=val} directives not handled by any plugin.`,
-		{ processor }
-	);
-	expect(res.code).toMatchInlineSnapshot(`
+  const astroConfig = {
+    root: new URL(import.meta.url),
+    srcDir: new URL('./_src/', import.meta.url),
+  };
+
+  const useTranslations = createTranslationSystemFromFs(
+    starlightConfig,
+    // Using non-existent `_src/` to ignore custom files in this test fixture.
+    { srcDir: new URL('./_src/', import.meta.url) }
+  );
+
+  function absolutePathToLang(path: string) {
+    return getAbsolutePathFromLang(path, { astroConfig, starlightConfig });
+  }
+
+  const { renderMarkdown } = await createMarkdownTestHelper({
+    userConfig: { title },
+    astroMarkdownOptions,
+    remarkPlugins: [
+      ...starlightAsides({
+        starlightConfig,
+        astroConfig: {
+          root: new URL(import.meta.url),
+          srcDir: new URL('./_src/', import.meta.url),
+        },
+        useTranslations,
+        absolutePathToLang,
+      }),
+      // A custom remark plugin injected by a Starlight plugin through an Astro integration would
+      // run before the restoration plugin.
+      function customRemarkPlugin() {
+        return function transformer(tree: Root) {
+          visit(tree, (node, index, parent) => {
+            if (node.type !== 'textDirective' || typeof index !== 'number' || !parent) return;
+            if (node.name === 'abbr') {
+              parent.children.splice(index, 1, { type: 'text', value: 'TEXT FROM REMARK PLUGIN' });
+            }
+          });
+        };
+      },
+      remarkDirectivesRestoration,
+    ],
+  });
+
+  const res = await renderMarkdown(
+    `This is a:test of a sentence with a :abbr[SL]{name="Starlight"} directive handled by another remark plugin and some other text:name[content]{key=val} directives not handled by any plugin.`
+  );
+  expect(res.code).toMatchInlineSnapshot(`
 		"<p>This is a:test of a sentence with a TEXT FROM REMARK PLUGIN directive handled by another remark plugin and some other text:name[content]{key="val"} directives not handled by any plugin.</p>"
 	`);
 });
 
 test('does not transform back directive nodes with data', async () => {
-	const processor = await createMarkdownProcessor({
-		remarkPlugins: [
-			...starlightAsides({
-				starlightConfig,
-				astroConfig: {
-					root: new URL(import.meta.url),
-					srcDir: new URL('./_src/', import.meta.url),
-				},
-				useTranslations,
-				absolutePathToLang,
-			}),
-			// A custom remark plugin updating the node with data that should be consumed by rehype.
-			function customRemarkPlugin() {
-				return function transformer(tree: Root) {
-					visit(tree, (node) => {
-						if (node.type !== 'textDirective') return;
-						node.data ??= {};
-						node.data.hName = 'span';
-						node.data.hProperties = { class: `api` };
-					});
-				};
-			},
-			remarkDirectivesRestoration,
-		],
-	});
+  const starlightConfig = StarlightConfigSchema.parse({
+    title: 'Asides Tests',
+    locales: { en: { label: 'English' }, fr: { label: 'French' } },
+    defaultLocale: 'en',
+  } satisfies StarlightUserConfig);
 
-	const res = await renderMarkdown(`This method is available in the :api[thing] API.`, {
-		processor,
-	});
-	expect(res.code).toMatchInlineSnapshot(
-		`"<p>This method is available in the <span class="api">thing</span> API.</p>"`
-	);
+  const astroConfig = {
+    root: new URL(import.meta.url),
+    srcDir: new URL('./_src/', import.meta.url),
+  };
+
+  const useTranslations = createTranslationSystemFromFs(
+    starlightConfig,
+    // Using non-existent `_src/` to ignore custom files in this test fixture.
+    { srcDir: new URL('./_src/', import.meta.url) }
+  );
+
+  function absolutePathToLang(path: string) {
+    return getAbsolutePathFromLang(path, { astroConfig, starlightConfig });
+  }
+
+  const { renderMarkdown } = await createMarkdownTestHelper({
+    userConfig: { title },
+    astroMarkdownOptions,
+    remarkPlugins: [
+      ...starlightAsides({
+        starlightConfig,
+        astroConfig,
+        useTranslations,
+        absolutePathToLang,
+      }),
+      // A custom remark plugin updating the node with data that should be consumed by rehype.
+      function customRemarkPlugin() {
+        return function transformer(tree: Root) {
+          visit(tree, (node) => {
+            if (node.type !== 'textDirective') return;
+            node.data ??= {};
+            node.data.hName = 'span';
+            node.data.hProperties = { class: `api` };
+          });
+        };
+      },
+      remarkDirectivesRestoration,
+    ],
+  });
+
+  const res = await renderMarkdown(`This method is available in the :api[thing] API.`);
+  expect(res.code).toMatchInlineSnapshot(
+    `"<p>This method is available in the <span class="api">thing</span> API.</p>"`
+  );
 });

--- a/packages/starlight/__tests__/remark-rehype/setupMarkdown.ts
+++ b/packages/starlight/__tests__/remark-rehype/setupMarkdown.ts
@@ -1,0 +1,92 @@
+import { createMarkdownProcessor } from '@astrojs/markdown-remark';
+import { starlightAutolinkHeadings } from '../../integrations/heading-links';
+import { createTranslationSystemFromFs } from '../../utils/translations-fs';
+import { absolutePathToLang as getAbsolutePathFromLang } from '../../integrations/shared/absolutePathToLang';
+import { StarlightConfigSchema, type StarlightUserConfig } from '../../utils/user-config';
+import { starlightAsides, remarkDirectivesRestoration } from '../../integrations/asides';
+
+export type AstroMarkdownOptions = Array<'rehype' | 'remark'>;
+
+export async function createMarkdownTestHelper({
+  userConfig = {},
+  remarkPlugins,
+  rehypePlugins,
+  astroMarkdownOptions = [],
+}: {
+  userConfig?: Partial<StarlightUserConfig>;
+  remarkPlugins?: any[] | undefined;
+  rehypePlugins?: any[] | undefined;
+    astroMarkdownOptions: AstroMarkdownOptions;
+}) {
+  const starlightConfig = StarlightConfigSchema.parse({
+    title: 'Markdown render Tests',
+    locales: { en: { label: 'English' }, fr: { label: 'French' } },
+    defaultLocale: 'en',
+    ...userConfig,
+  } satisfies StarlightUserConfig);
+
+  const astroConfig = {
+    root: new URL(import.meta.url),
+    srcDir: new URL('./_src/', import.meta.url),
+  };
+
+  const useTranslations = createTranslationSystemFromFs(starlightConfig, {
+    srcDir: astroConfig.srcDir,
+  });
+
+  const absolutePathToLang = (path: string) =>
+    getAbsolutePathFromLang(path, { astroConfig, starlightConfig });
+
+  const defaultRehypePlugins = [
+    ...starlightAutolinkHeadings({
+      starlightConfig,
+      astroConfig: {
+        srcDir: astroConfig.srcDir,
+        experimental: { headingIdCompat: false },
+      },
+      useTranslations,
+      absolutePathToLang,
+    }),
+  ];
+
+  const defaultRemarkPlugins = [
+    ...starlightAsides({
+      starlightConfig,
+      astroConfig,
+      useTranslations,
+      absolutePathToLang,
+    }),
+    // The restoration plugin is run after the asides and any other plugin that may have been
+    // injected by Starlight plugins.
+    remarkDirectivesRestoration,
+  ];
+
+  const processorOptions: Record<string, any> = {};
+
+  if (astroMarkdownOptions.includes('rehype')) {
+    processorOptions.rehypePlugins = rehypePlugins ?? defaultRehypePlugins;
+  }
+
+  if (astroMarkdownOptions.includes('remark')) {
+    processorOptions.remarkPlugins = remarkPlugins ?? defaultRemarkPlugins;
+  }
+
+  const processor = await createMarkdownProcessor(processorOptions);
+
+  function renderMarkdown(
+    content: string,
+    options: { fileURL?: URL } = {}
+  ) {
+    return processor.render(
+      content,
+      {
+        // @ts-expect-error fileURL is part of MarkdownProcessor's options
+        fileURL:
+          options.fileURL ??
+          new URL(`./_src/content/docs/index.md`, import.meta.url),
+      }
+    );
+  }
+
+  return { renderMarkdown, starlightConfig, processor };
+}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description


- Closes #3239
Create a [‘createMarkdownTestHelper`](https://github.com/sgalcheung/starlight/blob/b4c829dabc01861e9155747335ba1c0242db0930/packages/starlight/__tests__/remark-rehype/setupMarkdown.ts#L10) method to reduce repeated creation of createMarkdownProcessor, and this method could initialize different parameters in the test method, so we get all tests passed!

before
<img width="932" alt="image" src="https://github.com/user-attachments/assets/4587c290-5b7f-4347-b038-bcb1e4e49780" />

after
<img width="819" alt="image" src="https://github.com/user-attachments/assets/00c2f9ea-7cf0-42e1-99cb-f3ab7d6da98b" />

Next, I will create a test to reproduce this bug, so that we can better verify the modified code logic.