### PR TITLE
i18n(fr): small rewording and fixes in top-level pages

### DIFF
--- a/docs/src/content/docs/fr/environmental-impact.md
+++ b/docs/src/content/docs/fr/environmental-impact.md
@@ -59,7 +59,7 @@ La façon dont une page web est construite peut avoir un impact sur la puissance
 En utilisant un minimum de JavaScript, Starlight réduit la puissance de traitement dont le téléphone, la tablette ou l'ordinateur d'un utilisateur a besoin pour charger et afficher les pages.
 
 Soyez vigilant lorsque vous ajoutez des fonctionnalités telles que des scripts de suivi analytique ou des contenus à forte teneur en JavaScript, comme des vidéos intégrées, car ils peuvent augmenter la consommation d'énergie de la page.
-Si vous avez besoin d'analyses, envisagez de choisir une option légère comme [Cabin][cabin], [Fathom][fathom], ou [Plausible][plausible].
+Si vous avez besoin de mesures d'audience, envisagez de choisir une option légère comme [Cabin][cabin], [Fathom][fathom], ou [Plausible][plausible].
 Les vidéos intégrées comme celles de YouTube et de Vimeo peuvent être améliorées en attendant de [charger la vidéo lors de l'interaction avec l'utilisateur][lazy-video].
 Des paquets comme [`astro-embed`][embed] peuvent aider pour les services communs.
 

