### PR TITLE
Allow toggling mdx optimize mode on & off

### DIFF
--- a/packages/starlight/__tests__/basics/user-config.test.ts
+++ b/packages/starlight/__tests__/basics/user-config.test.ts
@@ -12,3 +12,20 @@ test('preserve social config order', () => {
 	});
 	expect((config.social || []).map(({ icon }) => icon)).toEqual(['twitch', 'github', 'discord']);
 });
+
+test('markdown.optimize defaults to true', () => {
+	const config = StarlightConfigSchema.parse({
+		title: 'Test',
+	});
+	expect(config.markdown.optimize).toBe(true);
+});
+
+test('mdxStrictMode can be set to false', () => {
+	const config = StarlightConfigSchema.parse({
+		title: 'Test',
+		markdown: {
+			optimize: false,
+		},
+	});
+	expect(config.markdown.optimize).toBe(false);
+});

--- a/packages/starlight/index.ts
+++ b/packages/starlight/index.ts
@@ -102,7 +102,7 @@ export default function StarlightIntegration(
 					integrations.push(starlightSitemap(starlightConfig));
 				}
 				if (!allIntegrations.find(({ name }) => name === '@astrojs/mdx')) {
-					integrations.push(mdx({ optimize: true }));
+					integrations.push(mdx({ optimize: starlightConfig.markdown.optimize }));
 				}
 
 				// Add Starlight directives restoration integration at the end of the list so that remark

--- a/packages/starlight/utils/user-config.ts
+++ b/packages/starlight/utils/user-config.ts
@@ -285,6 +285,15 @@ const UserConfigSchema = z.object({
 				.describe(
 					'Define additional directories where files should be processed by Starlight’s Markdown pipeline. Default: `[]`.'
 				),
+			/**
+			 * Define whether to optimize the MDX output for faster builds and rendering. Default: `true`.
+			 *
+			 * See https://docs.astro.build/en/guides/integrations-guide/mdx/#optimize
+			 */
+			optimize: z
+				.boolean()
+				.default(true)
+				.describe('Define whether to optimize the MDX output for faster builds and rendering. Default: `true`.'),
 		})
 		.default({})
 		.describe('Configure features that impact Starlight’s Markdown processing.'),


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

<!-- New features should first be discussed and approved by maintainers in GitHub or Discord discussions. -->
<!-- If this PR adds a new public-facing feature, uncomment the line below and include a link to the relevant discussion. -->
<!-- - [x] This PR adds a new feature which has been discussed and approved [here](link to GitHub or Discord discussion). -->

Astro has a bug where if mdx optimize=true then it sometimes ignores the customizing/overriding of mdx components via `export const components = `.  To unblock starlight users and allow overriding of mdx components, add an explicit option on the starlight.markdown config that can turn the mdx optimize off.

Astro bug: https://github.com/withastro/astro/issues/14611

The workaround when directly working with Astro is:

```
mdx({
	optimize: true,
}),
```

However, doing this in Starlight requires additional workaround as then you also need to replicate the `starlightExpressiveCode` behavior which must come *before* mdx.  The most straightforward solution is to expose an option so that users can explicitly control `optimize` being true or false, which is what I do in here.

**Note**: I didn't start a discussion first, as this seemed to fall under the ["Make a pull request (PR) to address an open issue or to fix obvious problems" part of the contribution guidelines](https://github.com/withastro/starlight/blob/main/CONTRIBUTING.md) but can start a discussion instead.