### PR TITLE
refactor(ci): use original first interaction action again

### DIFF
--- a/.github/workflows/welcome-bot.yml
+++ b/.github/workflows/welcome-bot.yml
@@ -13,11 +13,10 @@ jobs:
     name: Welcome First-Time Contributors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: zephyrproject-rtos/action-first-interaction@58853996b1ac504b8e0f6964301f369d2bb22e5c
+      - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3.1.0
         with:
           repo-token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
-          pr-opened-message: |
+          pr-message: |
             Hello! Thank you for opening your **first PR** to Starlight! ✨
 
             Here’s what will happen next:


### PR DESCRIPTION
#### Description

In https://github.com/withastro/starlight/pull/1139 we decided to use a fork of [`actions/first-interaction`](https://github.com/actions/first-interaction) because the Node version was outdated and the fork has more robust features in general (read the detailed benefits in HiDeoo's list in the PR).

Since then, the original action has been updated quite well, and seems to be maintained actively again, whereas now the fork has not been updated for about a year. I have not done a comparison performance- or feature-wise in depth. But I recommend using the original and actively maintained action.

Therefore, I reverted the commit and also removed the checkout step, as it is actually not necessary.