### PR TITLE
i18n(fr): small rewording in `components`

### DIFF
--- a/docs/src/content/docs/fr/components/asides.mdx
+++ b/docs/src/content/docs/fr/components/asides.mdx
@@ -17,7 +17,7 @@ Incluez des informations supplémentaires non essentielles avec le composant `<A
 
 </Preview>
 
-## Import
+## Importation
 
 ```tsx
 import { Aside } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/fr/components/badges.mdx
+++ b/docs/src/content/docs/fr/components/badges.mdx
@@ -15,7 +15,7 @@ import Preview from '~/components/component-preview.astro';
 
 </Preview>
 
-## Import
+## Importation
 
 ```tsx
 import { Badge } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/fr/components/card-grids.mdx
+++ b/docs/src/content/docs/fr/components/card-grids.mdx
@@ -24,7 +24,7 @@ import Preview from '~/components/component-preview.astro';
 
 </Preview>
 
-## Import
+## Importation
 
 ```tsx
 import { CardGrid } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/fr/components/cards.mdx
+++ b/docs/src/content/docs/fr/components/cards.mdx
@@ -19,7 +19,7 @@ import Preview from '~/components/component-preview.astro';
 
 </Preview>
 
-## Import
+## Importation
 
 ```tsx
 import { Card } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/fr/components/code.mdx
+++ b/docs/src/content/docs/fr/components/code.mdx
@@ -16,7 +16,7 @@ import Preview from '~/components/component-preview.astro';
 	slot="preview"
 	code={`## Bienvenue
 
-Bonjour depuis **l'espace**!`}
+Bonjour depuis **l'espace** !`}
 lang="md"
 title="exemple.md"
 ins={3}
@@ -24,7 +24,7 @@ ins={3}
 
 </Preview>
 
-## Import
+## Importation
 
 ```tsx
 import { Code } from '@astrojs/starlight/components';
@@ -76,7 +76,7 @@ export const highlights = ['fichier', 'CMS'];
 
 ### Afficher du code importé
 
-Dans les fichiers MDX et les composants Astro, utilisez le [suffixe d'import `?raw` de Vite](https://vite.dev/guide/assets#importing-asset-as-string) pour importer n'importe quel fichier de code sous forme de chaîne de caractères.
+Dans les fichiers MDX et les composants Astro, utilisez le [suffixe d'importation `?raw` de Vite](https://vite.dev/guide/assets#importing-asset-as-string) pour importer n'importe quel fichier de code sous forme de chaîne de caractères.
 Vous pouvez ensuite passer cette chaîne importée au composant `<Code>` pour l'inclure dans votre page.
 
 <Preview>

--- a/docs/src/content/docs/fr/components/file-tree.mdx
+++ b/docs/src/content/docs/fr/components/file-tree.mdx
@@ -26,7 +26,7 @@ import Preview from '~/components/component-preview.astro';
 
 </Preview>
 
-## Import
+## Importation
 
 ```tsx
 import { FileTree } from '@astrojs/starlight/components';
@@ -133,7 +133,7 @@ import { FileTree } from '@astrojs/starlight/components';
 ### Ajouter des commentaires
 
 Ajoutez un commentaire à un fichier ou à un répertoire en ajoutant du texte après le nom.
-Le formatage Markdown en ligne, tel que le gras et l'italique, est pris en charge dans les commentaires.
+La syntaxe de mise en forme Markdown, telle que le gras et l'italique, est prise en charge dans les commentaires.
 
 <Preview>
 

--- a/docs/src/content/docs/fr/components/icons.mdx
+++ b/docs/src/content/docs/fr/components/icons.mdx
@@ -20,7 +20,7 @@ import Preview from '~/components/component-preview.astro';
 
 </Preview>
 
-## Import
+## Importation
 
 ```tsx
 import { Icon } from '@astrojs/starlight/components';
@@ -37,21 +37,21 @@ Une icône requiert un attribut [`name`](#name) défini avec [une des icônes di
 import { Icon } from '@astrojs/starlight/components';
 
 <Icon name="star" />
-<Icon name="starlight" label="Le logo Starlight" />
+<Icon name="starlight" label="Le logo de Starlight" />
 ```
 
 <Fragment slot="markdoc">
 
 ```markdoc
 {% icon name="star" /%}
-{% icon name="starlight" label="Le logo Starlight" /%}
+{% icon name="starlight" label="Le logo de Starlight" /%}
 ```
 
 </Fragment>
 
 <Fragment slot="preview">
 	<Icon name="star" />
-	<Icon name="starlight" label="Le logo Starlight" />
+	<Icon name="starlight" label="Le logo de Starlight" />
 </Fragment>
 
 </Preview>
@@ -103,7 +103,7 @@ Le nom de l'icône à afficher correspondant à [une des icônes disponibles ave
 
 **Type :** `string`
 
-Un label optionnel pour fournir un contexte aux technologies d'assistance, comme les lecteurs d'écran.
+Une étiquette optionnelle pour fournir un contexte aux technologies d'assistance, comme les lecteurs d'écran.
 
 Quand l'attribut `label` n'est pas défini, l'icône sera complètement masquée des technologies d'assistance.
 Dans ce cas, assurez-vous que le contexte reste compréhensible sans l'icône.

--- a/docs/src/content/docs/fr/components/link-buttons.mdx
+++ b/docs/src/content/docs/fr/components/link-buttons.mdx
@@ -17,7 +17,7 @@ import Preview from '~/components/component-preview.astro';
 
 </Preview>
 
