### PR TITLE
fix: mobile toc issue with custom banners

### DIFF
--- a/.changeset/weak-spiders-itch.md
+++ b/.changeset/weak-spiders-itch.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes and issue where the Table of Contents is unable to find any current heading when the page has a banner with custom styling regarding its height.

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -1,6 +1,16 @@
 ---
 title: Getting Started
 description: Learn how to start building your next documentation site with Starlight by Astro.
+banner:
+  content: 'TODO(trueberryless): Remove'
+head:
+  - tag: style
+    content: |
+      :root .sl-banner {
+        background-color: red;
+        color: white;
+        padding-block: 2rem;
+      }
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';

--- a/packages/starlight/components/TableOfContents/starlight-toc.ts
+++ b/packages/starlight/components/TableOfContents/starlight-toc.ts
@@ -60,6 +60,8 @@ export class StarlightTOC extends HTMLElement {
 
 		/** Handle intersections and set the current link to the heading for the current intersection. */
 		const setCurrent: IntersectionObserverCallback = (entries) => {
+			let found = false;
+
 			for (const { isIntersecting, target } of entries) {
 				if (!isIntersecting) continue;
 				const heading = getElementHeading(target);
@@ -67,8 +69,30 @@ export class StarlightTOC extends HTMLElement {
 				const link = links.find((link) => link.hash === '#' + encodeURIComponent(heading.id));
 				if (link) {
 					this.current = link;
+					found = true;
 					break;
 				}
+			}
+
+			// Fallback: if no heading intersects (because the banner is higher and moves the content down too much),
+			// create a temporal IntersectionObserver without rootMargin that finds the nearest heading.
+			// See https://github.com/withastro/starlight/issues/3047
+			if (!found) {
+				const tempObserver = new IntersectionObserver((tempEntries) => {
+					for (const { isIntersecting, target } of tempEntries) {
+						if (!isIntersecting) continue;
+						const heading = getElementHeading(target);
+						if (!heading) continue;
+						const link = links.find((link) => link.hash === '#' + encodeURIComponent(heading.id));
+						if (link) {
+							this.current = link;
+							break;
+						}
+					}
+					tempObserver.disconnect();
+				});
+
+				document.querySelectorAll('main [id]').forEach((el) => tempObserver.observe(el));
 			}
 		};
 


### PR DESCRIPTION
### Description

This PR fixes an issue with the Table of Contents being unable to find any heading when the page has a banner with custom styling. This issue is currently tracked in #3047.

The issue is fixed by introducing a temporary `IntersectionObserver` without any `rootMargin` (so that it definitely gets an intersection target). This new code only runs when there is no other intersecting target found by the existing [`IntersectionObserver`](https://github.com/withastro/starlight/blob/2768932065980d7e1b2fc615706b605a9527fb36/packages/starlight/components/TableOfContents/starlight-toc.ts#L83).

Please note that this issue could also be resolved in some other ways of course and I'm not sure if introducing a second `IntersectionObserver` is a good practice just for this edge case. Feel free to suggest cleaner solutions!

#### Other considered solution

Another solution that came to my mind, but where I figured that it has too many side effects (and therefore I didn't commit to it): By dynamically incorporating the actual height of the banner in the calculation of `bottom` it would be possible to always guarantee that a heading can be found (which would mean that we don't need a second observer). However, the problem with that approach would be that the observer would then permanently be too big and headings would "too early" be considered current headings. For example: If the banner is really big, headings that scroll into the middle of the screen could potentially be set as the "current" headings in the ToC, which would be misleading.

To demonstrate what I mean with this paragraph in code:

```diff
-const bottom = top + 53;
+const bottom = top + 53 + bannerHeight; // assuming we calculate the actual banner height before
```

https://github.com/withastro/starlight/blob/2768932065980d7e1b2fc615706b605a9527fb36/packages/starlight/components/TableOfContents/starlight-toc.ts#L107

### Related stuff and todo

- Closes #3047
- [ ] Remove TODOs