### PR TITLE
Use shared format workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,28 +5,14 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   format:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code using Git
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.head_ref }}
-          # Needs access to push to main
-          token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
-      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22.12.0
-          cache: 'pnpm'
-      - run: pnpm i
-      - name: Format with Prettier
-        run: pnpm format
-      - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
-        with:
-          commit_message: '[ci] format'
-          branch: ${{ github.head_ref }}
-          commit_user_name: fredkbot
-          commit_user_email: fred+astrobot@astro.build
+    if: github.repository_owner == 'withastro'
+    uses: withastro/automation/.github/workflows/format.yml@497c9268ad4267c842a8f6c4d830ad0182d6f6b3 # main
+    with:
+      command: "format"
+    secrets: inherit


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

This PR updates our format workflow to use the shared workflow from https://github.com/withastro/automation/ that we use in other repos.

While there, I also borrowed some details from how we run this elsewhere:

- Cancels in-progress formatting runs if another commit comes in
- Doesn’t run outside the `withastro` org (just in case someone is committing to `main` in a fork)