### PR TITLE
Removed empty footer in Splash template

### DIFF
--- a/packages/starlight/components/Page.astro
+++ b/packages/starlight/components/Page.astro
@@ -101,7 +101,6 @@ if (pagefindEnabled) mainDataAttributes['data-pagefind-body'] = '';
 								<MarkdownContent>
 									<slot />
 								</MarkdownContent>
-								<Footer />
 							</ContentPanel>
 						) : (
 							<>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

In `template: "splash"` an empty footer is added. The problem is it creates an empty margin at the bottom

<img width="1120" height="512" alt="image" src="https://github.com/user-attachments/assets/56bbd082-8a46-4d7d-b811-ccf6d2e57468" />

So, this PR removes the footer in that template.
