### PR TITLE
docs(i18n): add missing Extend step in zh-CN getting-started guide

### DIFF
--- a/docs/src/content/docs/zh-cn/getting-started.mdx
+++ b/docs/src/content/docs/zh-cn/getting-started.mdx
@@ -92,6 +92,7 @@ Starlight 已经准备好让你添加新内容或导入你现有的文件！
 - **配置：** 在[自定义 Starlight](/zh-cn/guides/customization/)中了解常见选项。
 - **导航：** 使用[侧边栏导航](/zh-cn/guides/sidebar/)指南设置你的侧边栏。
 - **组件：** 在[组件](/zh-cn/components/using-components/)指南中发现内置的卡片、标签页等更多内容。
+- **扩展：** 在我们的[「插件」](/zh-cn/resources/plugins/)和[「主题」](/zh-cn/resources/themes/)目录中探索社区插件。
 - **部署：** 使用 Astro 文档中的[部署你的 Astro 站点](https://docs.astro.build/zh-cn/guides/deploy/)指南发布你的站点。
 
 ## 更新 Starlight


### PR DESCRIPTION
Hi Starlight team! 👋

I was reading through the Chinese translation of the getting started guide and noticed that the **Extend** step was missing from the "Next steps" section.

**What this PR does:**
- Adds the missing "**扩展：**" (Extend) step to the zh-CN getting-started guide
- Includes links to the plugins and themes resources pages

**Before:**
The Chinese guide went directly from "组件" (Components) to "部署" (Deploy), skipping the "Extend" section that exists in the English version.

**After:**
Now matches the English version with all 5 steps:
1. 配置 (Configure)
2. 导航 (Navigate)
3. 组件 (Components)
4. **扩展 (Extend)** ← New!
5. 部署 (Deploy)

Hope this helps keep the Chinese docs in sync! Let me know if you'd like any changes 😊

Thanks for the amazing work on Starlight! 🌟