### PR TITLE
Enable `text-autospace` in Chinese and Japanese documents

### DIFF
--- a/.changeset/gentle-hats-help.md
+++ b/.changeset/gentle-hats-help.md
@@ -4,9 +4,7 @@
 
 Enables [the CSS property `text-autospace`](https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-autospace) in Chinese and Japanese documents.
 
-The specification is mature enough to meet most requirements, though there could be edge cases where it causes issues. You can disable this until the specification and browser implementations are more stable.
-
-If you would prefer to revert this change, you can add the following custom CSS to your site:
+The specification is mature enough to meet most requirements, though there could be edge cases where it causes issues. Most users should be satisfied or unaffected by this change and no additional measures should be necessary, but if you would prefer to revert this change, you can add the following custom CSS to your site:
 
 ```css
 [lang] {

--- a/.changeset/gentle-hats-help.md
+++ b/.changeset/gentle-hats-help.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': minor
+---
+
+Enables [the CSS property `text-autospace`](https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-autospace) in Chinese and Japanese documents.

--- a/.changeset/gentle-hats-help.md
+++ b/.changeset/gentle-hats-help.md
@@ -3,3 +3,13 @@
 ---
 
 Enables [the CSS property `text-autospace`](https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-autospace) in Chinese and Japanese documents.
+
+The specification is mature enough to meet most requirements, though there could be edge cases where it causes issues. You can disable this until the specification and browser implementations are more stable.
+
+If you would prefer to revert this change, you can add the following custom CSS to your site:
+
+```css
+[lang] {
+	text-autospace: initial;
+}
+```

--- a/.changeset/gentle-hats-help.md
+++ b/.changeset/gentle-hats-help.md
@@ -4,10 +4,10 @@
 
 Enables [the CSS property `text-autospace`](https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-autospace) in Chinese and Japanese documents.
 
-The specification is mature enough to meet most requirements, though there could be edge cases where it causes issues. Most users should be satisfied or unaffected by this change and no additional measures should be necessary, but if you would prefer to revert this change, you can add the following custom CSS to your site:
+If you would prefer to disable autospacing in Chinese and Japanese pages, you can add the following custom CSS to your site:
 
 ```css
-[lang] {
+[lang]:where(:lang(zh, ja)) {
 	text-autospace: initial;
 }
 ```

--- a/packages/starlight/style/reset.css
+++ b/packages/starlight/style/reset.css
@@ -28,6 +28,21 @@
 		background-color: var(--sl-color-bg);
 	}
 
+	[lang]:where(:lang(zh, ja)) {
+		text-autospace: normal;
+	}
+
+	[lang]:where(:not(:lang(zh, ja))) {
+		text-autospace: initial;
+	}
+
+	pre,
+	code,
+	samp,
+	kbd {
+		text-autospace: no-autospace;
+	}
+	
 	input,
 	button,
 	textarea,


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

<!-- New features should first be discussed and approved by maintainers in GitHub or Discord discussions. -->
<!-- If this PR adds a new public-facing feature, uncomment the line below and include a link to the relevant discussion. -->
<!-- - [x] This PR adds a new feature which has been discussed and approved [here](link to GitHub or Discord discussion). -->

- Closes #3871 <!-- Add an issue number if this PR will close it. -->

Especially in Chinese and Japanese, the CSS property `text-autospace: normal` is preferred for better looking like books by automatically inserting spaces with the moderate width.

- https://developer.chrome.com/blog/css-i18n-features#inter-script_spacing_text-autospace
- https://developer.mozilla.org/docs/Web/CSS/text-autospace
- https://webkit.org/blog/16574/webkit-features-in-safari-18-4/#:~:text=Text%20auto%20space
- https://github.com/vuejs/vitepress/issues/4996
- https://github.com/web-infra-dev/rspress/pull/2920
- https://github.com/web-infra-dev/rspress/releases/tag/v2.0.0-rc.3

Without this, some users and AIs try to insert such spaces manually as workarounds but they are too wide and prevent keywords from searched.

Japanese:

Before:

<img width="730" height="759" alt="image" src="https://github.com/user-attachments/assets/fb0d5921-7da5-4b82-8422-388369a2f092" />


After:

<img width="729" height="750" alt="image" src="https://github.com/user-attachments/assets/789ed541-5c97-49ad-a39b-8b0b4254a567" />

Note: the current Chinese content of Starlight translation is not affected because it took the workarounds like manually inserting spaces.

The other languages are not affected.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
