### PR TITLE
Made working with sidebars a little easier

### DIFF
--- a/packages/starlight/components/SidebarSublist.astro
+++ b/packages/starlight/components/SidebarSublist.astro
@@ -21,7 +21,7 @@ const { sublist, nested } = Astro.props;
 					<a
 						href={entry.href}
 						aria-current={entry.isCurrent && 'page'}
-						class:list={[{ large: !nested }, entry.attrs.class]}
+						class:list={['sl-sidebar-link', { large: !nested }, entry.attrs.class]}
 						{...entry.attrs}
 					>
 						<span>{entry.label}</span>

--- a/packages/starlight/types.ts
+++ b/packages/starlight/types.ts
@@ -5,3 +5,4 @@ export type {
 	HookParameters,
 } from './utils/plugins';
 export type { StarlightIcon } from './components/Icons';
+import type { SidebarEntry } from './utils/routing/types';

--- a/packages/starlight/types.ts
+++ b/packages/starlight/types.ts
@@ -5,4 +5,4 @@ export type {
 	HookParameters,
 } from './utils/plugins';
 export type { StarlightIcon } from './components/Icons';
-import type { SidebarEntry } from './utils/routing/types';
+export type { SidebarEntry } from './utils/routing/types';


### PR DESCRIPTION
## Description

- Closes #3264
- Added a new `'sl-sidebar-link'` class to sidebar links.
- Exported the `SidebarEntry` type
