### PR TITLE
fix(pagefind): expose diacriticSimilarity and metaWeights ranking options

### DIFF
--- a/.changeset/pagefind-ranking-fields.md
+++ b/.changeset/pagefind-ranking-fields.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Adds support for the `diacriticSimilarity` and `metaWeights` Pagefind ranking options in the Starlight `pagefind.ranking` config. Previously, both fields were silently dropped during validation because they were not declared in the schema.

--- a/packages/starlight/__tests__/basics/pagefind.test.ts
+++ b/packages/starlight/__tests__/basics/pagefind.test.ts
@@ -1,7 +1,8 @@
 import { fileURLToPath } from 'node:url';
-import { afterEach, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import * as pagefind from 'pagefind';
 import { starlightPagefind } from '../../integrations/pagefind';
+import { PagefindConfigSchema } from '../../schemas/pagefind';
 import { TestAstroIntegrationLogger } from '../test-plugin-utils';
 
 vi.mock('pagefind');
@@ -66,4 +67,53 @@ test('logs Pagefind errors and closes Pagefind', async () => {
 	expect(logger.error).toHaveBeenCalledWith(`Pagefind error: ${errorMessage}`);
 
 	expect(pagefind.close).toHaveBeenCalled();
+});
+
+describe('PagefindConfigSchema ranking weights', () => {
+	const schema = PagefindConfigSchema();
+
+	// Regression coverage for https://github.com/withastro/starlight/issues/3912 —
+	// the schema previously omitted `diacriticSimilarity` (Pagefind v1.2.0) and
+	// `metaWeights` (Pagefind v1.4.0), so those options were silently stripped
+	// during validation and never reached Pagefind.
+
+	test('accepts diacriticSimilarity as a non-negative number', () => {
+		const config = schema.parse({ ranking: { diacriticSimilarity: 0.5 } });
+		expect(config.ranking.diacriticSimilarity).toBe(0.5);
+
+		const zero = schema.parse({ ranking: { diacriticSimilarity: 0 } });
+		expect(zero.ranking.diacriticSimilarity).toBe(0);
+	});
+
+	test('accepts metaWeights as a record of string to number', () => {
+		const config = schema.parse({ ranking: { metaWeights: { title: 5, description: 2 } } });
+		expect(config.ranking.metaWeights).toEqual({ title: 5, description: 2 });
+	});
+
+	test('preserves defaults for existing ranking fields when only new fields are set', () => {
+		const config = schema.parse({ ranking: { diacriticSimilarity: 1 } });
+		expect(config.ranking.pageLength).toBe(0.1);
+		expect(config.ranking.termFrequency).toBe(0.1);
+		expect(config.ranking.termSaturation).toBe(2);
+		expect(config.ranking.termSimilarity).toBe(9);
+		expect(config.ranking.diacriticSimilarity).toBe(1);
+	});
+
+	test('rejects diacriticSimilarity below 0', () => {
+		const result = schema.safeParse({ ranking: { diacriticSimilarity: -1 } });
+		expect(result.success).toBe(false);
+	});
+
+	test('rejects metaWeights with non-number values', () => {
+		const result = schema.safeParse({ ranking: { metaWeights: { title: 'high' } } });
+		expect(result.success).toBe(false);
+	});
+
+	test('still strips unknown ranking keys', () => {
+		const config = schema.parse({
+			ranking: { diacriticSimilarity: 0.5, unknownKey: 42 },
+		} as Parameters<typeof schema.parse>[0]);
+		expect('unknownKey' in config.ranking).toBe(false);
+		expect(config.ranking.diacriticSimilarity).toBe(0.5);
+	});
 });

--- a/packages/starlight/schemas/pagefind.ts
+++ b/packages/starlight/schemas/pagefind.ts
@@ -34,6 +34,26 @@ const pagefindRankingWeightsSchema = z.object({
 	 * @see https://pagefind.app/docs/ranking/#configuring-term-similarity
 	 */
 	termSimilarity: z.number().min(0).default(9),
+	/**
+	 * Set Pagefind’s `diacriticSimilarity` ranking option.
+	 *
+	 * Values must be greater than or equal to `0`. When unset, Pagefind applies
+	 * its built-in default.
+	 *
+	 * Available in Pagefind v1.2.0 or later.
+	 *
+	 * @see https://pagefind.app/docs/ranking/#configuring-diacritic-similarity
+	 */
+	diacriticSimilarity: z.number().min(0).optional(),
+	/**
+	 * Set Pagefind’s `metaWeights` ranking option to boost matches in specific
+	 * metadata fields (for example, `title` or `description`).
+	 *
+	 * Available in Pagefind v1.4.0 or later.
+	 *
+	 * @see https://pagefind.app/docs/ranking/#configuring-metadata-weights
+	 */
+	metaWeights: z.record(z.string(), z.number()).optional(),
 });
 const pagefindIndexOptionsSchema = z.object({
 	/**


### PR DESCRIPTION
Closes #3912.

## Problem

[`pagefindRankingWeightsSchema`](packages/starlight/schemas/pagefind.ts)
declares the four Pagefind ranking weights that existed before Pagefind
v1.2.0: `pageLength`, `termFrequency`, `termSaturation`, and
`termSimilarity`.

Pagefind has since added two more ranking options:

- `diacriticSimilarity` — Pagefind v1.2.0 ([docs](https://pagefind.app/docs/ranking/#configuring-diacritic-similarity))
- `metaWeights` — Pagefind v1.4.0 ([docs](https://pagefind.app/docs/ranking/#configuring-metadata-weights))

Because Zod's `z.object()` defaults to strip mode, those two fields are
silently dropped during config validation. The serialised config in the
build output never includes them, so setting them in `astro.config.mjs`
has no effect:

\`\`\`js
// astro.config.mjs
starlight({
  pagefind: {
    ranking: {
      metaWeights: { title: 5, description: 2 },
    },
  },
})
\`\`\`

\`\`\`js
// dist/_astro/Search.astro_*.js — metaWeights gone
{ranking:{pageLength:.1,termFrequency:.1,termSaturation:2,termSimilarity:9}}
\`\`\`

## Fix

Add both fields to `pagefindRankingWeightsSchema` as optional values, so
they pass schema validation and reach Pagefind:

- `diacriticSimilarity: z.number().min(0).optional()`
- `metaWeights: z.record(z.string(), z.number()).optional()`

Defaults are intentionally left to Pagefind itself. The schema mirrors
the API contract; Pagefind already applies its own defaults
(`diacriticSimilarity = 1.0`, `metaWeights = {}`) when the keys are
omitted. The change is backwards-compatible — existing configs are
unaffected.

JSDoc references the relevant Pagefind documentation pages and notes
the Pagefind version each field was added in.

## Tests

[\`packages/starlight/__tests__/basics/pagefind.test.ts\`](packages/starlight/__tests__/basics/pagefind.test.ts)
gains a new \`describe('PagefindConfigSchema ranking weights')\` block
covering both axes:

- **Positive** — `diacriticSimilarity` accepts non-negative numbers (`0`,
  `0.5`, `1`); `metaWeights` accepts `Record<string, number>`; existing
  ranking-field defaults are preserved when only the new fields are set.
- **Negative** — `diacriticSimilarity` is rejected for values `< 0`;
  `metaWeights` is rejected when a value is not a number; unknown keys
  inside `ranking` are still stripped so existing strip-by-default
  behaviour is preserved.

## Verification

\`\`\`
$ pnpm vitest run packages/starlight/__tests__/basics/pagefind.test.ts
 Test Files  1 passed (1)
      Tests  8 passed (8)

$ pnpm vitest run --project basics packages/starlight/__tests__/basics/pagefind.test.ts \
    packages/starlight/__tests__/basics/user-config.test.ts \
    packages/starlight/__tests__/basics/config.test.ts
 Test Files  3 passed (3)
      Tests  14 passed (14)
\`\`\`