### PR TITLE
Exclude banner content from Pagefind indexing

### DIFF
--- a/.changeset/smooth-pillows-decide.md
+++ b/.changeset/smooth-pillows-decide.md
@@ -1,0 +1,9 @@
+---
+'@astrojs/starlight': minor
+---
+
+Excludes banner content from search results
+
+Previously, content set in [`banner`](https://starlight.astro.build/reference/frontmatter/#banner) in page frontmatter was indexed by Starlight’s default search provider Pagefind. This could cause unexpected search results, especially for sites setting a common banner content on multiple pages. Starlight’s default `Banner` component is now excluded from search indexing.
+
+This change does not impact `Banner` overrides using custom components.

--- a/packages/starlight/components/Banner.astro
+++ b/packages/starlight/components/Banner.astro
@@ -2,7 +2,7 @@
 const { banner } = Astro.locals.starlightRoute.entry.data;
 ---
 
-{banner && <div class="sl-banner" set:html={banner.content} />}
+{banner && <div class="sl-banner" data-pagefind-ignore set:html={banner.content} />}
 
 <style>
 	@layer starlight.core {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #3267
- Partially addresses the issue raised in #3267 where a banner’s content would end up indexed by Pagefind and displayed in search results by excluding the default `Banner.astro` component from indexing.
- #3271 will address the styling issues more fully for cases where this still occurs, but I think it makes sense for us to exclude banner content nonetheless as it’s often unexpected for this content to show up in search results, especially for sites where people set banners to show up on all pages for example.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
