### PR TITLE
Make sure to enable `text-autospace` even in Chromium-based browsers

### DIFF
--- a/.changeset/empty-cases-pick.md
+++ b/.changeset/empty-cases-pick.md
@@ -2,4 +2,4 @@
 '@astrojs/starlight': patch
 ---
 
-Make sure to enable `text-autospace` even in non-Firefox browsers
+Fixes CSS selector for `text-autospace` styles in Chromium browsers

--- a/.changeset/empty-cases-pick.md
+++ b/.changeset/empty-cases-pick.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Make sure to enable `text-autospace` even in non-Firefox browsers

--- a/packages/starlight/style/reset.css
+++ b/packages/starlight/style/reset.css
@@ -28,11 +28,12 @@
 		background-color: var(--sl-color-bg);
 	}
 
-	[lang]:where(:lang(zh, ja)) {
+	/* :lang(zh, ja) has not been supported by non-Firefox browsers at the time of writing (2026-05) */
+	[lang]:where(:lang(zh), :lang(ja)) {
 		text-autospace: normal;
 	}
 
-	[lang]:where(:not(:lang(zh, ja))) {
+	[lang]:where(:not(:lang(zh), :lang(ja))) {
 		text-autospace: initial;
 	}
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

<!-- New features should first be discussed and approved by maintainers in GitHub or Discord discussions. -->
<!-- If this PR adds a new public-facing feature, uncomment the line below and include a link to the relevant discussion. -->
<!-- - [x] This PR adds a new feature which has been discussed and approved [here](link to GitHub or Discord discussion). -->

- Fixes https://github.com/withastro/starlight/pull/3872#issuecomment-4405904913  <!-- Add an issue number if this PR will close it. -->

`:lang(zh, ja)` used in #3872 shamefully has not been supported Chromium ~~and Safari~~. As a result, `text-autospace` has been enabled only in Firefox. Replaced it with the combination of `:lang(zh)` and `:lang(ja)`.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->

Screenshot in Chrome (Pay attention to the slight presence of whitespace around "Astro" and "Starlight"):

Before (https://starlight.astro.build/ja/getting-started/):

<img width="2317" height="1111" alt="image" src="https://github.com/user-attachments/assets/862f2cd9-2682-4bd4-8c75-087cd2ffc937" />

After:

<img width="2059" height="866" alt="image" src="https://github.com/user-attachments/assets/44067d89-503e-4919-b23f-2b369a70daf7" />