### PR TITLE
Update i18next

### DIFF
--- a/.changeset/proud-schools-peel.md
+++ b/.changeset/proud-schools-peel.md
@@ -4,4 +4,4 @@
 
 Updates `i18next`, used for Starlight’s localization APIs, from v23 to v26
 
-There should be no user-facing changes from this update
+There should not be any user-facing changes from this update

--- a/.changeset/proud-schools-peel.md
+++ b/.changeset/proud-schools-peel.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/starlight': minor
+---
+
+Updates `i18next`, used for Starlight’s localization APIs, from v23 to v26
+
+There should be no user-facing changes from this update

--- a/packages/starlight/package.json
+++ b/packages/starlight/package.json
@@ -73,7 +73,7 @@
     "hast-util-select": "^6.0.4",
     "hast-util-to-string": "^3.0.1",
     "hastscript": "^9.0.1",
-    "i18next": "^23.11.5",
+    "i18next": "^26.0.7",
     "js-yaml": "^4.1.1",
     "klona": "^2.0.6",
     "magic-string": "^0.30.21",

--- a/packages/starlight/utils/createTranslationSystem.ts
+++ b/packages/starlight/utils/createTranslationSystem.ts
@@ -72,11 +72,11 @@ export async function createTranslationSystem<T extends i18nSchemaOutput>(
 
 		const t = i18n.getFixedT(lang, I18nextNamespace) as I18nT;
 		t.all = () => i18n.getResourceBundle(lang, I18nextNamespace) as ReturnType<I18nT['all']>;
-		// Since i18next 25.10.4 the `ExistsFunction` type has a signature including a predicate. We
-		// need the explicit return type to help TS narrow and infer the type correctly.
+		// Since i18next 25.10.4 the `ExistsFunction` type has a signature including a predicate that
+		// TS cannot preserve when composing a new function to add default options.
 		// See: https://github.com/i18next/i18next/issues/2425
-		t.exists = (key, options): key is keyof object =>
-			i18n.exists(key, { lng: lang, ns: I18nextNamespace, ...options });
+		t.exists = ((key, options) =>
+			i18n.exists(key, { lng: lang, ns: I18nextNamespace, ...options })) as ExistsFunction;
 		t.dir = (dirLang = lang) => i18n.dir(dirLang);
 
 		return t;

--- a/packages/starlight/utils/createTranslationSystem.ts
+++ b/packages/starlight/utils/createTranslationSystem.ts
@@ -72,7 +72,11 @@ export async function createTranslationSystem<T extends i18nSchemaOutput>(
 
 		const t = i18n.getFixedT(lang, I18nextNamespace) as I18nT;
 		t.all = () => i18n.getResourceBundle(lang, I18nextNamespace) as ReturnType<I18nT['all']>;
-		t.exists = (key, options) => i18n.exists(key, { lng: lang, ns: I18nextNamespace, ...options });
+		// Since i18next 25.10.4 the `ExistsFunction` type has a signature including a predicate. We
+		// need the explicit return type to help TS narrow and infer the type correctly.
+		// See: https://github.com/i18next/i18next/issues/2425
+		t.exists = (key, options): key is keyof object =>
+			i18n.exists(key, { lng: lang, ns: I18nextNamespace, ...options });
 		t.dir = (dirLang = lang) => i18n.dir(dirLang);
 
 		return t;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,8 +216,8 @@ importers:
         specifier: ^9.0.1
         version: 9.0.1
       i18next:
-        specifier: ^23.11.5
-        version: 23.11.5
+        specifier: ^26.0.7
+        version: 26.0.7(typescript@6.0.3)
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -2379,8 +2379,13 @@ packages:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
 
-  i18next@23.11.5:
-    resolution: {integrity: sha512-41pvpVbW9rhZPk5xjCX2TPJi2861LEig/YRhUkY+1FQ2IQPS0bKUDYnEqY8XPPbB48h1uIwLnP9iiEfuSl20CA==}
+  i18next@26.0.7:
+    resolution: {integrity: sha512-f7tL/iw0VQsx4nC5oNxBM2RjM8alNys5KzyiQTU6A9TI5TI89py4/Ez1cKFvHiLWsvzOXvuGUES+Kk/A2WiANQ==}
+    peerDependencies:
+      typescript: ^5 || ^6
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -6438,9 +6443,9 @@ snapshots:
 
   human-id@4.1.3: {}
 
-  i18next@23.11.5:
-    dependencies:
-      '@babel/runtime': 7.24.7
+  i18next@26.0.7(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
 
   iconv-lite@0.7.2:
     dependencies:


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- This PR updates i18next from v23 to v26
- I reviewed their changelog and [migration guide](https://www.i18next.com/misc/migration-guide) and I don’t think any of the changes should impact users as most of the changes were either internal API things on the side Starlight itself sets up or removing deprecated formats and environments which we already didn’t support
- Nevertheless, I’ve included a minor changeset just to be safe and flag it in case someone is doing something elaborate with i18next.