### PR TITLE
Add `starlight-github-alerts` plugin to plugin showcase

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -178,6 +178,11 @@ Extend your site with official plugins supported by the Starlight team and commu
 		title="starlight-changelogs"
 		description="Display changelogs alongside your project documentation."
 	/>
+	<LinkCard
+		href="https://github.com/HiDeoo/starlight-github-alerts"
+		title="starlight-github-alerts"
+		description="Render GitHub alerts as Starlight asides."
+	/>
 </CardGrid>
 
 ## Community tools and integrations


### PR DESCRIPTION
#### Description

This PR adds the [`starlight-github-alerts`](https://github.com/HiDeoo/starlight-github-alerts) plugin to the documentation plugin showcase.