### PR TITLE
Fix `absolutePathToLang()` issue

### DIFF
--- a/.changeset/dry-tomatoes-camp.md
+++ b/.changeset/dry-tomatoes-camp.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes a potential issue with `absolutePathToLang()` not handling paths with spaces correctly.

--- a/packages/starlight/__tests__/plugins/translations.test.ts
+++ b/packages/starlight/__tests__/plugins/translations.test.ts
@@ -68,4 +68,6 @@ test('can infer langs from an absolute path in the plugin context using absolute
 	expect(langs[1]).toBe('pt-BR');
 	// A page not matching any language defaults to the default language.
 	expect(langs[2]).toBe('en');
+	// A known language and an absolute path containing spaces.
+	expect(langs[3]).toBe('ar');
 });

--- a/packages/starlight/__tests__/plugins/vitest.config.ts
+++ b/packages/starlight/__tests__/plugins/vitest.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { defineVitestConfig } from '../test-config';
 
 export default defineVitestConfig({
@@ -77,9 +78,10 @@ export default defineVitestConfig({
 							useTranslations('en')('testPlugin3.doThing'),
 						],
 						langs: [
-							absolutePathToLang(new URL('./en/index.md', docsUrl).pathname),
-							absolutePathToLang(new URL('./pt-br/index.md', docsUrl).pathname),
-							absolutePathToLang(new URL('./index.md', docsUrl).pathname),
+							absolutePathToLang(fileURLToPath(new URL('./en/index.md', docsUrl))),
+							absolutePathToLang(fileURLToPath(new URL('./pt-br/index.md', docsUrl))),
+							absolutePathToLang(fileURLToPath(new URL('./index.md', docsUrl))),
+							absolutePathToLang(fileURLToPath(new URL('./ar/path with spaces/index.md', docsUrl))),
 						],
 					};
 

--- a/packages/starlight/integrations/shared/absolutePathToLang.ts
+++ b/packages/starlight/integrations/shared/absolutePathToLang.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from 'node:url';
 import type { AstroConfig } from 'astro';
 import type { StarlightConfig } from '../../types';
 import { localeToLang } from './localeToLang';
@@ -16,8 +17,8 @@ export function absolutePathToLang(
 	}
 ): string {
 	const docsPath = getCollectionPath('docs', astroConfig.srcDir);
-	// Format path to unix style path.
-	path = path?.replace(/\\/g, '/');
+	// Format path to URL-encoded path.
+	path = pathToFileURL(path).pathname;
 	// Ensure that the page path starts with a slash if the docs directory also does,
 	// which makes stripping the docs path in the next step work on Windows, too.
 	if (path && !path.startsWith('/') && docsPath.startsWith('/')) path = '/' + path;


### PR DESCRIPTION
#### Description

- Closes #3297

This PR fixes an issue with the `absolutePathToLang()` helper function not handling absolute paths with spaces correctly.

- `absolutePathToLang()` is meant to be called with the `path` property of a virtual file (altho not mandatory), which is always a POSIX-style path (using `/` as a separator) no matter the operating system.
- It calls `getCollectionPath()` that relies on an URL `pathname` which will also be POSIX-style but also encoded, e.g. spaces are replaced with `%20`.
- A virtual file's `path` property does not encodes special characters like spaces.

This can lead to issues when the path contains spaces which can be solved in different approaches:

- Using `fileURLToPath()` in `getCollectionPath()` to convert the URL to a file path, altho depending on the OS, different separators will be used and would require an additional step to convert it again to a POSIX-style path.
- Relying on `pathToFileURL()` on the input path of `absolutePathToLang()` to convert it to a URL-encoded path also using POSIX-style separators and using its `pathname`.

I went with the second approach which replaces an existing step instead of adding a new one.

On top of the added test, I also manually tested on Windows.