### PR TITLE
Prevent `<Card>` icon from being shrunk

### DIFF
--- a/.changeset/two-dolphins-drive.md
+++ b/.changeset/two-dolphins-drive.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Prevents [icons in the `<Card>` component](https://starlight.astro.build/components/cards/#add-icons-to-cards) from being shrunk in some narrow viewports.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -4,7 +4,8 @@ head:
   - tag: title
     content: Starlight 🌟 Build documentation sites with Astro
 description: Starlight helps you build beautiful, high-performance documentation websites with Astro.
-template: splash
+# TODO(HiDeoo) Uncomment the following line
+# template: splash
 editUrl: false
 lastUpdated: false
 banner:

--- a/packages/starlight/user-components/Card.astro
+++ b/packages/starlight/user-components/Card.astro
@@ -58,6 +58,7 @@ const { icon, title } = Astro.props;
 			background-color: var(--sl-card-bg);
 			padding: 0.2em;
 			border-radius: 0.25rem;
+			flex-shrink: 0;
 		}
 		.card .body {
 			margin: 0;


### PR DESCRIPTION
#### Description

Initially [spotted](https://github.com/withastro/docs/pull/11870#issuecomment-2966754497) by @ArmandPhilippot in Astro Docs, this PR prevents icons in `<Card>` components from being shrunk.

| Before | After |
| ------ | ----- |
| <img width="931" alt="SCR-20250613-jnwj" src="https://github.com/user-attachments/assets/d41f9848-c9d4-4ea1-a11e-2849f268bfa7" />   | <img width="931" alt="SCR-20250613-jnyw" src="https://github.com/user-attachments/assets/adba8e5a-ff6f-4ad3-9ca5-32e784ae03a0" />   |

##### Remaining tasks

- [ ] Remove the code change in `docs/src/content/docs/index.mdx` only used to make the issue more visible.