### PR TITLE
Run all tests on CI workflow changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     outputs:
       docs: ${{ steps.filter.outputs.docs }}
       packages: ${{ steps.filter.outputs.packages }}
+      ci: ${{ steps.filter.outputs.ci }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,13 @@ jobs:
               - 'docs/**'
             packages:
               - 'packages/**'
+            ci:
+              - '.github/workflows/ci.yml'
 
   unit-test:
     name: Run unit tests
     needs: changes
-    if: ${{ needs.changes.outputs.packages == 'true' }}
+    if: ${{ needs.changes.outputs.packages == 'true' || needs.changes.outputs.ci == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -57,7 +59,7 @@ jobs:
   e2e-test:
     name: 'Run E2E tests (${{ matrix.os }})'
     needs: changes
-    if: ${{ needs.changes.outputs.packages == 'true' }}
+    if: ${{ needs.changes.outputs.packages == 'true' || needs.changes.outputs.ci == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -149,7 +151,7 @@ jobs:
   links:
     name: Check for broken links
     needs: changes
-    if: ${{ needs.changes.outputs.docs == 'true' }}
+    if: ${{ needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
#### Description

I noticed a while ago in https://github.com/withastro/starlight/pull/3374 that if the `.github/workflows/ci.yml` is updated but nothing in the `packages/**` directories is, our unit tests and e2e tests do not run. In the case of the linked PR, this was not really a problem, altho, if we were to update an environment variable like `NODE_VERSION` in this file and nothing else, we want to make sure that all tests run.

This PR updates the [`dorny/paths-filter`](https://github.com/dorny/paths-filter) configuration to include a new `ci` filter matching this file used to trigger some jobs that were previously skipped when only this file was changed (I considered adding this file to the existing filters, which would have avoided the need to edit the `if` conditions, but I felt that it was cleaner to have a dedicated filter for this purpose).

Here are 2 runs for this PR only modifying the CI workflow file:

- [Before this changes is fully implemented, tests are skipped](https://github.com/withastro/starlight/actions/runs/17798652381?pr=3433)
- [After this change, all tests run as expected](https://github.com/withastro/starlight/actions/runs/17798763172?pr=3433)