### PR TITLE
i18n(fr): fix typo and links in `reference` files

### DIFF
--- a/docs/src/content/docs/fr/reference/configuration.mdx
+++ b/docs/src/content/docs/fr/reference/configuration.mdx
@@ -15,7 +15,7 @@ import starlight from '@astrojs/starlight';
 export default defineConfig({
 	integrations: [
 		starlight({
-			title: 'Mon délicieux site de docs',
+			title: 'Mon ravissant site de docs',
 		}),
 	],
 });
@@ -35,7 +35,7 @@ Lorsque vous utilisez la forme objet, les clés doivent être des étiquettes d'
 ```ts
 starlight({
 	title: {
-		fr: 'Mon délicieux site de docs',
+		fr: 'Mon ravissant site de docs',
 		de: 'Meine bezaubernde Dokumentationsseite',
 	},
 });
@@ -102,7 +102,7 @@ Configure les éléments de navigation de la barre latérale de votre site.
 Une barre latérale est un tableau de liens et de groupes de liens.
 À l'exception des éléments utilisant `slug`, chaque élément doit comporter un `label` et l'une des propriétés suivantes :
 
-- `link` — un lien uninque vers une URL spécifique, comme `'/home'` ou `'https://example.com'`.
+- `link` — un lien unique vers une URL spécifique, comme `'/home'` ou `'https://example.com'`.
 
 - `slug` — une référence à une page interne, par exemple `'guides/getting-started'`.
 
@@ -525,17 +525,17 @@ Si vous utilisez un adaptateur SSR et que vous souhaitez générer les pages Sta
 **Type :** [`HeadConfig[]`](#headconfig)
 
 Ajoute des balises personnalisées au `<head>` de votre site Starlight.
-Cela peut être utile pour ajouter des analyses et d'autres scripts et ressources tiers.
+Cela peut être utile pour ajouter une solution de mesure d'audience ou d'autres scripts et ressources tiers.
 
 ```js
 starlight({
 	head: [
-		// Exemple : ajouter un script d'analyse Fathom tag.
+		// Exemple : ajouter une balise pour le script de suivi de Fathom
 		{
 			tag: 'script',
 			attrs: {
 				src: 'https://cdn.usefathom.com/script.js',
-				'data-site': 'MY-FATHOM-ID',
+				'data-site': 'MON-ID-FATHOM',
 				defer: true,
 			},
 		},
@@ -543,7 +543,7 @@ starlight({
 });
 ```
 
-Les entrées dans `head` sont converties directement en éléments HTML et ne passent pas par le traitement de [script](https://docs.astro.build/fr/guides/client-side-scripts/#regroupement-de-script) ou de [style](https://docs.astro.build/fr/guides/styling/#mettre-en-forme-avec-astro) d'Astro.
+Les entrées dans `head` sont converties directement en éléments HTML et ne passent pas par le traitement de [script](https://docs.astro.build/fr/guides/client-side-scripts/#traitement-des-scripts) ou de [style](https://docs.astro.build/fr/guides/styling/#mettre-en-forme-avec-astro) d'Astro.
 Si vous avez besoin d'importer des ressources locales comme des scripts, des styles ou des images, [redéfinissez le composant Head](/fr/guides/overriding-components/#réutiliser-un-composant-intégré).
 
 #### `HeadConfig`
@@ -691,7 +691,7 @@ import { docsSchema, i18nSchema } from '@astrojs/starlight/schema';
 
 export const collections = {
 	docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
-	// Optionel : la collection i18n est utilisée pour traduire l'interface
+	// Optionnel : la collection i18n est utilisée pour traduire l'interface
 	// utilisateur dans les sites multilingues
 	i18n: defineCollection({ loader: i18nLoader(), schema: i18nSchema() }),
 };

--- a/docs/src/content/docs/fr/reference/frontmatter.md
+++ b/docs/src/content/docs/fr/reference/frontmatter.md
@@ -39,7 +39,7 @@ Remplace le slug de la page. Consultez [« Définition d’identifiants personna
 
 **Type :** `string | boolean`
 
-Remplace la [configuration globale `editLink`](/fr/reference/configuration/#editlink). Mettez `false` pour désactiver le lien "Modifier cette page" pour une page spécifique ou pour fournir une URL alternative où le contenu de cette page est éditable.
+Remplace la [configuration globale `editLink`](/fr/reference/configuration/#editlink). Mettez `false` pour désactiver le lien « Modifier cette page » pour une page spécifique ou pour fournir une URL alternative où le contenu de cette page est éditable.
 
 ### `head`
 
@@ -68,7 +68,7 @@ Personnalisez les niveaux d'en-tête à inclure ou mettez `false` pour cacher la
 ```md
 ---
 # src/content/docs/exemple.md
-title: Pagee avec seulement des H2s dans la table des matières
+title: Page avec seulement des H2 dans la table des matières
 tableOfContents:
   minHeadingLevel: 2
   maxHeadingLevel: 2
@@ -211,7 +211,7 @@ lastUpdated: 2022-08-09
 
 **Type :** `boolean | string | { link?: string; label?: string }`
 
-Remplace la [configuration globale `pagination`](/fr/reference/configuration/#pagination). Si un string est spécifié, le texte du lien généré sera remplacé et si un objet est spécifié, le lien et le texte seront remplacés.
+Remplace la [configuration globale `pagination`](/fr/reference/configuration/#pagination). Si une chaîne de caractères est spécifiée, le texte du lien généré sera remplacé et si un objet est spécifié, le lien et le texte seront remplacés.
 
 ```md
 ---
@@ -225,7 +225,7 @@ prev: false
 ---
 # src/content/docs/exemple.md
 # Remplacer le texte du lien de la page
-prev: Poursuivre the tutorial
+prev: Poursuivre le tutoriel
 ---
 ```
 
@@ -314,9 +314,9 @@ Définir l'étiquette de cette page dans la barre latérale lorsqu'elle est affi
 ```md
 ---
 # src/content/docs/exemple.md
-title: About this project
+title: À propos de ce projet
 sidebar:
-  label: About
+  label: À propos
 ---
 ```
 
@@ -424,7 +424,7 @@ Consultez [« Définir un schéma de collection de contenus »](https://docs.ast
 **Par défaut :** `z.object({})`
 
 Étendez le schéma de Starlight avec des champs supplémentaires en définissant `extend` dans les options de `docsSchema()`.
-La valeur doit être un [schéma Zod](https://docs.astro.build/fr/guides/content-collections/#defining-datatypes-with-zod).
+La valeur doit être un [schéma Zod](https://docs.astro.build/fr/guides/content-collections/#définition-des-types-de-données-avec-zod).
 
 Dans l'exemple suivant, nous définissons un type plus strict pour `description` pour le rendre obligatoire et ajouter un nouveau champ `category` facultatif :
 
@@ -449,7 +449,7 @@ export const collections = {
 };
 ```
 
-Pour tirer parti de l'[utilitaire `image()` d'Astro](https://docs.astro.build/fr/guides/images/#images-in-content-collections), utilisez une fonction qui retourne votre extension de schéma :
+Pour tirer parti de l'[utilitaire `image()` d'Astro](https://docs.astro.build/fr/guides/images/#images-dans-les-collections-de-contenu), utilisez une fonction qui retourne votre extension de schéma :
 
 ```ts {10-15}
 // src/content.config.ts

--- a/docs/src/content/docs/fr/reference/overrides.md
+++ b/docs/src/content/docs/fr/reference/overrides.md
@@ -1,6 +1,6 @@
 ---
 title: Référence des redéfinitions
-description: Une vue d'ensemble de tous les composants et les props des composants supportés par les redéfinitions de Starlight.
+description: Une vue d'ensemble de tous les composants et les props des composants compatibles avec les redéfinitions de Starlight.
 tableOfContents:
   maxHeadingLevel: 4
 ---

--- a/docs/src/content/docs/fr/reference/plugins.md
+++ b/docs/src/content/docs/fr/reference/plugins.md
@@ -331,7 +331,7 @@ L'exemple ci-dessus affichera un message qui inclut une chaîne d'interface util
 
 Appelez `absolutePathToLang()` avec un chemin de fichier absolu pour obtenir la langue de ce fichier.
 
-Cela peut être particulièrement utile lors de l'ajout de [modules d'extension remark ou rehype](https://docs.astro.build/fr/guides/markdown-content/#plugins-markdown) pour traiter les fichiers Markdown ou MDX.
+Cela peut être particulièrement utile lors de l'ajout de [modules d'extension remark ou rehype](https://docs.astro.build/fr/guides/markdown-content/#modules-dextension-markdown) pour traiter les fichiers Markdown ou MDX.
 Le [format de fichier virtuel](https://github.com/vfile/vfile) utilisé par ces modules d'extension inclut le [chemin absolu](https://github.com/vfile/vfile#filepath) du fichier en cours de traitement, qui peut être utilisé avec `absolutePathToLang()` pour déterminer la langue du fichier.
 La langue retournée peut être utilisé avec l'utilitaire [`useTranslations()`](#usetranslations) pour obtenir des chaînes d'interface utilisateur pour cette langue.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Updates the French translations in `references` to:
* fix some links to Astro Docs (some headings in the French version of Astro have been reworded, and some anchors weren't translated in Starlight Docs)
* fix some typo
* use French quotes
* translate some examples to be consistent with the other translated examples in the same page
* replace some translations:
  * `delightful` > `ravissant` (`délicieux` is for something you eat... I reused the same translation we had in [Manual setup](https://starlight.astro.build/fr/manual-setup/#configurer-lint%C3%A9gration))
  * `a string` > `une chaîne de caractère` (instead of `un string`...)
  * `analytics` > I would use a different translation according to the context (e.g. `script de suivi (d'audience)` `solution d'analyse statistiques`, `outil de mesure d'audience`, etc.) but `analyse` by itself sounds wrong. For reference, the [French CNIL](https://www.cnil.fr/fr/definition/mesure-daudience-analytics) uses `Mesures d'audience` for `analytics`.
  * `support` > `compatible avec` (based on the translations we agreed upon in the [French i18n guide](https://github.com/withastro/docs/blob/main/i18n-guides/fran%C3%A7ais.md#langage-courant)), [`supporté` is an anglicism](https://www.larousse.fr/dictionnaires/francais/supporter/75533).

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
