### PR TITLE
Refactor a docs component to remove unnecessary `getEntry`

### DIFF
--- a/docs/src/components/languages-list.astro
+++ b/docs/src/components/languages-list.astro
@@ -1,17 +1,12 @@
 ---
-import { getEntry } from 'astro:content';
 import translations from '../../../packages/starlight/translations';
 
 interface Props {
 	startsSentence?: boolean;
 }
 
-// The current page's slug.
-const slug = Astro.url.pathname.replace(/^\//, '').replace(/\/$/, '');
-// The docs entry for the current page, or `undefined` if the page is using fallback content.
-const entry = await getEntry('docs', slug);
 // The BCP-47 tag for the current page or fallback content's language.
-const pageLang = entry && Astro.currentLocale ? Astro.currentLocale : 'en';
+const pageLang = Astro.locals.starlightRoute.entryMeta.lang;
 // The BCP-47 tags for all supported languages in Starlight.
 const supportedLangs = Object.keys(translations);
 // An i18n helper that returns the language name for a given BCP-47 tag configured for the current page's language.


### PR DESCRIPTION
#### Description

This is a small PR refactoring a docs component to use simpler localization approach.
This component previously parsed the current URL to a slug and used `getEntry` to see if matching content was found to figure out if it was used in a page using fallback content or if Astro’s `currentLocale` property was a reliable source for the language to use.

This is no longer needed as it can access the content’s locale directly from `Astro.locals` now that we have route data.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
