### PR TITLE
docs: directly link to Starlight sites in showcase instead of landing pages

### DIFF
--- a/docs/src/components/showcase-sites.astro
+++ b/docs/src/components/showcase-sites.astro
@@ -9,7 +9,7 @@ import FluidGrid from './fluid-grid.astro';
 	<Card title="capo.js" href="https://rviscomi.github.io/capo.js/" thumbnail="capo.js.png" />
 	<Card
 		title="Web Monetization API"
-		href="https://webmonetization.org/"
+		href="https://webmonetization.org/docs/"
 		thumbnail="webmonetization.org.png"
 	/>
 	<Card
@@ -31,7 +31,11 @@ import FluidGrid from './fluid-grid.astro';
 		href="https://starter.obytes.com"
 		thumbnail="starter.obytes.com.jpg"
 	/>
-	<Card title="Kanri" href="https://kanriapp.com" thumbnail="kanriapp.com.png" />
+	<Card
+		title="Kanri"
+		href="https://www.kanriapp.com/getting-started/what-is-kanri/"
+		thumbnail="kanriapp.com.png"
+	/>
 	<Card title="Refact" href="https://docs.refact.ai/" thumbnail="refact.ai.png" />
 	<Card
 		title="Some drops of PHP Book"
@@ -44,7 +48,11 @@ import FluidGrid from './fluid-grid.astro';
 		href="https://ai-prompt-snippets.vercel.app/"
 		thumbnail="ai-prompt-snippets.png"
 	/>
-	<Card title="Folks Router" href="https://folksrouter.io/" thumbnail="folksrouter.io.png" />
+	<Card
+		title="Folks Router"
+		href="https://folksrouter.io/docs/introduction"
+		thumbnail="folksrouter.io.png"
+	/>
 	<Card
 		title="React Awesome Reveal"
 		href="https://react-awesome-reveal.morello.dev/"
@@ -69,7 +77,7 @@ import FluidGrid from './fluid-grid.astro';
 		thumbnail="docs.ghostfam.com.png"
 	/>
 	<Card title="Mr. Robøt" href="https://docs.mrrobot.app" thumbnail="docs.mrrobot.app.png" />
-	<Card title="Open SaaS Docs" href="https://opensaas.sh" thumbnail="opensaas.sh.png" />
+	<Card title="Open SaaS Docs" href="https://docs.opensaas.sh/" thumbnail="opensaas.sh.png" />
 	<Card
 		title="Astro Snipcart"
 		href="https://astro-snipcart.vercel.app/"
@@ -127,7 +135,7 @@ import FluidGrid from './fluid-grid.astro';
 		thumbnail="styledictionary.com.png"
 	/>
 	<Card title="CodeSweetly" href="https://codesweetly.com/" thumbnail="codesweetly.com.png" />
-	<Card title="grpcmd" href="https://grpc.md/" thumbnail="grpc.md.png" />
+	<Card title="grpcmd" href="https://grpc.md/docs/" thumbnail="grpc.md.png" />
 	<Card
 		title="Pokemon Database"
 		href="https://pokemon-siace.netlify.app/"
@@ -203,7 +211,7 @@ import FluidGrid from './fluid-grid.astro';
 		href="https://openai.github.io/openai-agents-js/"
 		thumbnail="openai.github.io.png"
 	/>
-	<Card title="opencode" href="https://opencode.ai/" thumbnail="opencode.ai.png" />
+	<Card title="opencode" href="https://opencode.ai/docs" thumbnail="opencode.ai.png" />
 	<Card title="Scalekit Docs" href="https://docs.scalekit.com/" thumbnail="docs.scalekit.com.png" />
 	<Card title="Aptos Docs" href="https://aptos.dev" thumbnail="aptos.dev.png" />
 	<Card title="OmniPrint Docs" href="https://omni-byte.com/docs/" thumbnail="omni-byte.com.png" />


### PR DESCRIPTION


<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

This is a follow-up PR of #3563 where I asked whether to consistently link to the documentation of showcase entries or their landing pages. As Chris answered, it is desired to link to the documentation as the showcase is intended to show of what people can do with Starlight 🙌 

Therefore, I replaced these links (landing pages) with the links (docs):

```
• Web Monetization API: https://webmonetization.org/ -> https://webmonetization.org/docs/
• Kanri: https://kanriapp.com/ -> https://www.kanriapp.com/getting-started/what-is-kanri/
• Folks Router: https://folksrouter.io/ -> https://folksrouter.io/docs/introduction
• Open SaaS Docs: https://opensaas.sh/ -> https://docs.opensaas.sh/
• grpcmd: https://grpc.md/ -> https://grpc.md/docs/
• opencode: https://opencode.ai/ -> https://opencode.ai/docs
```

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
