### PR TITLE
i18n(de): update sidebar, ref/config, ref/front

### DIFF
--- a/docs/src/content/docs/de/guides/sidebar.mdx
+++ b/docs/src/content/docs/de/guides/sidebar.mdx
@@ -45,7 +45,7 @@ Die folgende Seitenleiste automatisch generiert:
 	]}
 />
 
-Erfahre mehr über autogenerierte Seitenleisten im Abschnitt [autogenerierte Gruppen](#automatisch-generierte-gruppen).
+Erfahre mehr über autogenerierte Seitenleisten im Abschnitt [autogenerierte Links](#automatisch-generierte-links).
 
 ## Links und Linkgruppen hinzufügen
 
@@ -186,15 +186,15 @@ Die obige Konfiguration erzeugt die folgende Seitenleiste:
 	]}
 />
 
-### Automatisch generierte Gruppen
+### Automatisch generierte Links
 
-Starlight kann automatisch eine Gruppe in deiner Seitenleiste erzeugen, die auf einem Verzeichnis deiner Dokumente basiert.
+Starlight kann automatisch Links in deiner Seitenleiste erzeugen, die auf einem Verzeichnis deiner Dokumente basiert.
 Dies ist hilfreich, wenn du nicht jedes Element der Seitenleiste manuell in eine Gruppe eintragen willst.
 
 Standardmäßig werden die Seiten in alphabetischer Reihenfolge nach der Datei [`id`](/de/reference/route-data/#id) sortiert.
 
-Füge eine automatisch generierte Gruppe hinzu, indem du ein Objekt mit den Eigenschaften `label` und `autogenerate` verwendest. In der Konfiguration von `autogenerate` muss das `directory` angegeben werden, das für die Einträge in der Seitenleiste verwendet werden soll.
-
+Füge automatisch generierte Links hinzu, indem du ein Objekt mit der Eigenschaften `autogenerate` verwendest. 
+In der Konfiguration von `autogenerate` muss das `directory` angegeben werden, das für die Einträge in der Seitenleiste verwendet werden soll.
 Zum Beispiel wird mit der folgenden Konfiguration:
 
 ```js "label:" "autogenerate:"
@@ -202,8 +202,8 @@ starlight({
 	sidebar: [
 		{
 			label: 'Konstellationen',
-			// Automatisches Erzeugen einer Gruppe von Links für das Verzeichnis 'constellations'.
-			autogenerate: { directory: 'constellations' },
+			// Automatisches Erzeugen von Links für das Verzeichnis 'constellations'.
+			items: [{ autogenerate: { directory: 'constellations' } }],
 		},
 	],
 });
@@ -264,7 +264,7 @@ sidebar:
 ---
 ```
 
-Eine autogenerierte Gruppe, die eine Seite mit dem obigen Frontmatter enthält, erzeugt die folgende Seitenleiste:
+Eine Gruppe mit autogenerierten Links, die eine Seite mit dem obigen Frontmatter enthält, erzeugt die folgende Seitenleiste:
 
 <SidebarPreview
 	config={[
@@ -284,12 +284,12 @@ Eine autogenerierte Gruppe, die eine Seite mit dem obigen Frontmatter enthält, 
 />
 
 :::note[Anmerkung]
-Die `sidebar` Frontmatter-Konfiguration wird nur für Links in automatisch generierten Gruppen und für Dokumentations-Links verwendet, die mit der Eigenschaft `slug` definiert wurden. Sie gilt nicht für Links, die mit der Eigenschaft `link` definiert wurden.
+Die `sidebar` Frontmatter-Konfiguration wird nur für automatisch generierte Links und für Dokumentations-Links verwendet, die mit der Eigenschaft `slug` definiert wurden. Sie gilt nicht für Links, die mit der Eigenschaft `link` definiert wurden.
 :::
 
 ## Abzeichen
 
-Links, Gruppen und automatisch generierte Gruppen können auch eine `badge`-Eigenschaft enthalten, um ein Abzeichen neben dem jeweiligen Text anzuzeigen.
+Links und Gruppen können auch eine `badge`-Eigenschaft enthalten, um ein Abzeichen neben dem jeweiligen Text anzuzeigen.
 
 ```js {9,16}
 starlight({
@@ -304,11 +304,11 @@ starlight({
 				},
 			],
 		},
-		// Eine automatisch generierte Gruppe mit dem "Veraltet"-Abzeichen.
+		// Eine Gruppe mit dem "Veraltet"-Abzeichen.
 		{
 			label: 'Monde',
 			badge: 'Veraltet',
-			autogenerate: { directory: 'moons' },
+			items: [{ autogenerate: { directory: 'moons' } }],
 		},
 	],
 });
@@ -440,21 +440,19 @@ Die obige Konfiguration erzeugt die folgende Seitenleiste:
 
 ### Benutzerdefinierte HTML-Attribute für automatisch generierte Links
 
-Du kannst die HTML-Attribute aller Links in [automatisch generierten Gruppen](#automatisch-generierte-gruppen) anpassen, indem du die Eigenschaft `attrs` in der Konfiguration `autogenerate` festlegst.
+Du kannst die HTML-Attribute aller [automatisch generierten Links](#automatisch-generierte-links) anpassen, indem du die Eigenschaft `attrs` in der Konfiguration `autogenerate` festlegst.
 Einzelne Seiten können eigene Attribute über das [`sidebar.attrs`-Frontmatter-Feld](/de/reference/frontmatter/#attrs) festlegen, welches mit der `autogenerate.attrs`-Konfiguration zusammengeführt wird.
 
 Zum Beispiel wird mit der folgenden Konfiguration:
 
-```js {10}
+```js {8}
 starlight({
 	sidebar: [
 		{
-			label: 'Konstellationen',
 			autogenerate: {
-				// Erstelle automatisch eine Gruppe von Links
-				// für das Verzeichnis 'constellations'.
+				// Erstelle automatisch Links für das Verzeichnis 'constellations'.
 				directory: 'constellations',
-				// Alle Link-Bezeichnungen in dieser Gruppe kursiv darstellen.
+				// Alle automatisch generierten Link-Bezeichnungen kursiv darstellen.
 				attrs: { style: 'font-style: italic' },
 			},
 		},
@@ -479,30 +477,18 @@ Und der folgenden Dateistruktur:
 
 Die folgende Seitenleiste mit allen automatisch generierten Links in Kursivschrift erstellt:
 
+
 <SidebarPreview
 	config={[
+		{ label: 'Kiel des Schiffes', link: '', attrs: { style: 'font-style: italic' } },
+		{ label: 'Zentaur', link: '', attrs: { style: 'font-style: italic' } },
 		{
-			label: 'Konstellationen',
+			label: 'seasonal',
 			items: [
 				{
-					label: 'Kiel des Schiffes',
+					label: 'Andromeda',
 					link: '',
 					attrs: { style: 'font-style: italic' },
-				},
-				{
-					label: 'Zentaur',
-					link: '',
-					attrs: { style: 'font-style: italic' },
-				},
-				{
-					label: 'seasonal',
-					items: [
-						{
-							label: 'Andromeda',
-							link: '',
-							attrs: { style: 'font-style: italic' },
-						},
-					],
 				},
 			],
 		},
@@ -673,53 +659,23 @@ Die obige Konfiguration erzeugt die folgende Seitenleiste:
 	]}
 />
 
-[Autogenerierte Gruppen](#automatisch-generierte-gruppen) respektieren den `collapsed` Wert ihrer Elterngruppe:
+[Automatisch generierte Untergruppen](#automatisch-generierte-links) können standardmäßig ausgeblendet werden, indem du die Eigenschaft `autogenerate.collapsed` auf `true` setzt.
 
-```js {5-7}
+```js {9-11}
 starlight({
 	sidebar: [
 		{
 			label: 'Konstellationen',
-			// Die Gruppe und ihre automatisch generierte
-			// Untergruppen standardmäßig einklappen.
-			collapsed: true,
-			autogenerate: { directory: 'constellations' },
-		},
-	],
-});
-```
-
-Die obige Konfiguration erzeugt die folgende Seitenleiste:
-
-<SidebarPreview
-	config={[
-		{
-			label: 'Konstellationen',
-			collapsed: true,
 			items: [
-				{ label: 'Kiel des Schiffes', link: '' },
-				{ label: 'Zentaur', link: '' },
 				{
-					label: 'seasonal',
-					collapsed: true,
-					items: [{ label: 'Andromeda', link: '' }],
+					autogenerate: {
+						directory: 'constellations',
+						// Standardmäßig werden automatisch 
+						// generierte Untergruppen ausgeblendet.
+						collapsed: true,
+					},
 				},
 			],
-		},
-	]}
-/>
-
-Dieses Verhalten kann durch die Definition der Eigenschaft `autogenerate.collapsed` außer Kraft gesetzt werden.
-
-```js {5-7} "collapsed: true"
-starlight({
-	sidebar: [
-		{
-			label: 'Konstellationen',
-			// Die Gruppe "Konstellationen" nicht einklappen, aber ihre
-			// automatisch generierten Untergruppen.
-			collapsed: false,
-			autogenerate: { directory: 'constellations', collapsed: true },
 		},
 	],
 });

--- a/docs/src/content/docs/de/reference/configuration.mdx
+++ b/docs/src/content/docs/de/reference/configuration.mdx
@@ -101,16 +101,16 @@ Mit dieser Konfiguration würde eine `/einfuehrung` einen Bearbeitungslink haben
 
 Konfiguriere die Navigationselemente der Seitenleiste deiner Website.
 
-Eine Seitenleiste ist eine Array von Links und Linkgruppen.
-Mit Ausnahme von Einträgen, die `slug` verwenden, muss jeder Eintrag ein `label` und eine der folgenden Eigenschaften haben:
+Eine Seitenleiste besteht aus einer Reihe von Links, Linkgruppen und automatisch generierten Einträgen.
+Sidebar-Elemente werden mithilfe einer der folgenden Eigenschaften definiert:
 
-- `link` - ein einzelner Link zu einer bestimmten URL, z.&nbsp;B. `'/home'` oder `'https://example.com'`.
+- `link` - ein einzelner Link zu einer bestimmten URL, z.&nbsp;B. `'/home'` oder `'https://example.com'`. Ein Link muss außerdem ein `label` haben.
 
-- `slug` - ein Verweis auf eine interne Seite, z.&nbsp;B. `'guides/getting-started'`.
+- `slug` - ein Verweis auf eine interne Seite, z.&nbsp;B. `'guides/getting-started'`. Der Titel der verlinkten Seite wird standardmäßig als Bezeichnung verwendet.
 
-- `items` - ein Array, das weitere Links und Untergruppen enthält.
+- `items` - ein Array, das weitere Seitenleisten-Links, Untergruppen und automatisch generierte Einträge enthält. Eine Gruppe muss außerdem eine `label` haben.
 
-- `autogenerate` - ein Objekt, das ein Verzeichnis deiner Dokumentation angibt, aus dem automatisch eine Gruppe von Links erzeugt werden soll.
+- `autogenerate` - ein Objekt, das ein Verzeichnis deiner Dokumente angibt, für das automatisch Links und Untergruppen generiert werden sollen. Die automatisch generierten Einträge können in das `items`-Array einer Gruppe eingefügt werden.
 
 Interne Links können auch als Zeichenkette anstelle eines Objekts mit der Eigenschaft `slug` angegeben werden.
 
@@ -134,7 +134,7 @@ starlight({
 		// Eine Gruppe, die auf alle Seiten im Referenzverzeichnis verweist.
 		{
 			label: 'Referenzen',
-			autogenerate: { directory: 'referenz' },
+			items: [{ autogenerate: { directory: 'reference' } }]
 		},
 	],
 });
@@ -149,9 +149,9 @@ Zum Beispiel würde eine Seite, die aus der Datei `astro.md` erzeugt wurde, übe
 
 Gruppen von Links sind standardmäßig aufgeklappt. Du kannst dieses Verhalten ändern, indem du die Eigenschaft `collapsed` einer Gruppe auf `true` setzt.
 
-Autogenerierte Untergruppen respektieren standardmäßig die Eigenschaft `collapsed` ihrer übergeordneten Gruppe. Dies kannst du mit der Eigenschaft `autogenerate.collapsed` außer Kraft setzen.
+Automatisch generierte Untergruppen werden standardmäßig ebenfalls erweitert. Setze die Eigenschaft `autogenerate.collapsed`, um sie zusammenzuklappen.
 
-```js {5,13}
+```js {5,15}
 sidebar: [
   // Eine zusammengefasste Gruppe von Links
   {
@@ -162,10 +162,14 @@ sidebar: [
   // Eine aufgeklappte Gruppe, die automatisch generierte Untergruppen enthält, welche standardmäßig eingeklappt sind.
   {
     label: 'Referenzen',
-    autogenerate: {
-      directory: 'reference',
-      collapsed: true,
-    },
+    items: [
+      {
+        autogenerate: {
+          directory: 'reference',
+          collapsed: true,
+        },
+      },
+    ],
   },
 ],
 ```
@@ -223,17 +227,15 @@ type SidebarItem =
 					items: SidebarItem[];
 					collapsed?: boolean;
 			  }
-			| {
-					// Automatisch generierte Linkgruppe
-					label: string;
-					autogenerate: {
-						directory: string;
-						collapsed?: boolean;
-						attrs?: Record<string, string | number | boolean | undefined>;
-					};
-					collapsed?: boolean;
-			  }
-	  ));
+	  ))
+	| {
+			// Automatisch generierte Links und Untergruppen
+			autogenerate: {
+				directory: string;
+				collapsed?: boolean;
+				attrs?: Record<string, string | number | boolean | undefined>;
+			};
+	  };
 ```
 
 #### `BadgeConfig`

--- a/docs/src/content/docs/de/reference/frontmatter.md
+++ b/docs/src/content/docs/de/reference/frontmatter.md
@@ -286,7 +286,7 @@ draft: true
 ```
 
 Da Entwurfsseiten nicht in die Build-Ausgabe aufgenommen werden, kannst du keine Entwurfsseiten direkt mit [Slugs](/de/guides/sidebar/#interne-links) zu deiner Seitenleisten&shy;konfiguration hinzufügen.
-Entwurfsseiten in Verzeichnissen, die für [autogenerierte Seitenleisten-Gruppen](/de/guides/sidebar/#automatisch-generierte-gruppen) verwendet werden, werden bei Produktions-Builds automatisch ausgeschlossen.
+Entwurfsseiten in Verzeichnissen, die für [autogenerierte Seitenleisten-Links](/de/guides/sidebar/#automatisch-generierte-links) verwendet werden, werden bei Produktions-Builds automatisch ausgeschlossen.
 
 ### `sidebar`
 


### PR DESCRIPTION
#### Description

This PR updates the German translation of `guides/sidebar.mdx`, `reference/configuration.mdx` and `reference/frontmatter.mdx` with the changes from #3618 

I didn't include the `reference/route-data.mdx` changes yet, so we have small chunk PRs 👍 