### PR TITLE
Correct directory name for Chinese localization

### DIFF
--- a/docs/src/content/docs/guides/i18n.mdx
+++ b/docs/src/content/docs/guides/i18n.mdx
@@ -57,7 +57,7 @@ Starlight provides built-in support for multilingual sites, including routing, f
        - docs/
          - ar/
          - en/
-         - zh-cn/
+         - zh-CN/
 
    </FileTree>
 
@@ -108,7 +108,7 @@ When using a `root` locale, keep pages for that language directly in `src/conten
   - content/
     - docs/
       - **index.md**
-      - zh-cn/
+      - zh-CN/
         - **index.md**
 
 </FileTree>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

If the folder name doesn't match the configured `lang` it will not translate astro components.

- What does this PR change? Give us a brief description.

I discovered that localization doesn't work unless the folder names match the casing of the configured language.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
