### PR TITLE
Restrict Starlight line-height to Starlight content

### DIFF
--- a/packages/starlight/style/reset.css
+++ b/packages/starlight/style/reset.css
@@ -20,10 +20,13 @@
 
 	body {
 		font-family: var(--__sl-font);
-		line-height: var(--sl-line-height);
 		-webkit-font-smoothing: antialiased;
 		color: var(--sl-color-text);
 		background-color: var(--sl-color-bg);
+	}
+
+	body:not(:where(.not-content *)) {
+		line-height: var(--sl-line-height);
 	}
 
 	input,


### PR DESCRIPTION
#### Description

Starlight's `sl-line-height` value was applied even for `.not-content`. I used the same `:not` rule that you have elsewhere, but I wonder if this might not be better:

```css
body :not(.not-content *) {
  line-height: var(--sl-line-height);
}
```


Another possibility might be to set `line-height: normal` to `.not-content`, whichever you prefer 😄 
