### PR TITLE
Fix preview releases

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
+          # While releasing with changesets works with a shallow clone, this is not the case of
+          # running `changeset status` which does not extend a shallow clone.
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Setup PNPM


### PR DESCRIPTION
#### Description

This PR fixes our [currently broken](https://github.com/withastro/starlight/actions/runs/20076697024/job/57592861853?pr=3534) preview release workflow by ensuring a full Git history is fetched during the checkout step.

While shallow clones are [extended during the release process](https://github.com/changesets/changesets/blob/3cb9982b96aef8e2b46860258d56dbd7a2a02953/packages/git/src/index.ts#L58-L64), this code path seems to not be hit when running `changeset status`. Here is a side-by-side comparison of running that command in a full clone vs a shallow clone:

<img width="1583" height="1015" alt="image" src="https://github.com/user-attachments/assets/5bf39100-89f6-4850-8e88-2f039714a413" />
