### PR TITLE
feat: Export `SidebarEntry` types

### DIFF
--- a/packages/starlight/types.ts
+++ b/packages/starlight/types.ts
@@ -1,3 +1,4 @@
+export type { SidebarEntry, SidebarGroup, SidebarLink } from './utils/routing/types';
 export type { StarlightConfig } from './utils/user-config';
 export type {
 	StarlightPlugin,


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Export `SidebarEntry` and subtypes to allow easier overrides.

#### Notes

Currently, we can access those types like this:

```ts
import DefaultSidebarSublist from "@astrojs/starlight/components/SidebarSublist.astro";

type Props = Parameters<typeof DefaultSidebarSublist>[0];
type SidebarEntry = Props["sublist"][number];
type SidebarLink = Extract<SidebarEntry, { type: "link" }>;
```

after this being merge, this will be:

```ts
import type { SidebarEntry, SidebarLink } from "@astrojs/starlight/types"
``` 