### PR TITLE
fix: use interaction fork action again

### DIFF
--- a/.github/workflows/welcome-bot.yml
+++ b/.github/workflows/welcome-bot.yml
@@ -13,7 +13,6 @@ jobs:
     name: Welcome First-Time Contributors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: zephyrproject-rtos/action-first-interaction@58853996b1ac504b8e0f6964301f369d2bb22e5c
         with:
           repo-token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
#### Description

This PR reverts the revert of the usage of [the fork interaction action](https://github.com/zephyrproject-rtos/action-first-interaction), as [HiDeoo originally implemented it](https://github.com/withastro/starlight/pull/1139). As it turns out, the official action still has quite some weird bugs (which might [get fixed](https://github.com/actions/first-interaction/pull/404)), but I'd say: never change a running system.

#### Related

- https://github.com/withastro/starlight/pull/1139
- https://github.com/withastro/starlight/pull/3769
- https://github.com/withastro/starlight/pull/3774