### PR TITLE
[i18nIgnore] Fix typo in Spanish docs documentation

### DIFF
--- a/docs/src/content/docs/es/guides/i18n.mdx
+++ b/docs/src/content/docs/es/guides/i18n.mdx
@@ -67,7 +67,7 @@ Starlight proporciona soporte incorporado para sitios multilingües, incluidas l
 
 </Steps>
 
-Para escenarios de i18n más avanzados, Starlight también admite la configuración de internacionalizaciónutlizando la [opción `i18n` de Astro](https://docs.astro.build/es/guides/internationalization/#configuración-de-rutas-i18n).
+Para escenarios de i18n más avanzados, Starlight también admite la configuración de internacionalización utlizando la [opción `i18n` de Astro](https://docs.astro.build/es/guides/internationalization/#configuración-de-rutas-i18n).
 
 ### Usa una raíz de configuración regional
 

--- a/docs/src/content/docs/es/guides/i18n.mdx
+++ b/docs/src/content/docs/es/guides/i18n.mdx
@@ -67,7 +67,7 @@ Starlight proporciona soporte incorporado para sitios multilingües, incluidas l
 
 </Steps>
 
-Para escenarios de i18n más avanzados, Starlight también admite la configuración de internacionalización utlizando la [opción `i18n` de Astro](https://docs.astro.build/es/guides/internationalization/#configuración-de-rutas-i18n).
+Para escenarios de i18n más avanzados, Starlight también admite la configuración de internacionalización utilizando la [opción `i18n` de Astro](https://docs.astro.build/es/guides/internationalization/#configuración-de-rutas-i18n).
 
 ### Usa una raíz de configuración regional
 


### PR DESCRIPTION
There was a missing space between words.