### PR TITLE
Reserve space for scrollbars in sidebar to avoid layout shift

### DIFF
--- a/.changeset/grumpy-brooms-study.md
+++ b/.changeset/grumpy-brooms-study.md
@@ -1,0 +1,15 @@
+---
+'@astrojs/starlight': minor
+---
+
+Avoids the risk of layout shift when users expand and collapse sidebar groups
+
+This release can introduce additional padding to the site sidebar on certain devices to reserve space for scrollbars. You may wish to inspect your site sidebar visually when upgrading.
+
+If you would prefer to keep the previous styling, you can add the following custom CSS to your site:
+
+```css
+.sidebar-pane {
+  scrollbar-gutter: auto;
+}
+```

--- a/packages/starlight/components/PageFrame.astro
+++ b/packages/starlight/components/PageFrame.astro
@@ -56,6 +56,7 @@ const { hasSidebar } = Astro.locals.starlightRoute;
 			width: 100%;
 			background-color: var(--sl-color-black);
 			overflow-y: auto;
+			scrollbar-gutter: stable;
 		}
 
 		:global([aria-expanded='true']) ~ .sidebar-pane {


### PR DESCRIPTION
#### Description

- Closes #3744
- This PR adds `scrollbar-gutter: stable` to our sidebar to ensure space is reserved for a scrollbar and avoid layout shift when sidebar groups are expanded, overflowing the viewport

User agents vary in how they render scrollbars. Some, like macOS with a trackpad, are designed to appear and disappear and overlay on top of the UI. For these devices, this PR doesn’t change anything:

| Before | After |
|---|---|
| <img width="385" height="293" alt="sidebar with even padding either side of its contents" src="https://github.com/user-attachments/assets/244cccef-a61d-4e73-9d82-cadcc862fbac" /> | <img width="385" height="293" alt="an identical image to before" src="https://github.com/user-attachments/assets/244cccef-a61d-4e73-9d82-cadcc862fbac" /> |

However, in other circumstances, scrollbars require a gutter which is deducted from an element’s width (with padding etc. applied from the gutter’s edge). In these cases, the change in this PR reserves that gutter space even for sidebars that do not overflow the viewport:

| Before | After |
|---|---|
| <img width="864" height="554" alt="sidebar with even padding, as shown above" src="https://github.com/user-attachments/assets/561dfb00-b765-4358-8e71-3e36a69a685c" /> | <img width="864" height="554" alt="sidebar with more padding on the right than on the left to save space for the scrollbar" src="https://github.com/user-attachments/assets/e2e07fec-3b23-491a-aed7-2490f2899723" /> |

Note the additional whitespace between the group carets and the sidebar border in the “after” screenshot.

This isn’t an _amazing_ change to have to make: for sites whose scrollbar never overflows, user agents that need it will still reserve that extra space, unbalancing the layout pointlessly. Having the even padding on both sides of the scrollbar would be visually more pleasing, I think.

There is also the `scrollbar-gutter: stable both-edges` variant, which while balancing spacing either side of the scrollbar content, would introduce a lot of extra whitespace on the outer edge. You would think you might be able to adjust for that with padding but a) we don’t know when a gutter is reserved and when not and b) we don’t know the gutter width to know how much to reduce padding by.

So it’s a choice between prettier layout and avoiding layout shift when users interact. On balance, it’s probably worth avoiding layout shift and there are design solutions we could explore to lessen the visual impact (such as removing the border for example).