--- a/docs/src/content/docs/fr/getting-started.mdx
+++ b/docs/src/content/docs/fr/getting-started.mdx
@@ -13,7 +13,7 @@ Consultez les [instructions d'installation manuelle](/fr/manual-setup/) pour ajo
 
 ### Créer un nouveau projet
 
-Créez un nouveau projet Astro + Starlight en lançant la commande suivante dans votre terminal :
+Créez un nouveau projet Astro + Starlight en lançant la commande suivante dans votre terminal :
 
 <Tabs syncKey="pkg">
 <TabItem label="npm">
@@ -101,7 +101,7 @@ Comme Starlight est un logiciel en version bêta, il y aura des mises à jour et
 Assurez-vous de mettre à jour Starlight régulièrement !
 :::
 
-Starlight est une intégration Astro. Vous pouvez la mettre à jour ainsi que tous autres packages Astro en exécutant la commande suivante dans votre terminal :
+Starlight est une intégration Astro. Vous pouvez la mettre à jour ainsi que tout autre paquet d'Astro en exécutant la commande suivante dans votre terminal :
 
 <Tabs syncKey="pkg">
 <TabItem label="npm">
@@ -137,4 +137,4 @@ Consultez les guides de la barre latérale pour vous aider à ajouter du contenu
 Si vous ne trouvez pas votre réponse dans cette documentation, merci de consulter la [documentation d'Astro](https://docs.astro.build/fr/) pour la documentation complète d'Astro.
 Votre question peut être résolue en comprenant comment Astro fonctionne de manière générale, sous ce thème Starlight.
 
-Vous pouvez également vérifier [tous les problèmes connus de Starlight sur GitHub](https://github.com/withastro/starlight/issues) et obtenir de l'aide dans le [Discord Astro](https://astro.build/chat/) de notre communauté active et sympathique ! Publiez des questions dans notre forum `#support` avec le tag "starlight" ou visiter notre canal dédié `#starlight` pour discuter des développements en cours et plus encore !
+Vous pouvez également vérifier [tous les problèmes connus de Starlight sur GitHub](https://github.com/withastro/starlight/issues) et obtenir de l'aide auprès de notre communauté active et sympathique dans le [Discord d'Astro](https://astro.build/chat/) ! Publiez des questions dans notre forum `#support` avec le tag « starlight » ou visiter notre canal dédié `#starlight` pour discuter des développements en cours et plus encore !

--- a/docs/src/content/docs/fr/index.mdx
+++ b/docs/src/content/docs/fr/index.mdx
@@ -44,11 +44,11 @@ import Testimonial from '~/components/testimonial.astro';
 		avec vos intégrations et bibliothèques Astro préférées.
 	</Card>
 	<Card title="Markdown, Markdoc et MDX" icon="document">
-		Apportez votre langage de balisage préféré. Starlight vous offre une
+		Utilisez votre langage de balisage préféré. Starlight vous offre une
 		validation du frontmatter intégrée avec la sûreté du typage TypeScript.
 	</Card>
 	<Card
-		title="Apportez vos propres composants d'interface utilisateur"
+		title="Utilisez vos propres composants d'interface utilisateur"
 		icon="puzzle"
 	>
 		Starlight est une solution de documentation complète et indépendante du framework utilisé. Étendez-la avec React, Vue, Svelte, Solid et plus encore.

--- a/docs/src/content/docs/fr/index.mdx
+++ b/docs/src/content/docs/fr/index.mdx
@@ -36,7 +36,7 @@ import Testimonial from '~/components/testimonial.astro';
 <CardGrid stagger>
 	<Card title="Une documentation qui enchante" icon="open-book">
 		Comprend : Navigation dans le site, recherche, internationalisation,
-		référencement naturel, typographie facile à lire, mise en évidence du code,
+		référencement naturel, typographie facile à lire, coloration syntaxique,
 		mode sombre, etc.
 	</Card>
 	<Card title="Propulsé par Astro" icon="rocket">

--- a/docs/src/content/docs/fr/index.mdx
+++ b/docs/src/content/docs/fr/index.mdx
@@ -9,7 +9,7 @@ editUrl: false
 lastUpdated: false
 banner:
   content: |
-    En cours de mise à jour vers Astro 5?
+    En cours de mise à jour vers Astro 5 ?
     <a href="https://github.com/withastro/starlight/releases/tag/%40astrojs/starlight%400.30.0">
       Apprenez à mettre à niveau
     </a>
@@ -43,16 +43,15 @@ import Testimonial from '~/components/testimonial.astro';
 		Exploitez toute la puissance et les performances d'Astro. Étendez Starlight
 		avec vos intégrations et bibliothèques Astro préférées.
 	</Card>
-	<Card title="Markdown, Markdoc, et MDX" icon="document">
+	<Card title="Markdown, Markdoc et MDX" icon="document">
 		Apportez votre langage de balisage préféré. Starlight vous offre une
-		validation frontmatter intégrée avec la sécurité de type TypeScript.
+		validation du frontmatter intégrée avec la sûreté du typage TypeScript.
 	</Card>
 	<Card
 		title="Apportez vos propres composants d'interface utilisateur"
 		icon="puzzle"
 	>
-		Starlight est une solution de documentation complète, indépendante du cadre
-		de travail. Étendez avec React, Vue, Svelte, Solid, et plus encore.
+		Starlight est une solution de documentation complète et indépendante du framework utilisé. Étendez-la avec React, Vue, Svelte, Solid et plus encore.
 	</Card>
 </CardGrid>
 
@@ -164,7 +163,7 @@ import Testimonial from '~/components/testimonial.astro';
 
 <AboutAstro title="Proposé par">
 	Astro est un framework web tout-en-un conçu pour la rapidité.
-	Tirez votre contenu de n'importe où et déployez-le partout, le tout alimenté par vos composants et bibliothèques d'interface utilisateur préférés.
+	Extrayez votre contenu de n'importe où et déployez-le partout, le tout alimenté par vos composants et bibliothèques d'interface utilisateur préférés.
 
 [Découvrez Astro](https://astro.build/)
 

--- a/docs/src/content/docs/fr/manual-setup.mdx
+++ b/docs/src/content/docs/fr/manual-setup.mdx
@@ -77,7 +77,7 @@ export const collections = {
 };
 ```
 
-Starlight supporte également [l'option `legacy.collections`](https://docs.astro.build/fr/reference/legacy-flags/) où les collections sont gérées en utilisant l'implémentation de collections de contenu héritée.
+Starlight est également compatible avec [l'option `legacy.collections`](https://docs.astro.build/fr/reference/legacy-flags/) où les collections sont gérées en utilisant l'implémentation de collections de contenu héritée.
 Celà est utile si vous avez un projet Astro existant et que vous ne pouvez pas apporter de modifications aux collections pour utiliser un chargeur.
 
 ### Ajouter du contenu
@@ -125,7 +125,7 @@ import { FileTree } from '@astrojs/starlight/components';
 
 </FileTree>
 
-À l'avenir, nous prévoyons de mieux supporter ce cas d'utilisation pour éviter le besoin du répertoire supplémentaire dans `src/content/docs/`.
+À l'avenir, nous prévoyons de mieux prendre en charge ce cas d'utilisation pour éviter le besoin du répertoire supplémentaire dans `src/content/docs/`.
 
 ### Utiliser Starlight avec SSR
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Updates the French translations of the top-level pages to:
* replace the translation of `analytics` (for the same reason explained in #3429, `analyses` by itself sounds wrong)
* add non breaking spaces in some places to avoid the colon to be on a new line alone
* translate `package`
* use French quotes
* add missing space before some punctuation
* slightly reword some sentences
* replace the translation for `type-safety` (`sûreté du typage` is what we used both on Astro Docs and on the other pages)
* replace `supporte` with `est compatible avec`/`prend en charge` because `supporte` is an anglicism

In `index.md`, I'm a bit torn regarding `Apportez votre...`, this sounds like a literal translation and I think in French we would rather use `Utilisez votre` but in doubt I left it untouched.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
