### PR TITLE
i18n(fr): small rewording and fixes in `guides`

### DIFF
--- a/docs/src/content/docs/fr/guides/authoring-content.mdx
+++ b/docs/src/content/docs/fr/guides/authoring-content.mdx
@@ -3,9 +3,9 @@ title: Création de contenu en Markdown
 description: Un aperçu de la syntaxe Markdown prise en charge par Starlight.
 ---
 
-Starlight prend en charge l'ensemble de la syntaxe [Markdown](https://daringfireball.net/projects/markdown/) dans les fichiers `.md` ainsi que la syntaxe frontale [YAML](https://dev.to/paulasantamaria/introduction-to-yaml-125f) pour définir des métadonnées telles qu'un titre et une description.
+Starlight prend en charge l'ensemble de la syntaxe [Markdown](https://daringfireball.net/projects/markdown/) dans les fichiers `.md` ainsi que le frontmatter en [YAML](https://dev.to/paulasantamaria/introduction-to-yaml-125f) pour définir des métadonnées telles qu'un titre et une description.
 
-Veillez à consulter les [MDX docs](https://mdxjs.com/docs/what-is-mdx/#markdown) ou les [Markdoc docs](https://markdoc.dev/docs/syntax) si vous utilisez ces formats de fichiers, car la prise en charge et l'utilisation de Markdown peuvent varier.
+Veillez à consulter la [documentation de MDX](https://mdxjs.com/docs/what-is-mdx/#markdown) ou la [documentation de Markdoc](https://markdoc.dev/docs/syntax) si vous utilisez ces formats de fichiers, car la prise en charge et l'utilisation de Markdown peuvent varier.
 
 ## Frontmatter
 
@@ -23,12 +23,12 @@ Le contenu de la page suit le second `---`.
 Chaque page doit inclure au moins un titre (`title`).
 Consultez la [référence du frontmatter](/fr/reference/frontmatter/) pour connaître tous les champs disponibles et comment ajouter des champs personnalisés.
 
-## Styles en ligne
+## Styles incorporés au texte
 
-Le texte peut être **gras**, _italique_, ou ~~barré~~.
+Le texte peut être en **gras**, en _italique_, ou ~~barré~~.
 
 ```md
-Le texte peut être **gras**, _italique_, ou ~~barré~~.
+Le texte peut être en **gras**, en _italique_, ou ~~barré~~.
 ```
 
 Vous pouvez [faire un lien vers une autre page](/fr/getting-started/).
@@ -37,25 +37,25 @@ Vous pouvez [faire un lien vers une autre page](/fr/getting-started/).
 Vous pouvez [faire un lien vers une autre page](/fr/getting-started/).
 ```
 
-Vous pouvez mettre en évidence le `code en ligne` à l'aide d'un astérisque.
+Vous pouvez mettre en évidence le `code incorporé au texte` en utilisant des accents graves.
 
 ```md
-Vous pouvez mettre en évidence le `code en ligne` à l'aide de barres de défilement.
+Vous pouvez mettre en évidence le `code incorporé au texte` en utilisant des accents graves.
 ```
 
 ## Images
 
 Les images dans Starlight utilisent [la prise en charge intégrée des ressources optimisées d'Astro](https://docs.astro.build/fr/guides/images/).
 
-Markdown et MDX supportent la syntaxe Markdown pour l'affichage des images qui inclut le texte alt pour les lecteurs d'écran et les technologies d'assistance.
+Markdown et MDX prennent en charge la syntaxe Markdown pour l'affichage d'images qui incluent du texte alternatif pour les lecteurs d'écran et les technologies d'assistance.
 
-![Une illustration de planètes et d'étoiles avec le mot "astro"](https://raw.githubusercontent.com/withastro/docs/main/public/default-og-image.png)
+![Une illustration de planètes et d'étoiles avec le mot « astro »](https://raw.githubusercontent.com/withastro/docs/main/public/default-og-image.png)
 
 ```md
-![Une illustration de planètes et d'étoiles avec le mot "astro"](https://raw.githubusercontent.com/withastro/docs/main/public/default-og-image.png)
+![Une illustration de planètes et d'étoiles avec le mot « astro »](https://raw.githubusercontent.com/withastro/docs/main/public/default-og-image.png)
 ```
 
-Les chemins d'accès relatifs aux images sont également supportés pour les images stockées localement dans votre projet.
+Les chemins d'accès relatifs aux images sont également pris en charge pour les images stockées localement dans votre projet.
 
 ```md
 // src/content/docs/page-1.md
@@ -69,7 +69,7 @@ Vous pouvez structurer le contenu à l'aide d'un titre. En Markdown, les titres 
 
 ### Comment structurer le contenu d'une page dans Starlight
 
-Starlight est configuré pour utiliser automatiquement le titre de votre page comme titre de premier niveau et inclura un titre "Aperçu" en haut de la table des matières de chaque page. Nous vous recommandons de commencer chaque page par un paragraphe de texte normal et d'utiliser des titres de page à partir de `<h2>` :
+Starlight est configuré pour utiliser automatiquement le titre de votre page comme titre de premier niveau et inclura un titre « Aperçu » en haut de la table des matières de chaque page. Nous vous recommandons de commencer chaque page par un paragraphe de texte normal et d'utiliser des titres de page à partir de `<h2>` :
 
 ```md
 ---
@@ -79,7 +79,7 @@ description: Comment utiliser Markdown dans Starlight
 
 Cette page décrit comment utiliser Markdown dans Starlight.
 
-## Styles en ligne
+## Styles incorporés au texte
 
 ## Titres
 ```
@@ -105,7 +105,7 @@ Je peux faire un lien vers [ma conclusion](#conclusion) plus bas sur la même pa
 
 Les titres de niveau 2 (`<h2>`) et de niveau 3 (`<h3>`) apparaissent automatiquement dans la table des matières de la page.
 
-Pour en apprendre davantage sur la façon dont Astro traite les attributs `id` des titres de section, consultez la [documentation d'Astro](https://docs.astro.build/fr/guides/markdown-content/#identifiants-den-t%C3%AAte).
+Pour en apprendre davantage sur la façon dont Astro traite les attributs `id` des titres de section, consultez la [documentation d'Astro](https://docs.astro.build/fr/guides/markdown-content/#id-des-titres).
 
 ## Encarts
 
@@ -113,7 +113,7 @@ Les encarts (également connus sous le nom de « admonitions » ou « asides » 
 
 Starlight fournit une syntaxe Markdown personnalisée pour le rendu des encarts. Les blocs d'encarts sont indiqués en utilisant une paire de triples points `:::` pour envelopper votre contenu, et peuvent être de type `note`, `tip`, `caution` ou `danger`.
 
-Vous pouvez imbriquer n'importe quel autre type de contenu Markdown à l'intérieur d'un aparté, mais les aparté sont mieux adaptés à des morceaux de contenu courts et concis.
+Vous pouvez imbriquer n'importe quel autre type de contenu Markdown à l'intérieur d'un encart, mais les encarts sont mieux adaptés à des morceaux de contenu courts et concis.
 
 ### Encart de type note
 
@@ -179,7 +179,7 @@ Vos utilisateurs peuvent être plus productifs et trouver votre produit plus fac
 
 - Navigation claire
 - Thème de couleurs configurable par l'utilisateur
-- [Support i18n](/fr/guides/i18n/)
+- [Prise en charge i18n](/fr/guides/i18n/)
 
 :::
 
@@ -193,21 +193,21 @@ Vos utilisateurs peuvent être plus productifs et trouver votre produit plus fac
 
 - Navigation claire
 - Thème de couleurs configurable par l'utilisateur
-- [Support i18n](/fr/guides/i18n/)
+- [Prise en charge i18n](/fr/guides/i18n/)
 
 :::
 ```
 
-## Blockquotes
+## Blocs de citation
 
-> Il s'agit d'une citation en bloc, couramment utilisée pour citer une autre personne ou un document.
+> Il s'agit d'un bloc de citation, couramment utilisé pour citer une autre personne ou un document.
 >
-> Les guillemets sont indiqués par un `>` au début de chaque ligne.
+> Les blocs de citation sont indiqués par un `>` au début de chaque ligne.
 
 ```md
-> Il s'agit d'une citation en bloc, couramment utilisée pour citer une autre personne ou un document.
+> Il s'agit d'un bloc de citation, couramment utilisé pour citer une autre personne ou un document.
 >
-> Les guillemets sont indiqués par un `>` au début de chaque ligne.
+> Les blocs de citation sont indiqués par un `>` au début de chaque ligne.
 ```
 
 ## Blocs de code
@@ -235,7 +235,7 @@ var fun = function lang(l) {
 ### Fonctionnalités d'Expressive Code
 
 Starlight utilise [Expressive Code](https://expressive-code.com/) pour étendre les possibilités de formatage des blocs de code.
-Les plugins Expressive Code de marqueurs de texte et de cadres de fenêtre sont activés par défaut.
+Les modules d'extension Expressive Code de marqueurs de texte et de cadres de fenêtre sont activés par défaut.
 L'affichage des blocs de code peut être configuré à l'aide de [l'option de configuration `expressiveCode`](/fr/reference/configuration/#expressivecode) de Starlight.
 
 #### Marqueurs de texte
@@ -248,7 +248,7 @@ Du texte et des lignes entières peuvent être marqués à l'aide du marqueur pa
 
 Expressive Code fournit plusieurs options pour personnaliser l'apparence visuelle de vos exemples de code.
 Beaucoup d'entre elles peuvent être combinées pour obtenir des exemples de code très illustratifs.
-Merci d'explorer la [documentation d'Expressive Code](https://expressive-code.com/key-features/text-markers/#configuration) pour obtenir une liste complète des options disponibles.
+Veuillez explorer la [documentation d'Expressive Code](https://expressive-code.com/key-features/text-markers/#configuration) pour obtenir une liste complète des options disponibles.
 Certaines des options les plus courantes sont présentées ci-dessous :
 
 - [Marquer des lignes entières et des plages de lignes à l'aide du marqueur `{ }`](https://expressive-code.com/key-features/text-markers/#marking-full-lines--line-ranges) :
@@ -548,11 +548,11 @@ Starlight prend en charge toutes les autres syntaxes de rédaction Markdown, tel
 
 ## Configuration avancée de Markdown et MDX
 
-Starlight utilise le moteur de rendu Markdown et MDX d'Astro basé sur remark et rehype. Vous pouvez ajouter la prise en charge de syntaxe et comportement personnalisés en ajoutant `remarkPlugins` ou `rehypePlugins` dans votre fichier de configuration Astro. Pour en savoir plus, consultez [« Plugins Markdown »](https://docs.astro.build/fr/guides/markdown-content/#plugins-markdown) dans la documentation d'Astro.
+Starlight utilise le moteur de rendu Markdown et MDX d'Astro basé sur remark et rehype. Vous pouvez ajouter la prise en charge de syntaxe et comportement personnalisés en ajoutant `remarkPlugins` ou `rehypePlugins` dans votre fichier de configuration Astro. Pour en savoir plus, consultez [« Modules d’extension Markdown »](https://docs.astro.build/fr/guides/markdown-content/#modules-dextension-markdown) dans la documentation d'Astro.
 
 ## Markdoc
 
-Starlight supporte la création de contenu en Markdoc en utilisant l'intégration expérimentale [Astro Markdoc](https://docs.astro.build/fr/guides/integrations-guide/markdoc/) et le préréglage Markdoc de Starlight.
+Starlight prend en charge la création de contenu en Markdoc en utilisant l'intégration expérimentale [Astro Markdoc](https://docs.astro.build/fr/guides/integrations-guide/markdoc/) et le préréglage Markdoc de Starlight.
 
 ### Créer un nouveau projet avec Markdoc
 

--- a/docs/src/content/docs/fr/guides/authoring-content.mdx
+++ b/docs/src/content/docs/fr/guides/authoring-content.mdx
@@ -65,11 +65,11 @@ Les chemins d'accès relatifs aux images sont également pris en charge pour les
 
 ## En-têtes
 
-Vous pouvez structurer le contenu à l'aide d'un titre. En Markdown, les titres sont indiqués par un nombre de `#` en début de ligne.
+Vous pouvez structurer le contenu à l'aide d'en-têtes. En Markdown, les en-têtes sont indiqués par un certain nombre de `#` en début de ligne.
 
 ### Comment structurer le contenu d'une page dans Starlight
 
-Starlight est configuré pour utiliser automatiquement le titre de votre page comme titre de premier niveau et inclura un titre « Aperçu » en haut de la table des matières de chaque page. Nous vous recommandons de commencer chaque page par un paragraphe de texte normal et d'utiliser des titres de page à partir de `<h2>` :
+Starlight est configuré pour utiliser automatiquement le titre de votre page comme en-tête de premier niveau et inclura un en-tête « Aperçu » en haut de la table des matières de chaque page. Nous vous recommandons de commencer chaque page par un paragraphe de texte normal et d'utiliser des en-têtes de page à partir de `<h2>` :
 
 ```md
 ---
@@ -81,12 +81,12 @@ Cette page décrit comment utiliser Markdown dans Starlight.
 
 ## Styles incorporés au texte
 
-## Titres
+## En-têtes
 ```
 
-### Liens d'ancrage automatiques pour les titres
+### Liens d'ancrage automatiques pour les en-têtes
 
-L'utilisation de titres en Markdown vous donnera automatiquement des liens d'ancrage afin que vous puissiez accéder directement à certaines sections de votre page :
+L'utilisation d'en-têtes en Markdown vous donnera automatiquement des liens d'ancrage afin que vous puissiez accéder directement à certaines sections de votre page :
 
 ```md
 ---
@@ -103,9 +103,9 @@ Je peux faire un lien vers [ma conclusion](#conclusion) plus bas sur la même pa
 `https://my-site.com/page1/#introduction` renvoie directement à mon Introduction.
 ```
 
-Les titres de niveau 2 (`<h2>`) et de niveau 3 (`<h3>`) apparaissent automatiquement dans la table des matières de la page.
+Les en-têtes de niveau 2 (`<h2>`) et de niveau 3 (`<h3>`) apparaissent automatiquement dans la table des matières de la page.
 
-Pour en apprendre davantage sur la façon dont Astro traite les attributs `id` des titres de section, consultez la [documentation d'Astro](https://docs.astro.build/fr/guides/markdown-content/#id-des-titres).
+Pour en apprendre davantage sur la façon dont Astro traite les attributs `id` des en-têtes de section, consultez la [documentation d'Astro](https://docs.astro.build/fr/guides/markdown-content/#id-des-titres).
 
 ## Encarts
 

--- a/docs/src/content/docs/fr/guides/css-and-tailwind.mdx
+++ b/docs/src/content/docs/fr/guides/css-and-tailwind.mdx
@@ -79,7 +79,7 @@ Le CSS Tailwind de Starlight applique la configuration suivante :
 
 ### Créer un nouveau projet avec Tailwind
 
-Démarrez un nouveau projet Starlight avec Tailwind CSS préconfiguré en utilisant `create astro` :
+Démarrez un nouveau projet Starlight avec Tailwind CSS préconfiguré en utilisant `create astro` :
 
 <Tabs syncKey="pkg">
 <TabItem label="npm">
@@ -215,10 +215,10 @@ Lors de la [création d'un nouveau projet Starlight avec Tailwind](#créer-un-no
 
 Si définies, les propriétés personnalisées CSS suivantes remplaceront les styles par défaut de Starlight :
 
-- `--color-accent-*` — utilisé pour les liens et la mise en évidence de l'élément courant
-- `--color-gray-*` — utilisé pour les couleurs d'arrière-plan et les bordures
-- `--font-sans` — utilisé pour le texte de l'interface utilisateur et du contenu
-- `--font-mono` — utilisé pour les exemples de code
+- `--color-accent-*` — utilisée pour les liens et la mise en évidence de l'élément courant
+- `--color-gray-*` — utilisée pour les couleurs d'arrière-plan et les bordures
+- `--font-sans` — utilisée pour le texte de l'interface utilisateur et du contenu
+- `--font-mono` — utilisée pour les exemples de code
 
 ```css {9-12,14-17,19-22,34-37}
 /* src/styles/global.css */

--- a/docs/src/content/docs/fr/guides/customization.mdx
+++ b/docs/src/content/docs/fr/guides/customization.mdx
@@ -26,7 +26,7 @@ L’ajout d’un logo personnalisé à l’en-tête du site est un moyen rapide 
 
    </FileTree>
 
-2. Ajoutez le chemin vers votre logo à votre option de configuration Starlight [`logo.src`](/fr/reference/configuration/#logo) dans `astro.config.mjs`:
+2. Ajoutez le chemin vers votre logo à votre option de configuration Starlight [`logo.src`](/fr/reference/configuration/#logo) dans `astro.config.mjs` :
 
    ```diff lang="js"
    // astro.config.mjs
@@ -67,7 +67,7 @@ Vous pouvez afficher différentes versions de votre logo en modes clair et sombr
 
 <Steps>
 
-1. Ajouter un fichier image pour chaque variante dans `src/assets/`:
+1. Ajouter un fichier image pour chaque variante dans `src/assets/` :
 
    <FileTree>
 
@@ -80,7 +80,7 @@ Vous pouvez afficher différentes versions de votre logo en modes clair et sombr
 
    </FileTree>
 
-2. Ajouter les chemins vers vos variantes de logo dans les options `light` (clair) et `dark` (sombre) en remplacement de l’option `src` dans `astro.config.mjs`:
+2. Ajouter les chemins vers vos variantes de logo dans les options `light` (clair) et `dark` (sombre) en remplacement de l’option `src` dans `astro.config.mjs` :
 
    ```diff lang="js"
    starlight({
@@ -96,7 +96,7 @@ Vous pouvez afficher différentes versions de votre logo en modes clair et sombr
 
 ## Activer un plan de site
 
-Starlight possède une prise en charge intégrée pour la génération d’un plan de site. Activez la génération du plan de site en définissant votre URL comme `site` dans `astro.config.mjs`:
+Starlight possède une prise en charge intégrée pour la génération d’un plan de site. Activez la génération du plan de site en définissant votre URL comme `site` dans `astro.config.mjs` :
 
 ```js {4}
 // astro.config.mjs
@@ -164,7 +164,7 @@ defineConfig({
   </TabItem>
 </Tabs>
 
-Désactivez la table des matières complètement en définissant l’option `tableOfContents` à `false`:
+Désactivez la table des matières complètement en définissant l’option `tableOfContents` à `false` :
 
 <Tabs syncKey="config-type">
   <TabItem label="Frontmatter">
@@ -198,7 +198,7 @@ defineConfig({
 
 ## Liens sociaux
 
-Starlight supporte par défaut l’ajout de liens vers vos comptes de médias sociaux dans l’en-tête du site via l’option [`social`](/fr/reference/configuration/#social) dans l’intégration Starlight.
+Starlight prend en charge par défaut l’ajout de liens vers vos comptes de médias sociaux dans l’en-tête du site via l’option [`social`](/fr/reference/configuration/#social) dans l’intégration Starlight.
 
 Chaque entrée dans le tableau `social` doit être un objet avec trois propriétés :
 
@@ -232,17 +232,17 @@ export default defineConfig({
 
 ## Liens d’édition de page
 
-Starlight peut afficher un lien "Modifier cette page" dans le pied de page de chaque page.
+Starlight peut afficher un lien « Modifier cette page » dans le pied de page de chaque page.
 Cela permet au lecteur de trouver facilement le fichier à modifier pour améliorer vos documents.
 Pour les projets open source en particulier, cela peut aider à encourager les contributions de votre communauté.
 
-Pour activer les liens de modification, définissez l’option de configuration [`editLink.baseUrl`](/fr/reference/configuration/#editlink) en lui assignant l’URL utilisée pour modifier votre référentiel dans la configuration de l’intégration Starlight.
+Pour activer les liens de modification, définissez l’option de configuration [`editLink.baseUrl`](/fr/reference/configuration/#editlink) en lui assignant l’URL utilisée pour modifier votre dépôt dans la configuration de l’intégration Starlight.
 La valeur de `editLink.baseUrl` sera automatiquement ajoutée au chemin d’accès vers la page actuelle pour former le lien d’édition complet.
 
 Les formes d’URL les plus courantes incluent :
 
-- GitHub: `https://github.com/NOM_UTILISATEUR/NOM_DU_DEPOT/edit/NOM_DE_LA_BRANCHE/`
-- GitLab: `https://gitlab.com/NOM_UTILISATEUR/NOM_DU_DEPOT/-/edit/NOM_DE_LA_BRANCHE/`
+- GitHub : `https://github.com/NOM_UTILISATEUR/NOM_DU_DEPOT/edit/NOM_DE_LA_BRANCHE/`
+- GitLab : `https://gitlab.com/NOM_UTILISATEUR/NOM_DU_DEPOT/-/edit/NOM_DE_LA_BRANCHE/`
 
 Si votre projet Starlight ne se trouve pas à la racine de votre dépôt, incluez le chemin d’accès au projet à la fin de l’URL de base.
 
@@ -319,11 +319,11 @@ export default defineConfig({
 Par défaut, Starlight utilise des polices sans empattement disponibles en local sur la machine du visiteur pour tout les textes.
 Cela garantit que la documentation se charge rapidement dans une police familière à chaque utilisateur, sans nécessiter de bande passante supplémentaire pour télécharger des fichiers de police volumineux.
 
-Si vous souhaitez ajouter une police personnalisée à votre site Starlight, vous pouvez configurer les polices à utiliser dans des fichiers CSS personnalisés ou avec toute autre [technique de style Astro](https://docs.astro.build/en/guides/styling/).
+Si vous souhaitez ajouter une police personnalisée à votre site Starlight, vous pouvez configurer les polices à utiliser dans des fichiers CSS personnalisés ou avec toute autre [technique de style Astro](https://docs.astro.build/fr/guides/styling/).
 
 ### Configurer les polices
 
-Si vous avez déjà des fichiers de polices, suivez le [guide de configuration local](#configurer-les-polices-localement).
+Si vous avez déjà des fichiers de polices, suivez le [guide de configuration locale](#configurer-les-polices-localement).
 Pour utiliser Google Fonts, suivez le [Guide de configuration de Fontsource](#configurer-les-polices-avec-fontsource).
 
 #### Configurer les polices localement
@@ -391,8 +391,8 @@ Il fournit des modules npm que vous pouvez installer pour les polices que vous s
 1.  Trouvez la police que vous souhaitez utiliser dans le [catalogue de Fontsource](https://fontsource.org/).
     Cet exemple utilisera [IBM Plex Serif](https://fontsource.org/fonts/ibm-plex-serif).
 
-2.  Installez le package pour la police choisie.
-    Vous pouvez trouver le nom du package en cliquant sur "Installer" sur la page de police Fontsource.
+2.  Installez le paquet pour la police choisie.
+    Vous pouvez trouver le nom du paquet en cliquant sur « Installer » sur la page de police Fontsource.
 
         <Tabs syncKey="pkg">
 

--- a/docs/src/content/docs/fr/guides/customization.mdx
+++ b/docs/src/content/docs/fr/guides/customization.mdx
@@ -109,9 +109,9 @@ export default defineConfig({
 
 Apprenez comment [ajouter un lien du plan de site au fichier `robots.txt`](https://docs.astro.build/fr/guides/integrations-guide/sitemap/#lien-vers-le-plan-du-site-dans-le-fichier-robotstxt) dans la documentation d'Astro.
 
-## Mise en Page
+## Mise en page
 
-Par défaut, les pages Starlight utilisent une mise en page avec une barre latérale de navigation globale et une table des matières qui affiche les titres de la page courante.
+Par défaut, les pages Starlight utilisent une mise en page avec une barre latérale de navigation globale et une table des matières qui affiche les en-têtes de la page courante.
 
 Vous pouvez appliquer une mise en page plus large sans barres latérales en définissant [`template: splash`](/fr/reference/frontmatter/#template) dans le frontmatter de votre page.
 Cela fonctionne particulièrement bien pour les pages d’atterissage et vous pouvez le voir en action sur la [page d’accueil de ce site](/fr/).
@@ -130,7 +130,7 @@ template: splash
 Starlight affiche une table des matières sur chaque page pour permettre aux lecteurs d’accéder plus facilement à la section qu’ils recherchent.
 Vous pouvez personnaliser - ou même désactiver - la table des matières globalement dans l’intégration Starlight ou page par page dans votre frontmatter.
 
-Par défaut, les titres `<h2>` et `<h3>` sont inclus dans la table des matières. Modifiez les niveaux de titres à inclure à l’échelle du site à l’aide des options `minHeadingLevel` et `maxHeadingLevel` dans votre option de configuration [globale `tableOfContents`](/fr/reference/configuration/#tableofcontents). Remplacez ces valeurs par défaut sur une page individuelle en ajoutant les propriétés [frontmatter `tableOfContents`](/fr/reference/frontmatter/#tableofcontents) correspondantes :
+Par défaut, les en-têtes `<h2>` et `<h3>` sont inclus dans la table des matières. Modifiez les niveaux des en-têtes à inclure à l’échelle du site à l’aide des options `minHeadingLevel` et `maxHeadingLevel` dans votre option de configuration [globale `tableOfContents`](/fr/reference/configuration/#tableofcontents). Remplacez ces valeurs par défaut sur une page individuelle en ajoutant les propriétés [frontmatter `tableOfContents`](/fr/reference/frontmatter/#tableofcontents) correspondantes :
 
 <Tabs syncKey="config-type">
   <TabItem label="Frontmatter">

--- a/docs/src/content/docs/fr/guides/i18n.mdx
+++ b/docs/src/content/docs/fr/guides/i18n.mdx
@@ -67,7 +67,7 @@ Starlight offre une prise en charge intégrée des sites multilingues, y compris
 
 </Steps>
 
-Pour les scénarios i18n plus avancés, Starlight prend également en compte la configuration de l'internationalisation à l'aide de l'option de [configuration `i18n` d'Astro](https://docs.astro.build/fr/guides/internationalization/#configure-i18n-routing).
+Pour les scénarios i18n plus avancés, Starlight prend également en compte la configuration de l'internationalisation à l'aide de l'option de [configuration `i18n` d'Astro](https://docs.astro.build/fr/guides/internationalization/#configurer-le-routage-i18n).
 
 ### Utiliser une locale racine
 
@@ -141,7 +141,7 @@ Cela vous permet de remplacer la langue par défaut de Starlight sans activer d'
 
 ## Contenu de repli
 
-Starlight s'attend à ce que vous créiez des pages équivalentes dans toutes vos langues. Par exemple, si vous avez un fichier `en/about.md`, créez un `about.md` pour chaque autre langue que vous supportez. Cela permet à Starlight de fournir un contenu de repli automatique pour les pages qui n'ont pas encore été traduites.
+Starlight s'attend à ce que vous créiez des pages équivalentes dans toutes vos langues. Par exemple, si vous avez un fichier `en/about.md`, créez un `about.md` pour chaque autre langue que vous prenez en charge. Cela permet à Starlight de fournir un contenu de repli automatique pour les pages qui n'ont pas encore été traduites.
 
 Si une traduction n'est pas encore disponible pour une langue, Starlight affichera aux lecteurs le contenu de cette page dans la langue par défaut (définie via `defaultLocale`). Par exemple, si vous n'avez pas encore créé de version française de votre page À propos et que votre langue par défaut est l'anglais, les visiteurs de `/fr/about` verront le contenu anglais de `/en/about` avec un avis indiquant que cette page n'a pas encore été traduite. Cela vous permet d'ajouter du contenu dans votre langue par défaut et de le traduire progressivement lorsque vos traducteurs en ont le temps.
 
@@ -178,13 +178,13 @@ export default defineConfig({
 import LanguagesList from '~/components/languages-list.astro';
 import UIStringsList from '~/components/ui-strings-list.astro';
 
-En plus d'héberger des fichiers de contenu traduits, Starlight vous permet de traduire les chaînes de l'interface utilisateur par défaut (par exemple, l'en-tête "Sur cette page" dans la table des matières) afin que vos lecteurs puissent découvrir votre site entièrement dans la langue sélectionnée.
+En plus d'héberger des fichiers de contenu traduits, Starlight vous permet de traduire les chaînes de l'interface utilisateur par défaut (par exemple, l'en-tête « Sur cette page » dans la table des matières) afin que vos lecteurs puissent découvrir votre site entièrement dans la langue sélectionnée.
 
 Les textes de l'interface utilisateur traduits en <LanguagesList />
 sont disponibles prêts à l'emploi, et nous acceptons les
 [contributions pour ajouter d'autres langues par défaut](https://github.com/withastro/starlight/blob/main/CONTRIBUTING.md).
 
-Vous pouvez fournir des traductions pour les langues supplémentaires que vous supportez - ou remplacer nos étiquettes par défaut - via la collection de contenus `i18n`.
+Vous pouvez fournir des traductions pour les langues supplémentaires que vous prenez en charge — ou remplacer nos étiquettes par défaut — via la collection de contenus `i18n`.
 
 <Steps>
 
@@ -232,7 +232,7 @@ Vous pouvez fournir des traductions pour les langues supplémentaires que vous s
    }
    ```
 
-   La module de recherche de Starlight’s s’appuie sur la librairie [Pagefind](https://pagefind.app/).
+   Le module de recherche de Starlight s’appuie sur la librairie [Pagefind](https://pagefind.app/).
    Vous pouvez définir des traductions pour l’interface utilisateur de Pagefind dans le même fichier JSON en utilisant les clés `pagefind` :
 
    ```json
@@ -281,7 +281,7 @@ Consultez [« Définir un schéma de collection de contenus »](https://docs.ast
 ## Utiliser les traductions de l'interface utilisateur
 
 Vous pouvez accéder aux [chaînes de l'interface utilisateur intégrées](/fr/guides/i18n/#traduire-linterface-utilisateur-de-starlight) à Starlight ainsi qu'aux chaînes de l'interface utilisateur [définies par l'utilisateur](/fr/guides/i18n/#étendre-le-schéma-de-traduction), et celles [fournies par les modules d'extension](/fr/reference/plugins/#injecttranslations) via une API unifiée utilisant [i18next](https://www.i18next.com/).
-Cela inclut le support de fonctionnalités telles que [l'interpolation](https://www.i18next.com/translation-function/interpolation) et [la pluralisation](https://www.i18next.com/translation-function/plurals).
+Cela inclut la prise en charge de fonctionnalités telles que [l'interpolation](https://www.i18next.com/translation-function/interpolation) et [la pluralisation](https://www.i18next.com/translation-function/plurals).
 
 Dans les composants Astro, cette API est disponible via l'[objet global `Astro`](https://docs.astro.build/fr/reference/api-reference/#astrolocals) sous le nom `Astro.locals.t` :
 
@@ -291,7 +291,7 @@ Dans les composants Astro, cette API est disponible via l'[objet global `Astro`]
 </p>
 ```
 
-Vous pouvez également utiliser l'API dans les [points de terminaison](https://docs.astro.build/fr/guides/endpoints/), où l'objet `locals` est disponible dans le cadre du [contexte du point de terminaison](https://docs.astro.build/fr/reference/api-reference/#contextlocals):
+Vous pouvez également utiliser l'API dans les [points de terminaison](https://docs.astro.build/fr/guides/endpoints/), où l'objet `locals` est disponible dans le cadre du [contexte du point de terminaison](https://docs.astro.build/fr/reference/api-reference/#contextlocals) :
 
 ```ts title="src/pages/404.ts"
 export const GET = (context) => {

--- a/docs/src/content/docs/fr/guides/overriding-components.mdx
+++ b/docs/src/content/docs/fr/guides/overriding-components.mdx
@@ -7,7 +7,7 @@ import { Steps } from '@astrojs/starlight/components';
 
 L'interface utilisateur et les options de configuration par défaut de Starlight sont conçues pour être flexibles et fonctionner pour une variété de contenus. Une grande partie de l'apparence par défaut de Starlight peut être personnalisée grâce au [CSS](/fr/guides/css-and-tailwind/) et aux [options de configuration](/fr/guides/customization/).
 
-Quand vos besoins dépassent ce qui est possible de base, Starlight supporte la création de vos propres composants personnalisés pour étendre ou redéfinir (remplacer complètement) ses composants par défaut.
+Quand vos besoins dépassent ce qui est possible de base, Starlight prend en charge la création de vos propres composants personnalisés pour étendre ou redéfinir (remplacer complètement) ses composants par défaut.
 
 ## Quand redéfinir
 
@@ -67,7 +67,7 @@ Redéfinir les composants par défaut de Starlight peut être utile lorsque :
 
 ## Réutiliser un composant intégré
 
-Vous pouvez utiliser les composants par défaut de Starlight de la même manière que les vôtres : en les important et en les affichant dans vos propres composants personnalisés. Cela vous permet de conserver toute l'interface utilisateur de base de Starlight dans votre design, tout en ajoutant des éléments supplémentaires à côté.
+Vous pouvez utiliser les composants par défaut de Starlight de la même manière que les vôtres : en les important et en les affichant dans vos propres composants personnalisés. Cela vous permet de conserver toute l'interface utilisateur de base de Starlight dans votre design, tout en ajoutant des éléments supplémentaires à côté.
 
 L'exemple ci-dessous montre un composant personnalisé qui affiche un lien de courriel suivi du composant `SocialIcons` par défaut :
 

--- a/docs/src/content/docs/fr/guides/pages.mdx
+++ b/docs/src/content/docs/fr/guides/pages.mdx
@@ -180,7 +180,7 @@ Consultez le guide [« Barre latérale de navigation »](/fr/guides/sidebar/) po
 ##### `hasSidebar`
 
 **Type :** `boolean`  
-**Par défaut :** `false` si [`frontmatter.template`](/fr/reference/frontmatter/#template) est `'splash'`, autrement `true`
+**Par défaut :** `false` si [`frontmatter.template`](/fr/reference/frontmatter/#template) utilise `'splash'`, autrement `true`
 
 Contrôle l'affichage ou non de la barre latérale sur cette page.
 

--- a/docs/src/content/docs/fr/guides/project-structure.mdx
+++ b/docs/src/content/docs/fr/guides/project-structure.mdx
@@ -10,11 +10,11 @@ Les projets Starlight suivent généralement la même structure de fichiers et d
 ## Fichiers et répertoires
 
 - `astro.config.mjs` — Le fichier de configuration d'Astro ; inclut l'intégration et la configuration de Starlight.
-- `src/content.config.ts` — Fichier de configuration des collections de contenu ; ajoute les schémas de la matière première de Starlight à votre projet.
+- `src/content.config.ts` — Fichier de configuration des collections de contenu ; ajoute les schémas du frontmatter de Starlight à votre projet.
 - `src/content/docs/` — Fichiers de contenu. Starlight transforme chaque fichier `.md`, `.mdx` ou `.mdoc` de ce répertoire en une page de votre site.
 - `src/content/i18n/` (optionnel) — Données de traduction pour prendre en charge l'[internationalisation](/fr/guides/i18n/).
 - `src/` — Autre code source et fichiers (composants, styles, images, etc.) pour votre projet.
-- `public/` — Actifs statiques (polices, favicon, PDFs, etc.) qui ne seront pas traités par Astro.
+- `public/` — Ressources statiques (polices, favicon, PDF, etc.) qui ne seront pas traités par Astro.
 
 ## Exemple de contenu de projet
 

--- a/docs/src/content/docs/fr/guides/site-search.mdx
+++ b/docs/src/content/docs/fr/guides/site-search.mdx
@@ -82,7 +82,7 @@ Si vous avez accès au [programme DocSearch d'Algolia](https://docsearch.algolia
 
    </Tabs>
 
-2. Ajouter DocSearch à votre configuration [`plugins`](/fr/reference/configuration/#plugins) de Starlight dans le fichier `astro.config.mjs` et spécifiez votre `appId`, `apiKey` et `indexName` d'Algolia :
+2. Ajouter DocSearch à votre configuration [`plugins`](/fr/reference/configuration/#plugins) de Starlight dans le fichier `astro.config.mjs` et spécifiez vos `appId`, `apiKey` et `indexName` d'Algolia :
 
    ```js ins={4,10-16}
    // astro.config.mjs
@@ -112,11 +112,11 @@ Avec cette configuration mise à jour, la barre de recherche de votre site ouvri
 
 #### Configuration de DocSearch
 
-Le module d’extension DocSearch de Starlight supporte la personnalisation du composant DocSearch avec les options supplémentaires suivantes spécifiées dans la configuration du module d’extension :
+Le module d’extension DocSearch de Starlight prend en charge la personnalisation du composant DocSearch avec les options supplémentaires suivantes spécifiées dans la configuration du module d’extension :
 
 - `maxRecentSearches`: Limite le nombre de résultats affichés pour chaque groupe de recherche. La valeur par défaut est `5`.
 - `disableUserPersonalization`: Empêche DocSearch de sauvegarder les recherches récentes et favorites d'un utilisateur localement. La valeur par défaut est `false`.
-- `insights`: Active le plugin Algolia Insights et envoie les événements liés à toute recherche à votre index DocSearch. La valeur par défaut est `false`.
+- `insights`: Active le module d'extension Algolia Insights et envoie les événements liés à toute recherche à votre index DocSearch. La valeur par défaut est `false`.
 - `searchParameters`: Un objet personnalisant les [paramètres de recherche Algolia](https://www.algolia.com/doc/api-reference/search-api-parameters/).
 
 ##### Options supplémentaires de DocSearch

--- a/docs/src/content/docs/fr/reference/configuration.mdx
+++ b/docs/src/content/docs/fr/reference/configuration.mdx
@@ -75,7 +75,7 @@ type LogoConfig = { alt?: string; replacesTitle?: boolean } & (
 **Type :** `false | { minHeadingLevel?: number; maxHeadingLevel?: number }`  
 **Par défaut :** `{ minHeadingLevel: 2, maxHeadingLevel: 3 }`
 
-Configurez la table des matières affichée à droite de chaque page. Par défaut, les titres `<h2>` et `<h3>` seront inclus dans cette table des matières.
+Configurez la table des matières affichée à droite de chaque page. Par défaut, les en-têtes `<h2>` et `<h3>` seront inclus dans cette table des matières.
 
 ### `editLink`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Updates the French translations in `guides` to:
* revert some unwanted translations (`syntaxe frontale`, `matière première` for `frontmatter`)
* translate `docs`
* replace the translation for `inline` (`en ligne` is usually the wrong translation)
* fix some bad translations (`backticks` > `accents graves`, `blockquotes` > `bloc de citation`)
* replace `supporte` with `prend en charge` (`support` is an anglicism)
* use French quotes
* fix some Astro docs links because of updates on the French version
* translate `plugin` to be consistent with the other docs pages
* add missing space before some punctuation
* respect verb agreement (`propriété` > `utilisée` instead of `utilisé`)
* translate `package`
* replace `actifs` (financial/crypto word) with `ressources` for `assets`
* use non breaking space before punctuation in some places to avoid:

![starlight-without-non-breaking-spaces-example](https://github.com/user-attachments/assets/2095d69d-8c3f-423a-a6b2-37b3031db6a3)

(note the colon on a new line)

---

One thing I haven't updated for consistency: `en-tête`/`titre`. In Astro Docs we use `titre` for `headings` while in most places, Starlight uses `en-tête`. I could have replaced the `titre` occurrences in `authoring-content` but I'm a bit torn.
While `titre de niveau 2` sounds correct to me, `en-tête de niveau 2` sounds unusual to me. So I wasn't sure what to do and so I preferred to leave them as they are. For reference, LibreOffice uses `titre` in French when the English version uses `heading`:
|French|English|
|---|---|
|![libre-office-french-heading](https://github.com/user-attachments/assets/9071080b-b7d9-4ccf-92b7-441cb3b2c84c)|![libre-office-english-heading](https://github.com/user-attachments/assets/a19a00da-ae0e-4afd-9116-244b506f2595)|

**Note:** This is not necessarily blocking for this PR since I haven't updated that! But we might want to think about it to make things consistent in a future PR!

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
