### PR TITLE
Add customizable keyboard shortcuts

### DIFF
--- a/packages/docsearch/DocSearch.astro
+++ b/packages/docsearch/DocSearch.astro
@@ -119,6 +119,21 @@ const docsearchTranslations: DocSearchTranslationProps = {
 			mask-size: 100%;
 			background-color: currentColor;
 		}
+		.DocSearch-Button-Key:first-child {
+			margin-right: 0.4em;
+		}
+		.DocSearch-Button-Key {
+			display: inline-block;
+			font-size: 0.75em;
+			font-weight: 600;
+			opacity: 0.8;
+			border: 1px solid var(--sl-color-gray-4);
+			border-radius: 0.25rem;
+			padding: 0.125rem 0.375rem;
+			background-color: var(--sl-color-gray-6);
+			color: var(--sl-color-gray-1);
+			line-height: 1;
+		}
 	}
 </style>
 
@@ -136,6 +151,27 @@ const docsearchTranslations: DocSearchTranslationProps = {
 					Object.assign(options, translations);
 				} catch {}
 				docsearch(options);
+
+				const keyboardShortcuts = options.keyboardShortcuts ?? {};
+				const slashEnabled = keyboardShortcuts?.['/'] !== false;
+				const ctrlCmdKEnabled = keyboardShortcuts?.['Ctrl/Cmd+K'] !== false;
+
+				if (slashEnabled && !ctrlCmdKEnabled) {
+					const styleContainer = document.createElement('style');
+					styleContainer.innerHTML = `
+					.DocSearch-Button-Keys::before {
+						content: '';
+						width: 1em;
+						height: 1em;
+						-webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M17 2H7a5 5 0 0 0-5 5v10a5 5 0 0 0 5 5h10a5 5 0 0 0 5-5V7a5 5 0 0 0-5-5Zm3 15a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V7a3 3 0 0 1 3-3h10a3 3 0 0 1 3 3v10Z'%3E%3C/path%3E%3Cpath d='M15.293 6.707a1 1 0 1 1 1.414 1.414l-8.485 8.486a1 1 0 0 1-1.414-1.415l8.485-8.485Z'%3E%3C/path%3E%3C/svg%3E");
+						mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M17 2H7a5 5 0 0 0-5 5v10a5 5 0 0 0 5 5h10a5 5 0 0 0 5-5V7a5 5 0 0 0-5-5Zm3 15a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V7a3 3 0 0 1 3-3h10a3 3 0 0 1 3 3v10Z'%3E%3C/path%3E%3Cpath d='M15.293 6.707a1 1 0 1 1 1.414 1.414l-8.485 8.486a1 1 0 0 1-1.414-1.415l8.485-8.485Z'%3E%3C/path%3E%3C/svg%3E");
+						-webkit-mask-size: 100%;
+						mask-size: 100%;
+						background-color: currentColor;
+						}
+						`;
+					document.head.appendChild(styleContainer);
+				}
 			});
 		}
 	}

--- a/packages/docsearch/index.ts
+++ b/packages/docsearch/index.ts
@@ -43,6 +43,18 @@ const DocSearchConfigSchema = z
 		 * @see https://www.algolia.com/doc/api-reference/search-api-parameters/
 		 */
 		searchParameters: z.custom<SearchOptions>(),
+		/**
+		 * Configuration for keyboard shortcuts that trigger the DocSearch modal.
+		 * @see https://docsearch.algolia.com/docs/api/#keyboardshortcuts
+		 */
+		keyboardShortcuts: z
+			.object({
+				/** Enable/disable Ctrl/Cmd+K shortcut. @default true */
+				'Ctrl/Cmd+K': z.boolean().optional(),
+				/** Enable/disable / shortcut. @default true */
+				'/': z.boolean().optional(),
+			})
+			.optional(),
 	})
 	.strict()
 	.or(


### PR DESCRIPTION
#### Description

Pending the release of Algolia's @docsearch/js@3.10.0, [which will add support for customizing keyboard shortcuts](https://github.com/algolia/docsearch/pull/2741), this PR does the work to render these custom keyboard shortcuts in the @astrojs/starlight-docsearch component.

I'm now relying on the default rendering of these buttons for `Ctrl/Cmd+K`, but kept the familiar `/` rendering. Happy to change it too, but figured you'd probably prefer consistency where possible.

**With all keyboard shortcuts disabled**

<img width="2284" height="128" alt="nothing" src="https://github.com/user-attachments/assets/c4a8f0d3-f37d-4fad-bd56-b5619b55637d" />

**With `Ctrl/Cmd+K` enabled**

<img width="2284" height="128" alt="ctrlcmdk" src="https://github.com/user-attachments/assets/16f0090b-5f5c-425b-b040-36f1caa4e02b" />

**With `/` enabled**

<img width="2284" height="128" alt="slash" src="https://github.com/user-attachments/assets/3f2a71e7-9bd9-467f-af61-c18a2bd31f67" />
