### PR TITLE
Wait 3 days for Renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,6 +10,7 @@
 	],
 	rangeStrategy: 'bump',
 	ignorePaths: ['**/node_modules/**'],
+	minimumReleaseAge: '3 days',
 	packageRules: [
 		{
 			groupName: 'github-actions',


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Companion to #3902 
- Tells Renovate to wait for 3 days before applying updates to match our pnpm policy
- In practice not super important as we mainly use Renovate for GitHub Actions, which don’t involve pnpm, but still good to keep these in sync