### PR TITLE
docs: add starlight-copy-button to plugins showcase

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -201,7 +201,7 @@ Extend your site with official plugins supported by the Starlight team and commu
 	<LinkCard
 		href="https://github.com/dionysuzx/starlight-copy-button"
 		title="starlight-copy-button"
-		description="Copy full docs page markdown with a polished button in the page title."
+		description="Copy full docs page Markdown with a polished button in the page title."
 	/>
 </CardGrid>
 


### PR DESCRIPTION
## Summary
Add  to the community plugins list in the Starlight docs.

## Changes
- Add a new  entry in  pointing to:
  - https://github.com/dionysuzx/starlight-copy-button
