### PR TITLE
fix: empty aside alignment

### DIFF
--- a/.changeset/cold-maps-behave.md
+++ b/.changeset/cold-maps-behave.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fixes aside styling when used without any content

--- a/packages/starlight/style/asides.css
+++ b/packages/starlight/style/asides.css
@@ -45,6 +45,10 @@
 		margin-top: 0.5rem;
 	}
 
+	.starlight-aside__content:empty {
+		display: none;
+	}
+
 	.starlight-aside__content a {
 		color: var(--sl-color-asides-text-accent);
 	}

--- a/packages/starlight/user-components/Aside.astro
+++ b/packages/starlight/user-components/Aside.astro
@@ -34,7 +34,9 @@ if (!title) {
 	<p class="starlight-aside__title" aria-hidden="true">
 		<Icon name={icon || icons[type]} class="starlight-aside__icon" />{title}
 	</p>
-	<div class="starlight-aside__content">
-		<slot />
-	</div>
+	{/* 
+		The slot is intentionally not wrapped in newlines/whitespace to ensure CSS `:empty` 
+		can match when no content is provided. 
+	*/}
+	<div class="starlight-aside__content"><slot /></div>
 </aside>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

<!-- New features should first be discussed and approved by maintainers in GitHub or Discord discussions. -->
<!-- If this PR adds a new public-facing feature, uncomment the line below and include a link to the relevant discussion. -->
<!-- - [x] This PR adds a new feature which has been discussed and approved [here](link to GitHub or Discord discussion). -->

Hello,
this PR make it so Asides with empty content have the right alignment.

**Before**

<img width="772" height="203" alt="image" src="https://github.com/user-attachments/assets/4ecbcf14-51ec-4283-ad40-97486b14b5b9" />

**After**

<img width="773" height="209" alt="image" src="https://github.com/user-attachments/assets/2d6e4726-9fd5-460a-a2d2-63c4c40c12f4" />

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
