### PR TITLE
i18n(de): Fix typos in getting-started.mdx

### DIFF
--- a/docs/src/content/docs/de/getting-started.mdx
+++ b/docs/src/content/docs/de/getting-started.mdx
@@ -1,13 +1,13 @@
 ---
 title: Erste Schritte
-description: Lerne wie du deine nächste Dokumentations&shy;website mit Starlight und Astro erstellst.
+description: Lerne, wie du deine nächste Dokumentations&shy;website mit Starlight und Astro erstellst.
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 Starlight ist ein voll funktionsfähiges Dokumentations&shy;framework, welches auf [Astro](https://astro.build) aufbaut.
 Diese Anleitung wird dir helfen, mit einem neuen Projekt zu beginnen.
-Siehe dir die [manuellen Einrichtungs&shy;anweisungen](/de/manual-setup/) an, um Starlight zu einem bestehenden Astro-Projekt hinzuzufügen.
+Sieh dir die [manuellen Einrichtungs&shy;anweisungen](/de/manual-setup/) an, um Starlight zu einem bestehenden Astro-Projekt hinzuzufügen.
 
 ## Schnellstart
 


### PR DESCRIPTION
#### Description

This PR fixes some typos in the Getting started page.

Siehe dir is an “extended” imperative form with reflexive pronoun, but it sounds weird and “old-fashioned”. So I removed the redundant and unidiomatic -e ending.

A missing comma for a subordinate clause (wie: how) has also been added, because in German, all subordinate clauses (or at least most) require a comma preceding it, if the structure is:

main clause – subordinate clause