### PR TITLE
docs: add `starlight-auto-drafts` to plugins resources

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -163,6 +163,11 @@ Extend your site with official plugins supported by the Starlight team and commu
 		title="starlight-codeblock-fullscreen"
 		description="Add fullscreen toggle functionality to Expressive Code blocks in your documentation."
 	/>
+	<LinkCard
+		href="https://github.com/HiDeoo/starlight-auto-drafts"
+		title="starlight-auto-drafts"
+		description="Tweak draft pages default behavior and automatically remove sidebar links to draft pages in production mode."
+	/>
 </CardGrid>
 
 ## Community tools and integrations


### PR DESCRIPTION
#### Description

This PR adds the [`starlight-auto-drafts`](https://github.com/HiDeoo/starlight-auto-drafts) plugin to the plugins resources section of the documentation.