### PR TITLE
i18n(ja): sync outdated icon reference

### DIFF
--- a/docs/src/content/docs/ja/reference/icons.mdx
+++ b/docs/src/content/docs/ja/reference/icons.mdx
@@ -9,6 +9,19 @@ Starlightには、`<Icon>`コンポーネントを使用してコンテンツに
 
 アイコンは[`<Icon>`](/ja/components/icons/)コンポーネントを使用して表示できます。また、[カード](/ja/components/cards/)や[ヒーローアクション](/ja/reference/frontmatter/#hero)の設定など、他のコンポーネントでもよく使用されます。
 
+## `StarlightIcon` 型
+
+TypeScriptの`StarlightIcon`型を使用して、[Starlightの組み込みアイコン](#すべてのアイコン)の名前を参照できます。
+
+```ts {2} /icon: (StarlightIcon)/
+// src/icon.ts
+import type { StarlightIcon } from '@astrojs/starlight/types';
+
+function getIconLabel(icon: StarlightIcon) {
+	// …
+}
+```
+
 ## すべてのアイコン
 
 利用可能なすべてのアイコンとその関連名が以下にリストされています。アイコンをクリックすると、その名前がクリップボードにコピーされます。


### PR DESCRIPTION
#### Description

sync outdated japanese icon reference page

related: https://github.com/withastro/starlight/pull/3465 (fixes broken links)
