### PR TITLE
chore(docs): add Vocs to env comparison stats

### DIFF
--- a/docs/src/content/docs/environmental-impact.md
+++ b/docs/src/content/docs/environmental-impact.md
@@ -97,15 +97,16 @@ These tests with the [Website Carbon Calculator][wcc] compare similar pages buil
 | [docsify][dy-carbon]        | 0.04g              |   A    |
 | [Sphinx][sx-carbon]         | 0.04g              |   A    |
 | [mdBook][md-carbon]         | 0.05g              |   A    |
+| [Vocs][vs-carbon]           | 0.05g              |   A    |
 | [MkDocs][mk-carbon]         | 0.08g              |   A    |
-| [Fumadocs][fs-carbon]       | 0.08g              |   B    |
+| [Fumadocs][fs-carbon]       | 0.09g              |   B    |
 | [Docusaurus][ds-carbon]     | 0.09g              |   B    |
 | [Nextra][nx-carbon]         | 0.10g              |   B    |
 | [Docus][dc-carbon]          | 0.11g              |   B    |
-| [GitBook][gb-carbon]        | 0.28g              |   E    |
-| [Mintlify][mt-carbon]       | 0.64g              |   F    |
+| [GitBook][gb-carbon]        | 0.44g              |   F    |
+| [Mintlify][mt-carbon]       | 0.73g              |   F    |
 
-<small>Data collected on 8 April 2026. Click a link to see up-to-date figures.</small>
+<small>Data collected on 21 April 2026. Click a link to see up-to-date figures.</small>
 
 [sl-carbon]: https://www.websitecarbon.com/website/starlight-astro-build-getting-started/
 [vp-carbon]: https://www.websitecarbon.com/website/vitepress-dev-guide-what-is-vitepress/
@@ -113,6 +114,7 @@ These tests with the [Website Carbon Calculator][wcc] compare similar pages buil
 [sx-carbon]: https://www.websitecarbon.com/website/sphinx-doc-org-en-master-usage-quickstart-html/
 [mk-carbon]: https://www.websitecarbon.com/website/mkdocs-org-getting-started/
 [md-carbon]: https://www.websitecarbon.com/website/rust-lang-github-io-mdbook/
+[vs-carbon]: https://www.websitecarbon.com/website/vocs-dev/
 [nx-carbon]: https://www.websitecarbon.com/website/nextra-site-docs-docs-theme-start/
 [fs-carbon]: https://www.websitecarbon.com/website/fumadocs-dev-docs-ui/
 [dy-carbon]: https://www.websitecarbon.com/website/docsify-js-org/


### PR DESCRIPTION
#### Description

This PR is a follow-up of #3812 where I [suggested the addition of Vocs](https://github.com/withastro/starlight/pull/3812#issuecomment-4225948301). Since the date below the table is now newer for Vocs, I updated all the stats for the other websites as well (sorry for the translators 😅).

> [!NOTE]
> GitBook is jumping up and down 😆 

I also thought if it would make sense to automate the updates every half a year or yearly with a GitHub action. It "shouldn't" be that hard as the table is the same in all languages and the date can be localized 🤔 What do you think?