### PR TITLE
Update the monorepo to use pnpm v10

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,0 @@
-prefer-workspace-packages=true
-link-workspace-packages=true
-shell-emulator=true
-auto-install-peers=false

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.39.1"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.33.0",
   "size-limit": [
     {
       "name": "/index.html",
@@ -51,14 +51,5 @@
       "limit": "16.75 kB",
       "gzip": true
     }
-  ],
-  "pnpm": {
-    "peerDependencyRules": {
-      "ignoreMissing": [
-        "@algolia/client-search",
-        "playwright",
-        "search-insights"
-      ]
-    }
-  }
+  ]
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,18 @@ packages:
   - 'packages/**/*'
   - 'examples/**/*'
   - 'docs'
+
+# Link up monorepo packages instead of downloading them from npm
+preferWorkspacePackages: true
+linkWorkspacePackages: true
+
+# Run scripts in a bash-like emulation for better cross-platform support
+shellEmulator: true
+
+# Avoid installing unnecessary peer dependencies
+autoInstallPeers: false
+peerDependencyRules:
+  ignoreMissing:
+    - '@algolia/client-search'
+    - 'playwright'
+    - 'search-insights'


### PR DESCRIPTION
pnpm v11 is coming soon and I realised we were still on v9. While doing this work, I realised I could consolidate some of our monorepo config in `pnpm-workspace.yaml` that was previously scattered across three separate files. And YAML gives us an opportunity to add comments too which is a bonus.