### PR TITLE
feat: add removal comments in template READMEs

### DIFF
--- a/examples/basics/README.md
+++ b/examples/basics/README.md
@@ -6,10 +6,14 @@
 npm create astro@latest -- --template starlight
 ```
 
+<!-- ASTRO:REMOVE:START -->
+
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/starlight/tree/main/examples/basics)
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/starlight/tree/main/examples/basics)
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/withastro/starlight&create_from_path=examples/basics)
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fwithastro%2Fstarlight%2Ftree%2Fmain%2Fexamples%2Fbasics&project-name=my-starlight-docs&repository-name=my-starlight-docs)
+
+<!-- ASTRO:REMOVE:END -->
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 

--- a/examples/markdoc/README.md
+++ b/examples/markdoc/README.md
@@ -6,10 +6,14 @@
 npm create astro@latest -- --template starlight/markdoc
 ```
 
+<!-- ASTRO:REMOVE:START -->
+
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/starlight/tree/main/examples/markdoc)
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/starlight/tree/main/examples/markdoc)
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/withastro/starlight&create_from_path=examples/markdoc)
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fwithastro%2Fstarlight%2Ftree%2Fmain%2Fexamples%2Fmarkdoc&project-name=my-starlight-docs&repository-name=my-starlight-docs)
+
+<!-- ASTRO:REMOVE:END -->
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 

--- a/examples/tailwind/README.md
+++ b/examples/tailwind/README.md
@@ -6,10 +6,14 @@
 npm create astro@latest -- --template starlight/tailwind
 ```
 
+<!-- ASTRO:REMOVE:START -->
+
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/starlight/tree/main/examples/tailwind)
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/starlight/tree/main/examples/tailwind)
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/withastro/starlight&create_from_path=examples/tailwind)
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fwithastro%2Fstarlight%2Ftree%2Fmain%2Fexamples%2Ftailwind&project-name=my-starlight-docs&repository-name=my-starlight-docs)
+
+<!-- ASTRO:REMOVE:END -->
 
 > 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
 


### PR DESCRIPTION
## Changes

Currently all template `README.md` files include badges to open them in StackBlitz etc. This is confusing when a site is deployed.

This PR adds adjust the template `README.md` files in the starlight `examples/` folder according to https://github.com/withastro/astro/pull/14115

I think the rest of the changes from the other PR is not necessary here because `create-astro` lives in the astro repo, not here 🙌 


