### PR TITLE
Add `x-default` meta tag for multilingual sites

### DIFF
--- a/.changeset/eighty-suns-smoke.md
+++ b/.changeset/eighty-suns-smoke.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': minor
+---
+
+Adds a `<link rel="alternate" hreflang="x-default" href="...">` tag pointing to the default locale in multilingual sites. The `x-default` alternate is used as a signal of which language to fall back to if no other is available. Learn more in Google’s [SEO localization docs](https://developers.google.com/search/docs/specialty/international/localized-versions#xdefault).

--- a/packages/starlight/__tests__/i18n/head.test.ts
+++ b/packages/starlight/__tests__/i18n/head.test.ts
@@ -27,3 +27,19 @@ test('includes links to language alternates', () => {
 		});
 	}
 });
+
+test('includes link to default language', () => {
+	const route = routes[0]!;
+	const { head } = generateRouteData({
+		props: { ...route, headings: [] },
+		context: getRouteDataTestContext(),
+	});
+	expect(head).toContainEqual({
+		tag: 'link',
+		attrs: {
+			rel: 'alternate',
+			href: `https://example.com/en/`,
+			hreflang: 'x-default',
+		},
+	});
+});

--- a/packages/starlight/utils/head.ts
+++ b/packages/starlight/utils/head.ts
@@ -91,6 +91,14 @@ export function getHead(
 				},
 			});
 		}
+		headDefaults.push({
+			tag: 'link',
+			attrs: {
+				rel: 'alternate',
+				hreflang: 'x-default',
+				href: localizedUrl(canonical, config.defaultLocale.locale, project.trailingSlash).href,
+			},
+		});
 	}
 
 	// Link to sitemap, but only when `site` is set.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- This PR adds an additional `<link rel="alternate" hreflang="x-default" href="...">` meta tag to the existing `hreflang` alternates in multilingual sites.
- Previously I’d avoided this due to [Google’s docs on `x-default`](https://developers.google.com/search/docs/specialty/international/localized-versions#xdefault) saying that “it was designed for language selector pages”.
- But a (I think recent?) update to that page says you can use any page and I noticed that @jdevalk’s [SEO tools for Astro use `x-default` more liberally](https://github.com/jdevalk/seo-graph/tree/main/packages/astro-seo-graph#:~:text=og%3Alocale%3Aalternate%2E%20Emitted%20automatically%20from%20the%20alternates%20prop%20on%20multilingual%20pages). Given his many years of SEO experience, I’m guessing that’s a sign this is a safe approach.

#### Context

One reason for experimenting with this is to see if it helps with Starlight’s use of duplicate content. In multilingual Starlight sites that are not fully translated, the default language’s content gets reused to provide readers with _something_ without leaving their locale. This leads to situations like

- example.com/en/intro/ — default locale content
- example.com/fr/intro/ — translated content
- example.com/de/intro/ — not translated, so reuses `/en/` content (but with German UI for navigation etc.)

We’ve heard some reports that this reuse causes issues for search engines and can confuse them into using the non-default locale URL, so e.g. in this case a user searching in English gets suggested the `/de/` URL.

Factors:
- each page has `<html lang="en/fr/de">` to indicate locale
- each page contains `hreflang` alternates
- each page is its own canonical URL, including pages with duplicate content, because UI is localized
- for pages reusing content, the content embedded in the page has a `lang="en"` (or whatever the default locale is) attribute

I’m curious to see if `x-default` helps at all here as a signal in these cases.

The more extreme fix (and very likely to work) would be to use `canonical` to point back to the default locale for pages containing fallback content. However, this can have other unintended consequences. For example, site search indexers like Algolia skip indexing non-canonical pages by default, essentially removing this content if your language is not translated yet. So this change is an easier first step.