### PR TITLE
feat: disable DarkReader

### DIFF
--- a/.changeset/sharp-melons-add.md
+++ b/.changeset/sharp-melons-add.md
@@ -1,0 +1,17 @@
+---
+'@astrojs/starlight': minor
+---
+
+Disables the [DarkReader](https://darkreader.org/) extension for Starlight sites by adding a new meta tag: `<meta name="darkreader-lock" />`.
+
+⚠️ **Potentially breaking change:** If you were relying on this behaviour or you want the DarkReader extension to modify Starlight's built in dark mode, you can [add this middleware](https://starlight.astro.build/guides/route-data/#how-to-customize-route-data) to remove the new meta tag:
+
+```ts
+import { defineRouteMiddleware } from "@astrojs/starlight/route-data";
+
+export const onRequest = defineRouteMiddleware((context) => {
+  const { head } = context.locals.starlightRoute;
+  const filteredHead = head.filter((entry) => !entry.attrs || entry.attrs["name"] !== "darkreader-lock");
+  context.locals.starlightRoute.head = filteredHead;
+});
+```

--- a/packages/starlight/utils/head.ts
+++ b/packages/starlight/utils/head.ts
@@ -60,6 +60,8 @@ export function getHead(
 			tag: 'meta',
 			attrs: { name: 'twitter:card', content: 'summary_large_image' },
 		},
+		// Disable DarkReader
+		{ tag: 'meta', attrs: { name: 'darkreader-lock' } },
 	];
 
 	if (description)


### PR DESCRIPTION
## Description

This PR adds a new meta tag to Starlight which prevents the extension [DarkReader](https://darkreader.org/) from manipulating the dark mode Starlight provides (https://northstarthemes.com/blog/web-dev/disable-darkreader-on-site/#how-to-disable-darkreader-on-your-website).

I set the changeset to make this a minor change, as it might be a breaking change for some websites - I think. Open for suggestions.

## Some thoughts about these changes:
- Could there ever be the possibility that Starlight wants to show the light mode, and the user wants the DarkReader to enforce the dark mode? (drafting for this reason)
- Should it even be Starlight's responsibility to add such a meta tag to the head as this would probably mean that many other edge-cases should/could be included. I am leaning towards not including such "interactions with other tools/extensions" in Starlight as this would make everything bloat.
- On the other hand: As a user of DarkReader, I find it pretty annoying to have to disable DarkReader for all Starlight pages, as the are in dark mode by default and the DarkReader version makes them pretty ugly.
- Maybe we could make DarkReader detect the dark mode with some other cleaner changes.

Maybe we should turn this into an issue or discussion, just wanted to start with actual changes, as they are pretty minimal and explain better what's going on.