### PR TITLE
Revert #3281

### DIFF
--- a/.changeset/breezy-months-kneel.md
+++ b/.changeset/breezy-months-kneel.md
@@ -1,5 +1,0 @@
----
-"@astrojs/starlight": patch
----
-
-Adds a `sl-sidebar-link` class to sidebar links

--- a/packages/starlight/components/SidebarSublist.astro
+++ b/packages/starlight/components/SidebarSublist.astro
@@ -21,7 +21,7 @@ const { sublist, nested } = Astro.props;
 					<a
 						href={entry.href}
 						aria-current={entry.isCurrent && 'page'}
-						class:list={['sl-sidebar-link', { large: !nested }, entry.attrs.class]}
+						class:list={[{ large: !nested }, entry.attrs.class]}
 						{...entry.attrs}
 					>
 						<span>{entry.label}</span>


### PR DESCRIPTION
#### Description

- This PR reverts the changes made in #3281

- In #3281 we initially agreed to add a class name to every link in the sidebar. After approving and merging, I realised I hadn’t considered all the implications.

- Sidebars are one of the heftier parts of Starlight’s HTML output. Especially for larger sites. For example, Astro’s docs currently include 215 links in its sidebar. This means any changes to sidebar entry markup can quickly accumulate given they can be reproduced 100s of time on every page (in the uncached HTML). Using the Astro docs example, this adds up to multiple kilobytes per page.

- Given this, we discussed it a bit with the team and decided adding a class name like this is not justified. It is already feasible to target these links with CSS:
   ```css
   .sidebar-content a { /* styles */ }
   ```
   Adding a dedicated class name doesn’t provide any new functionality that is not currently available, and adds bloat to the HTML output, which may prove significant for content-heavy sites.