### PR TITLE
Fix Astro i18n config default locale issue

### DIFF
--- a/.changeset/pretty-snakes-behave.md
+++ b/.changeset/pretty-snakes-behave.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes a potential configuration issue for multilingual sites with a default language including a regional subtag.

--- a/packages/starlight/__tests__/i18n-non-root-single-locale/i18n.test.ts
+++ b/packages/starlight/__tests__/i18n-non-root-single-locale/i18n.test.ts
@@ -7,7 +7,8 @@ describe('processI18nConfig', () => {
 	test('returns the Astro i18n config for a monolingual site with a non-root single locale', () => {
 		const { astroI18nConfig, starlightConfig } = processI18nConfig(config, undefined);
 
-		expect(astroI18nConfig.defaultLocale).toBe('fr-CA');
+		// The default locale should match its associated custom locale `path`.
+		expect(astroI18nConfig.defaultLocale).toBe('fr');
 		expect(astroI18nConfig.locales).toMatchInlineSnapshot(`
 			[
 			  {

--- a/packages/starlight/__tests__/i18n/i18n.test.ts
+++ b/packages/starlight/__tests__/i18n/i18n.test.ts
@@ -7,7 +7,8 @@ describe('processI18nConfig', () => {
 	test('returns the Astro i18n config for a multilingual site with no root locale', () => {
 		const { astroI18nConfig, starlightConfig } = processI18nConfig(config, undefined);
 
-		expect(astroI18nConfig.defaultLocale).toBe('en-US');
+		// The default locale should match its associated custom locale `path`.
+		expect(astroI18nConfig.defaultLocale).toBe('en');
 		expect(astroI18nConfig.locales).toMatchInlineSnapshot(`
 			[
 			  {

--- a/packages/starlight/utils/i18n.ts
+++ b/packages/starlight/utils/i18n.ts
@@ -53,8 +53,11 @@ export function processI18nConfig(
 /** Generate an Astro i18n configuration based on a Starlight configuration. */
 function getAstroI18nConfig(config: StarlightConfig): NonNullable<AstroConfig['i18n']> {
 	return {
+		// When using custom locale `path`s, the default locale must match one of these paths.
+		// In Starlight, this matches the `locale` property if defined, and we fallback to the `lang`
+		// property if not (which would be set to the language’s directory name by default).
 		defaultLocale:
-			config.defaultLocale.lang ?? config.defaultLocale.locale ?? BuiltInDefaultLocale.lang,
+			config.defaultLocale.locale ?? config.defaultLocale.lang ?? BuiltInDefaultLocale.lang,
 		locales: config.locales
 			? Object.entries(config.locales).map(([locale, localeConfig]) => {
 					return {


### PR DESCRIPTION
#### Description

- Closes #3099

This PR fixes an issue where Starlight can generate an invalid Astro i18n configuration.

When using [custom locale paths](https://docs.astro.build/en/guides/internationalization/#custom-locale-paths), the default locale should match one of these paths. The current version uses the `lang` property of the `defaultLocale` configuration first, which would be fine in most cases, but for multilingual sites without a root locale and a default language that includes a regional subtag (e.g., `zh-CN`), this would not match the custom locale path (e.g. `zh-CN` instead of `zh-cn`).

We actually had tests checking the default locale of the generated Astro i18n configuration for similar cases but they were actually asserting the wrong value. I think this is something I missed at the time of the original implementation, altho I've added a todo for myself to make it either more obvious in the Astro Docs or maybe showcase that in the existing example instead of using `en` as the default locale which does not use a custom locale path.