### PR TITLE
docs: fix aside type in custom icon example

### DIFF
--- a/docs/src/content/docs/components/asides.mdx
+++ b/docs/src/content/docs/components/asides.mdx
@@ -142,7 +142,7 @@ Override the default aside icons by using the [`icon`](#icon) attribute set to t
 import { Aside } from '@astrojs/starlight/components';
 
 <Aside type="tip" icon="starlight">
-	A warning aside *with* a custom icon.
+	A tip aside *with* a custom icon.
 </Aside>
 ```
 
@@ -150,14 +150,14 @@ import { Aside } from '@astrojs/starlight/components';
 
 ```markdoc 'icon="starlight"'
 {% aside type="tip" icon="starlight" %}
-A warning aside *with* a custom icon.
+A tip aside *with* a custom icon.
 {% /aside %}
 ```
 
 </Fragment>
 
 <Aside slot="preview" type="tip" icon="starlight">
-	A warning aside *with* a custom icon.
+	A tip aside *with* a custom icon.
 </Aside>
 
 </Preview>


### PR DESCRIPTION
#### Description

This PR fixes the content of the "Use custom icons" section of the `<Aside>` component documentation to use the correct aside type.