### PR TITLE
Disable Prettier on GitHub Actions workflow files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -25,3 +25,6 @@ packages/starlight/__e2e__/fixtures/basics/src/content/docs/anchor-heading-compo
 
 # Malformed YAML file used for testing
 packages/starlight/__tests__/i18n/malformed-yaml-src/content/i18n/*.yml
+
+# GitHub Actions workflow files
+.github/workflows/*.yml


### PR DESCRIPTION
This PR disables Prettier formatting on GitHub Actions workflow files by adding a rule to the `.prettierignore` file. This prevents our formatting workflow from failing when it encounters formatting changes in these files and trying to commit them (this requires extra permissions).

I tested locally by running `pnpm format`.