### PR TITLE
Ensure tab links span the full tab height

### DIFF
--- a/.changeset/light-starfishes-cross.md
+++ b/.changeset/light-starfishes-cross.md
@@ -1,0 +1,16 @@
+---
+'@astrojs/starlight': minor
+---
+
+Fixes styling of labels that wrap across multiple lines in `<Tabs>` component
+
+⚠️ **Potentially breaking change:** Tab labels now have a narrower line-height and additional vertical padding. If you have custom CSS targetting the `<Tabs>` component, you may want to double check the visual appearance of your tabs when updating.
+
+If you want to preserve the previous styling, you can add the following custom CSS to your site:
+
+```css
+.tab > [role='tab'] {
+  line-height: var(--sl-line-height);
+  padding-block: 0;
+}
+```

--- a/packages/starlight/user-components/Tabs.astro
+++ b/packages/starlight/user-components/Tabs.astro
@@ -115,6 +115,7 @@ if (isSynced) {
 		}
 
 		.tab {
+			display: flex;
 			margin-bottom: -2px;
 		}
 		.tab > [role='tab'] {

--- a/packages/starlight/user-components/Tabs.astro
+++ b/packages/starlight/user-components/Tabs.astro
@@ -123,7 +123,7 @@ if (isSynced) {
 			align-items: center;
 			gap: 0.5rem;
 			line-height: var(--sl-line-height-headings);
-			padding: 0.25rem 1.25rem;
+			padding: 0.275rem 1.25rem;
 			text-decoration: none;
 			border-bottom: 2px solid var(--sl-color-gray-5);
 			color: var(--sl-color-gray-3);

--- a/packages/starlight/user-components/Tabs.astro
+++ b/packages/starlight/user-components/Tabs.astro
@@ -122,7 +122,8 @@ if (isSynced) {
 			display: flex;
 			align-items: center;
 			gap: 0.5rem;
-			padding: 0 1.25rem;
+			line-height: var(--sl-line-height-headings);
+			padding: 0.25rem 1.25rem;
 			text-decoration: none;
 			border-bottom: 2px solid var(--sl-color-gray-5);
 			color: var(--sl-color-gray-3);


### PR DESCRIPTION
#### Description

- Closes #3383
- Updates styles applied to tab labels so that they work better for long labels and labels that wrap onto a second line.
- For the default case, with labels that do not wrap, the appearance is unchanged, with the vertical layout identical. However, for labels that do wrap, line height is now tighter (using Starlight’s `1.2` heading line height), making each tab label a bit more compact and a bit more visually distinct.
- For tabs where only _some_ labels wrap, this PR fixes a bug where the bottom border of a tab would not align correctly

| Before | After |
|--------|--------|
| <img width="1440" height="204" alt="tab component with tab labels wrapping with a large line height. the first tab is shorter than the others, leaving its bottom border floating in the middle of the tab area." src="https://github.com/user-attachments/assets/f5d73c4c-1251-4734-a82d-aa43d4963898" /> | <img width="1440" height="186" alt="the same tab component with a tighter line height. the first tab’s border is now correctly aligned." src="https://github.com/user-attachments/assets/792838f2-f337-4cec-8c6d-196134b2caf6" /> |


<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
