### PR TITLE
Ignore type error in i18n util with newer TypeScript versions

### DIFF
--- a/.changeset/yellow-stingrays-report.md
+++ b/.changeset/yellow-stingrays-report.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes a type-checking issue for users on newer versions of TypeScript

--- a/packages/starlight/utils/i18n.ts
+++ b/packages/starlight/utils/i18n.ts
@@ -193,6 +193,9 @@ function getLocaleDir(locale: Intl.Locale): 'ltr' | 'rtl' {
 	}
 	// Firefox does not support `textInfo` or `getTextInfo` yet so we fallback to a well-known list
 	// of right-to-left languages.
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore — This is a type error with newer versions of TypeScript’s DOM types.
+	// TODO: remove or switch to @ts-expect-error in #3572
 	return wellKnownRTL.includes(locale.language) ? 'rtl' : 'ltr';
 }
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #3822 <!-- Add an issue number if this PR will close it. -->
- #3824 was closed, so handling this quickly in a new PR
- #3572 will address this properly, but we can ignore this error safely for now

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
