### PR TITLE
Approve postinstall scripts of esbuild & sharp

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,18 +2,21 @@ packages:
   - 'packages/**/*'
   - 'examples/**/*'
   - 'docs'
-
-# Link up monorepo packages instead of downloading them from npm
-preferWorkspacePackages: true
-linkWorkspacePackages: true
-
-# Run scripts in a bash-like emulation for better cross-platform support
-shellEmulator: true
+allowBuilds:
+  esbuild: true
+  sharp: true
 
 # Avoid installing unnecessary peer dependencies
 autoInstallPeers: false
+linkWorkspacePackages: true
 peerDependencyRules:
   ignoreMissing:
     - '@algolia/client-search'
     - 'playwright'
     - 'search-insights'
+
+# Link up monorepo packages instead of downloading them from npm
+preferWorkspacePackages: true
+
+# Run scripts in a bash-like emulation for better cross-platform support
+shellEmulator: true


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

<!-- New features should first be discussed and approved by maintainers in GitHub or Discord discussions. -->
<!-- If this PR adds a new public-facing feature, uncomment the line below and include a link to the relevant discussion. -->
<!-- - [x] This PR adds a new feature which has been discussed and approved [here](link to GitHub or Discord discussion). -->

- Closes #3875

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->

1. Ran `pnpm approve-builds --all`
2. Committed changed `pnpm-workspace.yaml`

pnpm sorted the entries. `allowBuilds` were added other than it.

Both esbuild and sharp are [approved by Bun's list](github.com/oven-sh/bun/blob/main/src/install/default-trusted-dependencies.txt).

No changesets should be required because this PR doesn't change any packages (doesn't affect on the actual code of any packages).