### PR TITLE
Explicitly disallow postinstall scripts of esbuild & sharp

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,11 @@ packages:
   - 'examples/**/*'
   - 'docs'
 
+# https://github.com/withastro/starlight/issues/3875
+allowBuilds:
+  esbuild: false # https://github.com/evanw/esbuild/issues/4085#issuecomment-2696009329
+  sharp: false # https://sharp.pixelplumbing.com/install/: "When using pnpm, add sharp to ignoredBuiltDependencies to silence warnings."
+
 # Link up monorepo packages instead of downloading them from npm
 preferWorkspacePackages: true
 linkWorkspacePackages: true


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

<!-- New features should first be discussed and approved by maintainers in GitHub or Discord discussions. -->
<!-- If this PR adds a new public-facing feature, uncomment the line below and include a link to the relevant discussion. -->
<!-- - [x] This PR adds a new feature which has been discussed and approved [here](link to GitHub or Discord discussion). -->

Opposite of:

- https://github.com/withastro/starlight/issues/3875
- https://github.com/withastro/starlight/pull/3876

but the goal is the same: to silence the Postinstall Scripts Unapproved notification when `pnpm install`.

References:

| Package | URL | Quote |
| -- | -- | -- |
| esbuild | https://github.com/evanw/esbuild/issues/4085#issuecomment-2696009329 | <q>The install script still optimizes the command by replacing the JavaScript shim by the actual binary executable, so that running the esbuild command directly doesn't have to run node first just to shell out to the executable. So it's not necessary for correctness (and you're welcome to disable the install script if you'd like to and if it still works for you) but it might result in esbuild being slower than it would have been otherwise.</q> |
| sharp | https://sharp.pixelplumbing.com/install/ | <q>When using `pnpm`, add `sharp` to [ignoredBuiltDependencies](https://pnpm.io/settings#ignoredbuiltdependencies)[^pnpm-11] to silence warnings.</q> |

[^pnpm-11]: equivalent to `allowBuilds` = `false` in pnpm v10.26+.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->

Changesets are **NOT** required.
