### PR TITLE
Update Lunaria workflow Node.js version

### DIFF
--- a/.github/workflows/lunaria.yml
+++ b/.github/workflows/lunaria.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22.12.0
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/lunaria.yml
+++ b/.github/workflows/lunaria.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version: 22.22.3
           cache: pnpm
 
       - name: Install dependencies


### PR DESCRIPTION
#### Description

This PR bumps the Node.js version used in the Lunaria workflow to the latest Node.js 22 version [like in our other workflows](https://github.com/withastro/starlight/blob/main/.github/workflows/ci.yml#L16) instead of the specific `22.12.0` version.

We recently updated to pnpm 11 which requires Node.js 22.13 or higher and would [error out](https://github.com/withastro/starlight/actions/runs/26351811215/job/77571272653?pr=3918) with the following message when running the workflow:

```
ERROR: This version of pnpm requires at least Node.js v22.13
The current version of Node.js is v22.12.0
```