### PR TITLE
Fix file filters added in #3520

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
+        # When updating filters here, make sure to also add or remove them from the
+        # outputs block above.
         with:
           filters: |
             docs:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- I noticed I messed up the paths in the filters added in #3520 so this PR fixes them
- I’m also not 100% confident it is set up correctly yet. I noticed a11y checks were skipped in #3510 even though based on [the `changes` job output](https://github.com/withastro/starlight/actions/runs/19032980902/job/54350811263?pr=3510#step:3:42) it looks like it should have run.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
