### PR TITLE
feat(social): add optional target attribute for social links

### DIFF
--- a/.changeset/social-link-target.md
+++ b/.changeset/social-link-target.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": minor
+---
+
+Adds an optional `target` attribute for social links (for example `_blank`), which is passed through to the rendered anchor in the social icons component.

--- a/packages/starlight/__tests__/basics/user-config.test.ts
+++ b/packages/starlight/__tests__/basics/user-config.test.ts
@@ -1,6 +1,19 @@
 import { expect, test } from 'vitest';
 import { StarlightConfigSchema } from '../../utils/user-config';
 
+test('preserve social link target attribute', () => {
+	const config = StarlightConfigSchema.parse({
+		title: 'Test',
+		social: [
+			{ icon: 'github', label: 'GitHub', href: 'https://github.com/withastro/starlight', target: '_blank' },
+			{ icon: 'discord', label: 'Discord', href: 'https://astro.build/chat' },
+		],
+	});
+	const social = config.social || [];
+	expect(social[0]?.target).toBe('_blank');
+	expect(social[1]?.target).toBeUndefined();
+});
+
 test('preserve social config order', () => {
 	const config = StarlightConfigSchema.parse({
 		title: 'Test',

--- a/packages/starlight/components/SocialIcons.astro
+++ b/packages/starlight/components/SocialIcons.astro
@@ -8,8 +8,8 @@ const links = config.social || [];
 {
 	links.length > 0 && (
 		<>
-			{links.map(({ label, href, icon }) => (
-				<a {href} rel="me" class="sl-flex">
+			{links.map(({ label, href, icon, target }) => (
+				<a {href} {target} rel="me" class="sl-flex">
 					<span class="sr-only">{label}</span>
 					<Icon name={icon} />
 				</a>

--- a/packages/starlight/schemas/social.ts
+++ b/packages/starlight/schemas/social.ts
@@ -2,7 +2,7 @@ import { z } from 'astro/zod';
 import { IconSchema } from './icon';
 
 const LinksSchema = z
-	.object({ icon: IconSchema(), label: z.string().min(1), href: z.string() })
+	.object({ icon: IconSchema(), label: z.string().min(1), href: z.string(), target: z.string().optional() })
 	.array()
 	.optional();
 


### PR DESCRIPTION
Expose optional target on social link config, render it on anchor tags,
and cover parsing with a user-config test.

#### Description

<!-- - [x] This PR adds a new feature which has been discussed and approved [here](link to GitHub or Discord discussion). -->

- Closes #3820
- What does this PR change? Change config to support `target`
- Did you change something visual? Nope.
