### PR TITLE
Style Pagefind root excerpt

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -35,6 +35,8 @@ export default defineConfig({
 	trailingSlash: 'always',
 	integrations: [
 		starlight({
+			// TODO(HiDeoo) Remove
+			routeMiddleware: './src/routeData.ts',
 			title: 'Starlight',
 			logo: {
 				light: '/src/assets/logo-light.svg',

--- a/docs/src/routeData.ts
+++ b/docs/src/routeData.ts
@@ -1,0 +1,9 @@
+// TODO(HiDeoo) Remove
+
+import { defineRouteMiddleware } from '@astrojs/starlight/route-data';
+
+export const onRequest = defineRouteMiddleware((context) => {
+	context.locals.starlightRoute.entry.data.banner = {
+		content: 'This is a <a href="https://starlight.astro.build/">test banner</a>.',
+	};
+});

--- a/packages/starlight/components/Search.astro
+++ b/packages/starlight/components/Search.astro
@@ -361,13 +361,15 @@ if (project.trailingSlash === 'never') dataAttributes['data-strip-trailing-slash
 			padding: 0;
 		}
 
-		#starlight__search .pagefind-ui__result-nested {
+		#starlight__search .pagefind-ui__result-nested,
+		#starlight__search .pagefind-ui__result-excerpt:not(:where(.pagefind-ui__result-nested *)) {
 			position: relative;
 			padding: var(--sl-search-result-nested-pad-block) var(--sl-search-result-pad-inline-end);
 			padding-inline-start: var(--sl-search-result-pad-inline-start);
 		}
 
 		#starlight__search .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)),
+		#starlight__search .pagefind-ui__result-excerpt:not(:where(.pagefind-ui__result-nested *)),
 		#starlight__search .pagefind-ui__result-nested {
 			position: relative;
 			background-color: var(--sl-color-black);
@@ -387,6 +389,7 @@ if (project.trailingSlash === 'never') dataAttributes['data-strip-trailing-slash
 			background-color: var(--sl-color-accent-low);
 		}
 
+		#starlight__search .pagefind-ui__result-excerpt:not(:where(.pagefind-ui__result-nested *)),
 		#starlight__search .pagefind-ui__result-thumb,
 		#starlight__search .pagefind-ui__result-inner {
 			margin-top: 0;
@@ -435,6 +438,8 @@ if (project.trailingSlash === 'never') dataAttributes['data-strip-trailing-slash
 			content: unset;
 		}
 
+		#starlight__search
+			.pagefind-ui__result-excerpt:not(:where(.pagefind-ui__result-nested *))::before,
 		#starlight__search .pagefind-ui__result-nested::before {
 			content: '';
 			position: absolute;
@@ -450,6 +455,18 @@ if (project.trailingSlash === 'never') dataAttributes['data-strip-trailing-slash
 		#starlight__search .pagefind-ui__result-nested:last-of-type::before {
 			-webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' viewBox='0 0 16 16'%3E%3Cpath d='M8 0v12m6 0H8'/%3E%3C/svg%3E");
 			mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' viewBox='0 0 16 16'%3E%3Cpath d='M8 0v12m6 0H8'/%3E%3C/svg%3E");
+		}
+
+		#starlight__search
+			.pagefind-ui__result-excerpt:not(:where(.pagefind-ui__result-nested *))::before {
+			-webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' viewBox='0 0 16 1000' preserveAspectRatio='xMinYMin slice'%3E%3Cpath d='M8 0v1000'/%3E%3C/svg%3E")
+				0% 0% / 100% no-repeat;
+			mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' viewBox='0 0 16 1000' preserveAspectRatio='xMinYMin slice'%3E%3Cpath d='M8 0v1000'/%3E%3C/svg%3E")
+				0% 0% / 100% no-repeat;
+		}
+		#starlight__search
+			.pagefind-ui__result-excerpt:not(:where(.pagefind-ui__result-nested *)):last-child::before {
+			content: unset;
 		}
 
 		/* Flip page and tree icons around the vertical axis when in an RTL layout. */


### PR DESCRIPTION
#### Description

- Closes #3267

In Pagefind, when searching the [indexed content section](https://pagefind.app/docs/indexing/#limiting-what-sections-of-a-page-are-indexed), if a result is [found before the first heading](https://github.com/Pagefind/pagefind/blob/d7d0b3a0f0eb12661cd2eb894ad02f10687a4ca0/pagefind_ui/default/svelte/result_with_subs.svelte#L31-L32), an extra excerpt is [shown below the page title](https://github.com/Pagefind/pagefind/blob/d7d0b3a0f0eb12661cd2eb894ad02f10687a4ca0/pagefind_ui/default/svelte/result_with_subs.svelte#L66-L68).

At the moment, we do not style this excerpt at all in Starlight altho it can appear under some conditions, e.g. having a banner with content that is a potential match, and as we render `<Banner>` in `<main>` (our `data-pagefind-body`), before the `<PageTitle>`, it'll be detected as root sub result and the excerpt will be shown.

This PR adds some basic styling to the root excerpt so that it is visually consistent with the rest of the search results altho I'm personally not really happy with the result, as it kinda looks like a result rather than just an excerpt for a root result? I'm definitely not the best person when it comes to design, but I think we may be able to improve it further? A difference from nested results is that the title/link and excerpt are not grouped together with a parent element, they're just siblings in the entire page results.

|                    | Preview  |
| ------------------ | -------- |
| With subresults    | <img width="605" alt="SCR-20250702-kqta" src="https://github.com/user-attachments/assets/35b2d1fb-14ad-4df0-a9b5-171e7802521d" /> |
| With no subresults | <img width="602" alt="SCR-20250702-kqvy" src="https://github.com/user-attachments/assets/634aefb4-488e-4e44-a9a0-252c63700e6a" /> |

This PR includes a temporary route data middleware adding a banner to every page so searching something like `test` will show the root excerpt.

#### Remaining tasks

- [ ] Add a changeset when happy with the PR so we have more context about how to describe the change