### PR TITLE
Update package manager to pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.2"
   },
-  "packageManager": "pnpm@10.33.3",
+  "packageManager": "pnpm@11.1.1",
   "size-limit": [
     {
       "name": "/index.html",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,3 +22,6 @@ peerDependencyRules:
     - '@algolia/client-search'
     - 'playwright'
     - 'search-insights'
+
+# Prevent installing packages published in the last 3 days
+minimumReleaseAge: 4320


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

This PR updates to pnpm 11 and configures a 3-day minimum release age for dependencies to mirror the main `astro` monorepo: https://github.com/withastro/astro/blob/3abcc86c092ca2a3455fc0ffc72b6b7ca300f1a2/pnpm-workspace.yaml#L32

This helps defend a little against supply chain attacks, but also avoids us installing deps that then cause issues in the `astro` monorepo CI because they’re newer than their config allows.