### PR TITLE
Disable minimum release age for `withastro/automation` updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,5 +34,11 @@
 			matchDepTypes: ['uses-with'],
 			enabled: false,
 		},
+		{
+			description: 'Disable minimum release age for withastro/automation digest updates',
+			matchManagers: ['github-actions'],
+			matchPackageNames: ['withastro/automation'],
+			minimumReleaseAge: null,
+		},
 	],
 }


### PR DESCRIPTION
#### Description

<!-- New features should first be discussed and approved by maintainers in GitHub or Discord discussions. -->
<!-- If this PR adds a new public-facing feature, uncomment the line below and include a link to the relevant discussion. -->
<!-- - [x] This PR adds a new feature which has been discussed and approved [here](link to GitHub or Discord discussion). -->

This PR disables the minimum release age check of 3 days [recently added](https://github.com/withastro/starlight/pull/3904)  for `withastro/automation` updates.

While reviewing #3903, and even after retrying the PR, I was confused why the `renovate/stability-days` check was still pending, even though all the updates were released around 10 days ago ([last change for `withastro/automation`](https://github.com/withastro/automation/commit/53c85fabe6ac4ed7a96e49a005f03fa6cc63d2ac) - [last release for `pnpm/action-setup`](https://github.com/pnpm/action-setup/releases/tag/v6.0.8)).

I'm not a Renovate expert, but I _think_ I finally understand the reason:

- The `withastro/automation` is a digest update as we're using the latest commit SHA on the `main` branch in workflow files without a version tag (`@<sha> # main`).
- As documented [here](https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-update-types-take-minimumreleaseage-into-account), for digest updates, having a release timestamp that can have `minimumReleaseAge` enforced is "Generally not supported".
- In Renovate 42, the absence of a release timestamp will be treated as if the release is not yet past the timestamp, which provides a safer default.

I'm not 100% sure, but I think this is the reason why the `renovate/stability-days` check is still pending, and will probably be always pending, preventing us from merging other updates.

A few extra points:

- If merging this PR and retrying #3903 does not resolve the issue, we can revert this PR and investigate further.
- If this works, it could still be a short-term solution and maybe a more long term solution would be to add proper releases with tags to `withastro/automation`.
- No matter what we end up doing, we will probably need to do the same to the Docs repo as I think https://github.com/withastro/docs/pull/13873 may have the same issue.