### PR TITLE
Remove invalid value attribute from `<select>`

### DIFF
--- a/.changeset/plenty-sloths-repeat.md
+++ b/.changeset/plenty-sloths-repeat.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Removes the invalid `value` attribute from the `<select>` tag

--- a/.changeset/plenty-sloths-repeat.md
+++ b/.changeset/plenty-sloths-repeat.md
@@ -2,4 +2,4 @@
 '@astrojs/starlight': patch
 ---
 
-Removes the invalid `value` attribute from the `<select>` tag
+Removes an invalid `value` attribute from the language and theme selectors

--- a/packages/starlight/components/LanguageSelect.astro
+++ b/packages/starlight/components/LanguageSelect.astro
@@ -18,7 +18,6 @@ function localizedPathname(locale: string | undefined): string {
 			<Select
 				icon="translate"
 				label={Astro.locals.t('languageSelect.accessibleLabel')}
-				value={localizedPathname(Astro.locals.starlightRoute.locale)}
 				options={Object.entries(config.locales).map(([code, locale]) => ({
 					value: localizedPathname(code),
 					selected: code === Astro.locals.starlightRoute.locale,

--- a/packages/starlight/components/Select.astro
+++ b/packages/starlight/components/Select.astro
@@ -3,7 +3,6 @@ import Icon from '../user-components/Icon.astro';
 
 interface Props {
 	label: string;
-	value: string;
 	icon: Parameters<typeof Icon>[0]['name'];
 	width?: string;
 	options: Array<{
@@ -26,7 +25,7 @@ interface Props {
 <label style={`--sl-select-width: ${Astro.props.width}`}>
 	<span class="sr-only">{Astro.props.label}</span>
 	<Icon name={Astro.props.icon} class="icon label-icon" />
-	<select value={Astro.props.value} autocomplete="off">
+	<select autocomplete="off">
 		{
 			Astro.props.options.map(({ value, selected, label }) => (
 				<option value={value} selected={selected} set:html={label} />

--- a/packages/starlight/components/ThemeSelect.astro
+++ b/packages/starlight/components/ThemeSelect.astro
@@ -7,7 +7,6 @@ import Select from './Select.astro';
 	<Select
 		icon="laptop"
 		label={Astro.locals.t('themeSelect.accessibleLabel')}
-		value="auto"
 		options={[
 			{ label: Astro.locals.t('themeSelect.dark'), selected: false, value: 'dark' },
 			{ label: Astro.locals.t('themeSelect.light'), selected: false, value: 'light' },


### PR DESCRIPTION
The [`<select>` element](https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element) does not have a `value` attribute. (There is a `value` _property_ on the `HTMLSelectElement` _object_, but that’s different.)