### PR TITLE
docs: remove duplicated plugin/component

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -99,11 +99,6 @@ Extend your site with official plugins supported by the Starlight team and commu
 		description="Add a nice credit to Starlight or Astro at the bottom of the table of contents."
 	/>
 	<LinkCard
-		href="https://github.com/trueberryless-org/starlight-contributor-list"
-		title="starlight-contributor-list"
-		description="Display a list of all contributors to your project."
-	/>
-	<LinkCard
 		href="https://github.com/dragomano/starlight-giscus"
 		title="starlight-giscus"
 		description="Add Giscus comments to your docs site."


### PR DESCRIPTION
#### Description

This PR removes a duplicated plugin/component entry in the documentation introduced in #3546.