### PR TITLE
feat: add isIndex fields

### DIFF
--- a/.changeset/three-otters-rhyme.md
+++ b/.changeset/three-otters-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': minor
+---
+
+Add a isIndex field to show that this is the index

--- a/packages/starlight/schema.ts
+++ b/packages/starlight/schema.ts
@@ -22,6 +22,11 @@ const StarlightFrontmatterSchema = (context: SchemaContext) =>
 		description: z.string().optional(),
 
 		/**
+		 * Is this page the index of the folder
+		 */
+		isIndex: z.boolean().optional(),
+
+		/**
 		 * Custom URL where a reader can edit this page.
 		 * Overrides the `editLink.baseUrl` global config if set.
 		 *

--- a/packages/starlight/utils/navigation.ts
+++ b/packages/starlight/utils/navigation.ts
@@ -172,7 +172,7 @@ function linkFromInternalSidebarLinkItem(
 	const badge = item.badge ?? frontmatter.sidebar?.badge;
 	const attrs = { ...frontmatter.sidebar?.attrs, ...item.attrs };
 	return makeSidebarLink(
-		slugToPathname(route.slug),
+		slugToPathname(route.id, frontmatter.isIndex),
 		label,
 		getSidebarBadge(badge, locale, label),
 		attrs
@@ -275,11 +275,12 @@ function treeify(routes: Route[], locale: string | undefined, baseDir: string): 
 
 /** Create a link entry for a given content collection entry. */
 function linkFromRoute(route: Route, attrs?: LinkHTMLAttributes): SidebarLink {
+	const { sidebar, title, isIndex } = route.entry.data;
 	return makeSidebarLink(
-		slugToPathname(route.slug),
-		route.entry.data.sidebar.label || route.entry.data.title,
-		route.entry.data.sidebar.badge,
-		{ ...attrs, ...route.entry.data.sidebar.attrs }
+		slugToPathname(route.id, isIndex),
+		sidebar.label || title,
+		sidebar.badge,
+		{ ...attrs, ...sidebar.attrs }
 	);
 }
 

--- a/packages/starlight/utils/routing/index.ts
+++ b/packages/starlight/utils/routing/index.ts
@@ -93,7 +93,7 @@ export const routes = getRoutes();
 function getParamRouteMapping(): ReadonlyMap<string | undefined, Route> {
 	const map = new Map<string | undefined, Route>();
 	for (const route of routes) {
-		map.set(slugToParam(route.slug), route);
+		map.set(slugToParam(route.id, route.entry.data.isIndex), route);
 	}
 	return map;
 }
@@ -105,7 +105,7 @@ export function getRouteBySlugParam(slugParam: string | undefined): Route | unde
 
 function getPaths(): Path[] {
 	return routes.map((route) => ({
-		params: { slug: slugToParam(route.slug) },
+		params: { slug: slugToParam(route.id, route.entry.data.isIndex) },
 		props: route,
 	}));
 }

--- a/packages/starlight/utils/slugs.ts
+++ b/packages/starlight/utils/slugs.ts
@@ -47,14 +47,14 @@ function localeToDir(locale: string | undefined): 'ltr' | 'rtl' {
  * @param slug Content collection slug
  * @returns Param compatible with Astro’s router
  */
-export function slugToParam(slug: string): string | undefined {
-	return slug === 'index' || slug === '' || slug === '/'
+export function slugToParam(slug: string, isIndex: boolean): string | undefined {
+	return isIndex || slug === 'index' || slug === '' || slug === '/'
 		? undefined
 		: (slug.endsWith('/index') ? slug.slice(0, -6) : slug).normalize();
 }
 
-export function slugToPathname(slug: string): string {
-	const param = slugToParam(slug);
+export function slugToPathname(slug: string, isIndex?: boolean): string {
+	const param = slugToParam(slug, isIndex ?? false);
 	return param ? '/' + param + '/' : '/';
 }
 


### PR DESCRIPTION
This PR should allow the user to add a frontmatter filed `isIndex`.

Like this a filename test.md can be the index of the folder "test"
The URL will be example.com/guides/test

instead of
example.com/guides/test/test