### PR TITLE
Fix Astro i18n default locale regression

### DIFF
--- a/.changeset/early-kings-fly.md
+++ b/.changeset/early-kings-fly.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes a regression in Starlight version `0.34.5` that caused multilingual sites with a default locale explicitly set to `root` to report a configuration error.

--- a/packages/starlight/__tests__/i18n-root-default-locale/i18n.test.ts
+++ b/packages/starlight/__tests__/i18n-root-default-locale/i18n.test.ts
@@ -1,0 +1,39 @@
+import { assert, describe, expect, test } from 'vitest';
+import config from 'virtual:starlight/user-config';
+import { processI18nConfig } from '../../utils/i18n';
+
+describe('processI18nConfig', () => {
+	test('returns Astro i18n config for a multilingual site with a root default locale', () => {
+		const { astroI18nConfig, starlightConfig } = processI18nConfig(config, undefined);
+
+		// The default locale matches the root locale's `lang` property.
+		expect(astroI18nConfig.defaultLocale).toBe('fr');
+		expect(astroI18nConfig.locales).toMatchInlineSnapshot(`
+			[
+			  {
+			    "codes": [
+			      "fr",
+			    ],
+			    "path": "fr",
+			  },
+			  {
+			    "codes": [
+			      "en-US",
+			    ],
+			    "path": "en",
+			  },
+			  {
+			    "codes": [
+			      "ar",
+			    ],
+			    "path": "ar",
+			  },
+			]
+		`);
+		assert(typeof astroI18nConfig.routing !== 'string');
+		expect(astroI18nConfig.routing?.prefixDefaultLocale).toBe(false);
+
+		// The Starlight configuration should not be modified.
+		expect(config).toStrictEqual(starlightConfig);
+	});
+});

--- a/packages/starlight/__tests__/i18n-root-default-locale/vitest.config.ts
+++ b/packages/starlight/__tests__/i18n-root-default-locale/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineVitestConfig } from '../test-config';
+
+export default defineVitestConfig({
+	title: 'i18n with root default locale',
+	defaultLocale: 'root',
+	locales: {
+		root: { label: 'French', lang: 'fr' },
+		en: { label: 'English', lang: 'en-US' },
+		ar: { label: 'Arabic', dir: 'rtl' },
+	},
+});

--- a/packages/starlight/utils/i18n.ts
+++ b/packages/starlight/utils/i18n.ts
@@ -57,7 +57,10 @@ function getAstroI18nConfig(config: StarlightConfig): NonNullable<AstroConfig['i
 		// In Starlight, this matches the `locale` property if defined, and we fallback to the `lang`
 		// property if not (which would be set to the language’s directory name by default).
 		defaultLocale:
-			config.defaultLocale.locale ?? config.defaultLocale.lang ?? BuiltInDefaultLocale.lang,
+			// If the default locale is explicitly set to `root`, we use the `lang` property instead.
+			(config.defaultLocale.locale === 'root'
+				? config.defaultLocale.lang
+				: (config.defaultLocale.locale ?? config.defaultLocale.lang)) ?? BuiltInDefaultLocale.lang,
 		locales: config.locales
 			? Object.entries(config.locales).map(([locale, localeConfig]) => {
 					return {


### PR DESCRIPTION
#### Description

- Closes #3305

This PR fixes a regression introduced in #3288 where I forgot that if your default language is your root locale, you can skip the `defaultLocale` option, but one can still specify it explicitly to `root` in the config.

When transforming the Starlight i18n config to an Astro i18n config, we already have [some logic in place](https://github.com/withastro/starlight/blob/main/packages/starlight/utils/i18n.ts#L65) to handle this when defining `path`s, but I forgot to apply the same logic when defining the `defaultLocale`.

I also added a new test suite where the Starlight config explicitly sets the default locale to `root` (we didn't have this before).