### PR TITLE
Fix inaccurate comment on `:lang` selectors

### DIFF
--- a/.changeset/happy-kings-know.md
+++ b/.changeset/happy-kings-know.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fix inaccurate comment on `:lang` selectors

--- a/.changeset/happy-kings-know.md
+++ b/.changeset/happy-kings-know.md
@@ -1,5 +1,0 @@
----
-'@astrojs/starlight': patch
----
-
-Fix inaccurate comment on `:lang` selectors

--- a/packages/starlight/style/reset.css
+++ b/packages/starlight/style/reset.css
@@ -28,7 +28,7 @@
 		background-color: var(--sl-color-bg);
 	}
 
-	/* :lang(zh, ja) has not been supported by non-Firefox browsers at the time of writing (2026-05) */
+	/* :lang(zh, ja) has not been supported by Chromium-based browsers at the time of writing (2026-05) */
 	[lang]:where(:lang(zh), :lang(ja)) {
 		text-autospace: normal;
 	}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

<!-- New features should first be discussed and approved by maintainers in GitHub or Discord discussions. -->
<!-- If this PR adds a new public-facing feature, uncomment the line below and include a link to the relevant discussion. -->
<!-- - [x] This PR adds a new feature which has been discussed and approved [here](link to GitHub or Discord discussion). -->

- Fixes https://github.com/withastro/starlight/pull/3890#pullrequestreview-4253703763 & https://github.com/withastro/starlight/pull/3890#issuecomment-4411190048

Tweak a comment: "non-Firefox" → "Chromium-based"

Safari has already supported the syntax `:lang(zh, ja)`.

<img width="1568" height="1006" alt="image" src="https://github.com/user-attachments/assets/384e3643-a076-4146-9a24-0dc204dd37c6" />

The position of Opera is the culprit.

This change is so trivial that we should ship it with other changes.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
