### PR TITLE
Fix slug override with `/` value

### DIFF
--- a/.changeset/popular-planets-whisper.md
+++ b/.changeset/popular-planets-whisper.md
@@ -2,4 +2,4 @@
 '@astrojs/starlight': patch
 ---
 
-Fixes an issue preventing to override the slug of a page with the `slug` frontmatter property using the `/` value.
+Fixes an issue preventing to override the slug of a page with the [`slug` frontmatter property](https://starlight.astro.build/reference/frontmatter/#slug) using the `/` value.

--- a/.changeset/popular-planets-whisper.md
+++ b/.changeset/popular-planets-whisper.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes an issue preventing to override the slug of a page with the `slug` frontmatter property using the `/` value.

--- a/packages/starlight/__tests__/basics/slugs.test.ts
+++ b/packages/starlight/__tests__/basics/slugs.test.ts
@@ -31,6 +31,9 @@ describe('slugToParam', () => {
 	test('returns undefined for root index', () => {
 		expect(slugToParam('index')).toBeUndefined();
 	});
+	test('returns undefined for /', () => {
+		expect(slugToParam('/')).toBeUndefined();
+	});
 	test('strips index from end of nested slug', () => {
 		expect(slugToParam('dir/index')).toBe('dir');
 		expect(slugToParam('dir/index/sub-dir/index')).toBe('dir/index/sub-dir');

--- a/packages/starlight/utils/slugs.ts
+++ b/packages/starlight/utils/slugs.ts
@@ -40,7 +40,7 @@ function localeToDir(locale: string | undefined): 'ltr' | 'rtl' {
 }
 
 export function slugToParam(slug: string): string | undefined {
-	return slug === 'index' || slug === ''
+	return slug === 'index' || slug === '' || slug === '/'
 		? undefined
 		: slug.endsWith('/index')
 			? slug.slice(0, -6)


### PR DESCRIPTION
#### Description

- Closes #3277

This PR fixes an issue preventing to override the slug of a page with the `slug` frontmatter property using the `/` value.

Huge thanks to @ArmandPhilippot for all the help in debugging this issue and setting up many reproductions pinpointing the problem.

As visible in this [StackBlitz example](https://stackblitz.com/edit/github-ynnmqg3z?file=src%2Fpages%2F%5B...slug%5D.astro), a dynamic route parameter set to the `/` value ends being `undefined` in `Astro.params`. In Starlight, we have an [`slugToParam`](https://github.com/withastro/starlight/blob/c07478ba8480b24c4c967dd660a39b844f3900fc/packages/starlight/utils/slugs.ts#L42-L48) function which does not handle this case.

With Starlight `0.32` and the introduction of route data, we are now always calling [`getRoute()`](https://github.com/withastro/starlight/blob/main/packages/starlight/utils/routing/data.ts#L28-L33) (which uses [`getRouteBySlugParam`](https://github.com/withastro/starlight/blob/main/packages/starlight/utils/routing/index.ts#L102-L104)) with the `context.params.slug` value (whereas before this was only used in SSR). When explicitly setting the `slug` frontmatter property to `/`, this results in the `getRouteBySlugParam()` being called with an `undefined` parameter but as the `slugToParam()` function does not handle this case, it's failing to find the route (which instead of having a key of `undefined` has a key of `/`).

Another local test to verify the fix:

1. Run `pnpm dev` in the `docs/` directory.
2. Delete the `docs/src/content/docs/index.mdx` file.
3. Add the following frontmatter field to `docs/src/content/docs/reference/configuration.mdx`:

   ```md
   slug: /
   ```

Before the fix, opening `http://localhost:4321/` would result in a `404` error. After the fix, it correctly displays the configuration reference page.