### PR TITLE
docs: showcase `astro-d2` and "Starlight Plugins by Example"

### DIFF
--- a/docs/src/content/docs/resources/community-content.mdx
+++ b/docs/src/content/docs/resources/community-content.mdx
@@ -109,6 +109,11 @@ Explore community-produced content maintained by Starlight users:
 		title="Starlight Examples"
 		description="A collection of StackBlitz embeds demonstrating practical ways of doing stuff in Starlight documentation sites."
 	/>
+	<LinkCard
+		href="https://hideoo.dev/notebooks/starlight-plugins-by-example"
+		title="Starlight Plugins by Example"
+		description="A collection of notes and examples about Starlight plugins and common patterns used to build them."
+	/>
 </CardGrid>
 
 ## Video Content

--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -222,4 +222,9 @@ These community tools and integrations can be used to add features to your Starl
 		title="astro-mermaid"
 		description="Client-side render Mermaid content in Markdown code blocks."
 	/>
+	<LinkCard
+		href="https://github.com/HiDeoo/astro-d2"
+		title="astro-d2"
+		description="Transform D2 Markdown code blocks into diagrams."
+	/>
 </CardGrid>


### PR DESCRIPTION
#### Description

This PR adds the following resources to the documentation:

- The [`astro-d2`](https://github.com/HiDeoo/astro-d2) integration, which provides another alternative to the PlantUML and Mermaid formats already linked in the documentation.
- A link to the [Starlight Plugins by Example](https://hideoo.dev/notebooks/starlight-plugins-by-example) notebook I wrote.