### PR TITLE
Add bottom margin to nested lists

### DIFF
--- a/.changeset/fluffy-plums-dress.md
+++ b/.changeset/fluffy-plums-dress.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+list elements are now given a bottom margin when they are within another list item element

--- a/.changeset/fluffy-plums-dress.md
+++ b/.changeset/fluffy-plums-dress.md
@@ -1,5 +1,5 @@
 ---
-'@astrojs/starlight': patch
+'@astrojs/starlight': minor
 ---
 
-list elements are now given a bottom margin when they are within another list item element
+Makes spacing of items in nested lists more consistent

--- a/packages/starlight/style/markdown.css
+++ b/packages/starlight/style/markdown.css
@@ -36,8 +36,6 @@
 	> :is(
 		:last-child:not(
 				li,
-				ul,
-				ol,
 				a,
 				strong,
 				em,

--- a/packages/starlight/style/markdown.css
+++ b/packages/starlight/style/markdown.css
@@ -54,7 +54,7 @@
 			 * need to style the last non-script element (`:not(script)`) that doesn't have a subsequent
 			 * sibling that is not a script (`:not(:has(~ :not(script)))`).
 			 */
-		:not(script):has(~ script:last-child):not(:has(~ :not(script))),
+		:not(script):has(~ script:last-child):not(:has(~ :not(script)))
 	) {
 		margin-bottom: 1.25rem;
 	}

--- a/packages/starlight/style/markdown.css
+++ b/packages/starlight/style/markdown.css
@@ -36,6 +36,8 @@
 	> :is(
 		:last-child:not(
 				li,
+				ul,
+				ol,
 				a,
 				strong,
 				em,
@@ -52,8 +54,18 @@
 			 * need to style the last non-script element (`:not(script)`) that doesn't have a subsequent
 			 * sibling that is not a script (`:not(:has(~ :not(script)))`).
 			 */
-		:not(script):has(~ script:last-child):not(:has(~ :not(script)))
+		:not(script):has(~ script:last-child):not(:has(~ :not(script))),
 	) {
+		margin-bottom: 1.25rem;
+	}
+
+	/* Apply a margin to a list element if it's in an li with other non-inline elements. */
+	.sl-markdown-content
+	li:has(
+		> :not(a, strong, em, del, span, input, code, br) + :not(li, a, strong, em, del, span, input, code, br)
+	)
+	:is(ol,ul):last-child
+	{
 		margin-bottom: 1.25rem;
 	}
 

--- a/packages/starlight/style/markdown.css
+++ b/packages/starlight/style/markdown.css
@@ -31,41 +31,31 @@
 		overflow-wrap: anywhere;
 	}
 
+	/*
+	 * This complex selector manages spacing inside lists.
+	 *
+	 * - Finds all lists containing items with non-inline direct children (e.g.
+	 *   ul > li > p)
+	 * - Applies a bottom margin to the last non-inline child of each list item
+	 *   in this list
+	 *
+	 * This ensures that even if only one list item contains a block element
+	 * (most commonly a paragraph), siblings of that list item are spaced
+	 * consistently.
+	 */
 	.sl-markdown-content
-	li
-	> :is(
-		:last-child:not(
-				li,
-				ul,
-				ol,
-				a,
-				strong,
-				em,
-				del,
-				span,
-				input,
-				code,
-				br,
-				script,
-				:where(.not-content *)
-			),
-			/**
-			 * For list items ending with 1 or multiple script elements (`:has(~ script:last-child)`), we
-			 * need to style the last non-script element (`:not(script)`) that doesn't have a subsequent
-			 * sibling that is not a script (`:not(:has(~ :not(script)))`).
+	 :is(ol, ul):has(> li > :not(a, strong, em, del, span, input, code, br, script, ol, ul))
+	 > li
+	 > :is(
+			:last-child:not(a, strong, em, del, span, input, code, br, script, :where(.not-content *)),
+			/*
+			 * For list items ending with 1 or multiple script elements (`:has(~
+			 * script:last-child)`), we need to style the last non-script
+			 * element (`:not(script)`) that doesn't have a subsequent sibling
+			 * that is not a script (`:not(:has(~ :not(script)))`).
 			 */
-		:not(script):has(~ script:last-child):not(:has(~ :not(script)))
-	) {
-		margin-bottom: 1.25rem;
-	}
-
-	/* Apply a margin to a list element if it's in an li with other non-inline elements. */
-	.sl-markdown-content
-	li:has(
-		> :not(a, strong, em, del, span, input, code, br) + :not(li, a, strong, em, del, span, input, code, br)
-	)
-	:is(ol,ul):last-child
-	{
+			:not(script):has(~ script:last-child):not(:has(~ :not(script)))
+	 ) {
 		margin-bottom: 1.25rem;
 	}
 


### PR DESCRIPTION
Closes #3860 

#### Description

When a compact list is nested in an expanded list it doesn't have a bottom margin applied, making the list look uneven. Often times I like to utilize an expanded ordered list for `<Steps>` components, but might want to include a bulleted `ul` in there. ~~This change just removes the `ul` and `ol` exclusions for applying a bottom margin that exist in list items.~~

After looking into it more, there were times when the original solution was adding margins when they shouldn't be added (e.g. a compact list containing another compact list). New CSS now applies the margin to only the list elements that are the last child of an `li` and are preceded by some other non-inline element.
