### PR TITLE
Add `starlight-changelogs` to plugins resources

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -173,6 +173,11 @@ Extend your site with official plugins supported by the Starlight team and commu
 		title="starlight-contextual-menu"
 		description="Add a contextual menu to your Starlight documentation."
 	/>
+	<LinkCard
+		href="https://github.com/HiDeoo/starlight-changelogs"
+		title="starlight-changelogs"
+		description="Display changelogs alongside your project documentation."
+	/>
 </CardGrid>
 
 ## Community tools and integrations


### PR DESCRIPTION
#### Description

This PR adds the [`starlight-changelogs`](https://github.com/HiDeoo/starlight-changelogs) to the `resources/plugins` page.