### PR TITLE
Add `starlight-links` Visual Studio Code extension to showcase

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -247,4 +247,9 @@ These community tools and integrations can be used to add features to your Starl
 		title="astro-d2"
 		description="Transform D2 Markdown code blocks into diagrams."
 	/>
+	<LinkCard
+		href="https://github.com/HiDeoo/starlight-links"
+		title="starlight-links"
+		description="Visual Studio Code extension providing IntelliSense for Starlight Markdown and MDX content links."
+	/>
 </CardGrid>


### PR DESCRIPTION
#### Description

While initially only supporting basic Markdown links, I [just updated](https://github.com/HiDeoo/starlight-links/releases/tag/starlight-links%400.2.0) the `starlight-links` Visual Studio Code extension to provide IntelliSense for most type of links found in Starlight projects, even custom components, so this is probably a good time to add it to the list of community tools.