### PR TITLE
a11y(toc): Change `aria-current` value from `true` to `location`

### DIFF
--- a/packages/starlight/components/TableOfContents/starlight-toc.ts
+++ b/packages/starlight/components/TableOfContents/starlight-toc.ts
@@ -16,7 +16,7 @@ export class StarlightTOC extends HTMLElement {
 	protected set current(link: HTMLAnchorElement) {
 		if (link === this._current) return;
 		if (this._current) this._current.removeAttribute('aria-current');
-		link.setAttribute('aria-current', 'true');
+		link.setAttribute('aria-current', 'location');
 		this._current = link;
 	}
 


### PR DESCRIPTION
#### Description

This is more precise in ARIA. While `true` works, `location` is more precise and semantic, just like using `<nav>` instead of a generic `<div>` where appropriate.

#### To‐do

- [ ] Add changeset