### PR TITLE
docs: add rehype-gfm-components plugin

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -287,4 +287,9 @@ These community tools and integrations can be used to add features to your Starl
 		title="starlight-contributor-list"
 		description="Display a list of all contributors to your project."
 	/>
+	<LinkCard
+	  href="https://claylo.github.io/rehype-gfm-components"
+	  title="rehype-gfm-components"
+	  description="Transform GFM Markdown into rich Starlight components. No MDX, no imports — the same file works on GitHub and in Starlight."
+	/>
 </CardGrid>


### PR DESCRIPTION
Write GFM, view it on GitHub, deploy it with Starlight. The same Markdown file for both -- all content easily viewable on GitHub, still transforms to rich and interactive components on your Starlight site. No MDX, no imports.

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Just a plugin for those who want to use Starlight ... and also want their docs to be fully readable on GitHub. (It can't be _just me_, right?)

Thank you for all your efforts on Starlight! I'm loving it.
