### PR TITLE
Disable Renovate `uses-with` for Node.js

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,5 +27,11 @@
 			matchDepTypes: ['packageManager'],
 			enabled: false,
 		},
+		{
+			description: 'Disable Node.js version updates with actions/setup-node',
+			matchDepNames: ['node'],
+			matchDepTypes: ['uses-with'],
+			enabled: false,
+		},
 	],
 }


### PR DESCRIPTION
#### Description

This PR is a follow-up to the `uses-with` updates in #3374 and #3375 and aims to disable Node.js version updates for `actions/setup-node` in Renovate.

As I mentioned in [this comment](https://github.com/withastro/starlight/pull/3374#issuecomment-3174710476), this is done for a few reasons:

- We want to control the Node.js version used in some workflows
- We probably don't want to deal with such PRs for every Node.js versions

As usual, I don't think there is a way to test this change without merging it, and not explicitely documented (or I missed it), but hopefully after merging this PR and waiting a bit, Renovate should close the 2 existing PRs I mentioned and should create 2 new ones only containing an update for `actions/checkout` (which was bundled in the previous PRs with the Node.js version update).

If this works as expected, I'll port this change to Astro Docs.