### PR TITLE
FileTree: document escaping special characters in filenames

### DIFF
--- a/docs/src/content/docs/components/file-tree.mdx
+++ b/docs/src/content/docs/components/file-tree.mdx
@@ -224,7 +224,7 @@ Escape special characters such as underscores or spaces in filenames by wrapping
 
 <Preview>
 
-```mdx {8}
+```mdx
 import { FileTree } from '@astrojs/starlight/components';
 
 <FileTree>
@@ -238,7 +238,7 @@ import { FileTree } from '@astrojs/starlight/components';
 
 <Fragment slot="markdoc">
 
-```markdoc {5}
+```markdoc
 {% filetree %}
 - `__init__.py`
 - `Hello world.txt`


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Follow up to #3713 
- Documents the use of code backticks to escape filenames like `__init__.py` that otherwise break because the `_` is interpreted as Markdown syntax

Docs preview: https://deploy-preview-3714--astro-starlight.netlify.app/components/file-tree/#escape-special-characters

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
