### PR TITLE
Two more Aside variants

### DIFF
--- a/packages/starlight/schemas/i18n.ts
+++ b/packages/starlight/schemas/i18n.ts
@@ -148,6 +148,8 @@ function starlightI18nSchema() {
 			'aside.note': z.string().describe('Text shown on the note aside variant'),
 			'aside.caution': z.string().describe('Text shown on the warning aside variant'),
 			'aside.danger': z.string().describe('Text shown on the danger aside variant'),
+			'aside.success': z.string().describe('Text shown on the success aside variant'),
+			'aside.minimal': z.string().describe('Text shown on the minimal aside variant'),
 
 			'fileTree.directory': z
 				.string()

--- a/packages/starlight/style/asides.css
+++ b/packages/starlight/style/asides.css
@@ -24,6 +24,16 @@
 		--sl-color-asides-border: var(--sl-color-red);
 		background-color: var(--sl-color-red-low);
 	}
+	.starlight-aside--success {
+		--sl-color-asides-text-accent: var(--sl-color-green-high);
+		--sl-color-asides-border: var(--sl-green-red);
+		background-color: var(--sl-color-green-low);
+	}
+	.starlight-aside--minimal {
+		--sl-color-asides-text-accent: var(--sl-color-gray-1);
+		--sl-color-asides-border: var(--sl-color-gray-3);
+		background-color: var(--sl-color-gray-6);
+	}
 
 	.starlight-aside__title {
 		display: flex;

--- a/packages/starlight/translations/en.json
+++ b/packages/starlight/translations/en.json
@@ -24,6 +24,8 @@
   "aside.tip": "Tip",
   "aside.caution": "Caution",
   "aside.danger": "Danger",
+  "aside.success": "Success",
+  "aside.minimal": "Aside",
   "fileTree.directory": "Directory",
   "builtWithStarlight.label": "Built with Starlight",
   "heading.anchorLabel": "Section titled “{{title}}”"

--- a/packages/starlight/user-components/Aside.astro
+++ b/packages/starlight/user-components/Aside.astro
@@ -4,8 +4,15 @@ import Icon from './Icon.astro';
 import { Icons, type StarlightIcon } from '../components/Icons';
 import { throwInvalidAsideIconError } from '../integrations/asides-error';
 
-const asideVariants = ['note', 'tip', 'caution', 'danger'] as const;
-const icons = { note: 'information', tip: 'rocket', caution: 'warning', danger: 'error' } as const;
+const asideVariants = ['note', 'tip', 'caution', 'danger', 'success', 'minimal'] as const;
+const icons = {
+	note: 'information',
+	tip: 'rocket',
+	caution: 'warning',
+	danger: 'error',
+	success: 'approve-check-circle',
+	minimal: 'right-caret',
+} as const;
 
 interface Props {
 	type?: (typeof asideVariants)[number];


### PR DESCRIPTION
#### Description

Added two more variants for Aside component: `success` & `minimal`

<img width="718" height="151" alt="image" src="https://github.com/user-attachments/assets/2dc3b9e9-2655-4b59-a6fd-27eeb17a596f" />

<img width="718" height="166" alt="image" src="https://github.com/user-attachments/assets/f4381b6c-252b-4230-8c4d-c2a11e602d5a" />

Inspired from https://github.com/HiDeoo/starlight-videos/blob/main/packages/starlight-videos/components/Box.astro