### PR TITLE
Update carbon calculator stats for v4 model

### DIFF
--- a/docs/src/content/docs/environmental-impact.md
+++ b/docs/src/content/docs/environmental-impact.md
@@ -100,8 +100,8 @@ These tests with the [Website Carbon Calculator][wcc] compare similar pages buil
 | [Nextra][nx-carbon]         | 0.05g              |   A    |
 | [MkDocs][mk-carbon]         | 0.07g              |   A    |
 | [Fumadocs][fs-carbon]       | 0.07g              |   A    |
-| [Docus][dc-carbon]          | 0.10g              |   B    |
 | [Docusaurus][ds-carbon]     | 0.10g              |   B    |
+| [Docus][dc-carbon]          | 0.11g              |   B    |
 | [GitBook][gb-carbon]        | 0.42g              |   F    |
 | [Mintlify][mt-carbon]       | 0.48g              |   F    |
 


### PR DESCRIPTION
Website Carbon Calculator [introduced a new model for estimating energy usage](https://www.wholegraindigital.com/blog/updating-website-carbon-to-v4-of-the-sustainable-web-design-model/), so this PR updates the table to use new measurements. Mostly no change in the ratings but the new model estimates lower CO₂ usage than the earlier version.

I had to update the Docus page being tested as their installation guide repeatedly errored out during testing. (They’re also notably the only entry whose CO₂ usage didn’t decrease this time round, presumably because of changes in their recent release.)
