### PR TITLE
i18n(zh-cn): Update authoring-content.mdx (#3268)

### DIFF
--- a/docs/src/content/docs/zh-cn/guides/authoring-content.mdx
+++ b/docs/src/content/docs/zh-cn/guides/authoring-content.mdx
@@ -260,7 +260,7 @@ Expressive Code 提供了几种自定义你的代码示例视觉外观的选项�
 
   </TabItem>
 
-  <TabItem label="Markdown/MDX">
+  <TabItem label="Markdoc">
 
   ````md
   ```js {% meta="{2-3}" %}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #3268
- What does this PR change? Give us a brief description.  
This PR fixes a typo in the Chinese authoring guide: the `<TabItem>` label was incorrectly written as `"Markdown/MDX"` and is corrected to `"Markdoc"`.  
- Did you change something visual? A before/after screenshot can be helpful.  
![image](https://github.com/user-attachments/assets/1e5ecc42-93b8-477e-9667-5fe741b75360)
![image](https://github.com/user-attachments/assets/30f79fd6-4da9-4ee9-a2a5-1a25793c5e03)



<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
