### PR TITLE
Set packages author to "withastro"

### DIFF
--- a/packages/docsearch/package.json
+++ b/packages/docsearch/package.json
@@ -2,7 +2,7 @@
   "name": "@astrojs/starlight-docsearch",
   "version": "0.6.0",
   "description": "Algolia DocSearch plugin for the Starlight documentation theme for Astro",
-  "author": "Chris Swithinbank <swithinbank@gmail.com>",
+  "author": "withastro",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/markdoc/package.json
+++ b/packages/markdoc/package.json
@@ -2,7 +2,7 @@
   "name": "@astrojs/starlight-markdoc",
   "version": "0.5.0",
   "description": "Markdoc preset for the Starlight documentation theme for Astro",
-  "author": "Chris Swithinbank <swithinbank@gmail.com>",
+  "author": "withastro",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/starlight/package.json
+++ b/packages/starlight/package.json
@@ -15,7 +15,7 @@
     "withastro",
     "astro-integration"
   ],
-  "author": "Chris Swithinbank <swithinbank@gmail.com>",
+  "author": "withastro",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -2,7 +2,7 @@
   "name": "@astrojs/starlight-tailwind",
   "version": "4.0.1",
   "description": "Tailwind CSS plugin for the Starlight documentation theme for Astro",
-  "author": "Chris Swithinbank <swithinbank@gmail.com>",
+  "author": "withastro",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
#### Description

Recently I noticed that most packages in this mono-repo are authored under "Chris Swithinbank".
I know that he is the founder of Star(book)light, but at the same time I noticed that most other Astro repos either have no author or just `"withastro"`. So I adapted it here as well.

If I am not aware that this project is still authored by Chris legally, then I am sorry for creating this PR.
Just let me know if I should adapt or close this PR!