-## Import
+## Importation
 
 ```tsx
 import { LinkButton } from '@astrojs/starlight/components';
@@ -80,7 +80,7 @@ import { LinkButton } from '@astrojs/starlight/components';
 	icon="external"
 	iconPlacement="start"
 >
-	Référence: Astro
+	Référence : Astro
 </LinkButton>
 ```
 
@@ -92,7 +92,7 @@ import { LinkButton } from '@astrojs/starlight/components';
 	 variant="secondary"
 	 icon="external"
 	 iconPlacement="start" %}
-Référence: Astro
+Référence : Astro
 {% /linkbutton %}
 ```
 
@@ -105,7 +105,7 @@ Référence: Astro
 	icon="external"
 	iconPlacement="start"
 >
-	Référence: Astro
+	Référence : Astro
 </LinkButton>
 
 </Preview>

--- a/docs/src/content/docs/fr/components/link-cards.mdx
+++ b/docs/src/content/docs/fr/components/link-cards.mdx
@@ -22,7 +22,7 @@ import Preview from '~/components/component-preview.astro';
 
 </Preview>
 
-## Import
+## Importation
 
 ```tsx
 import { LinkCard } from '@astrojs/starlight/components';
@@ -121,7 +121,7 @@ Le titre de la carte de liaison à afficher.
 **Obligatoire**  
 **Type :** `string`
 
-L'URL vers laquelle pointer lorsque d'une interaction avec la carte.
+L'URL vers laquelle pointer lors d'une interaction avec la carte.
 
 ### `description`
 

--- a/docs/src/content/docs/fr/components/steps.mdx
+++ b/docs/src/content/docs/fr/components/steps.mdx
@@ -49,7 +49,7 @@ import Preview from '~/components/component-preview.astro';
 
 </Preview>
 
-## Import
+## Importation
 
 ```tsx
 import { Steps } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/fr/components/tabs.mdx
+++ b/docs/src/content/docs/fr/components/tabs.mdx
@@ -19,7 +19,7 @@ import Preview from '~/components/component-preview.astro';
 
 </Preview>
 
-## Import
+## Importation
 
 ```tsx
 import { Tabs, TabItem } from '@astrojs/starlight/components';
@@ -69,7 +69,7 @@ Io, Europe, Ganymède
 Conservez plusieurs groupes d'onglets synchronisés en ajoutant l'attribut [`syncKey`](#synckey).
 
 Tous les composants `<Tabs>` avec la même valeur `syncKey` afficheront le même label actif.
-Cela permet à votre lecteur de choisir une fois (par exemple, leur système d'exploitation ou leur gestionnaire de paquets) et de voir leur choix persisté au travers de navigations entre différentes pages.
+Cela permet à votre lecteur de choisir une fois (par exemple, son système d'exploitation ou son gestionnaire de paquets) et de voir son choix persister en naviguant entre différentes pages.
 
 Pour synchroniser des onglets liés, ajoutez une propriété `syncKey` identique à chaque composant `<Tabs>` et assurez-vous qu'ils utilisent tous les mêmes libellés avec le composant `<TabItem>` :
 

--- a/docs/src/content/docs/fr/components/using-components.mdx
+++ b/docs/src/content/docs/fr/components/using-components.mdx
@@ -32,8 +32,8 @@ import CustomCard from '../../components/CustomCard.astro';
 </CustomCard>
 ```
 
-Starlight étant basé sur Astro, vous pouvez ajouter la prise en charge de composants construits avec n'importe quel [framework d'interface utilisateur pris en charge (React, Preact, Svelte, Vue, Solid, and Alpine)](https://docs.astro.build/fr/guides/framework-components/) dans vos fichiers MDX.
-Pour en savoir plus sur [l'utilisation de composants avec MDX](https://docs.astro.build/fr/guides/integrations-guide/mdx/#utilisation-de-composants-dans-mdx), consultez la documentation Astro.
+Starlight étant basé sur Astro, vous pouvez ajouter la prise en charge de composants construits avec n'importe quel [framework d'interface utilisateur pris en charge (React, Preact, Svelte, Vue, Solid et Alpine)](https://docs.astro.build/fr/guides/framework-components/) dans vos fichiers MDX.
+Pour en savoir plus sur [l'utilisation de composants avec MDX](https://docs.astro.build/fr/guides/integrations-guide/mdx/#utilisation-de-composants-dans-mdx), consultez la documentation d'Astro.
 
 ## Utilisation d'un composant avec Markdoc
 
@@ -54,7 +54,7 @@ Sirius, Véga, Bételgeuse
 {% /card %}
 ```
 
-Consultez la [documentation de l'intégration Astro Markdoc](https://docs.astro.build/fr/guides/integrations-guide/markdoc/#afficher-les-composants) pour plus d'informations sur l'utilisation des composants dans les fichiers Markdoc.
+Consultez la [documentation de l'intégration Markdoc d'Astro](https://docs.astro.build/fr/guides/integrations-guide/markdoc/#restituer-les-composants) pour plus d'informations sur l'utilisation des composants dans les fichiers Markdoc.
 
 ## Composants intégrés
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Updates the French translations in `components` to:
* replace `import` with `importation` (`import` is an anglicism, we choose to use `importation` according to the [French i18n guide in Astro Docs](https://github.com/withastro/docs/blob/main/i18n-guides/fran%C3%A7ais.md#langage-courant))
* add missing space before some punctuation
* translate `label`, I don't have a strong opinion between `étiquette` and `libellé`, but it seems `étiquette` is [the right translation](https://www.larousse.fr/dictionnaires/francais/label/45761)
* fix some typo/missing translation
* slightly reword a sentence to use the right pronouns (`le lecteur` > `son` / `les lecteurs` > `leur`)

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
