### PR TITLE
Use relative hero link in starter templates

### DIFF
--- a/examples/basics/src/content/docs/index.mdx
+++ b/examples/basics/src/content/docs/index.mdx
@@ -8,7 +8,7 @@ hero:
     file: ../../assets/houston.webp
   actions:
     - text: Example Guide
-      link: /guides/example/
+      link: ./guides/example/
       icon: right-arrow
     - text: Read the Starlight docs
       link: https://starlight.astro.build

--- a/examples/tailwind/src/content/docs/index.mdx
+++ b/examples/tailwind/src/content/docs/index.mdx
@@ -18,7 +18,7 @@ hero:
     file: ../../assets/houston.webp
   actions:
     - text: Example Guide
-      link: /guides/example/
+      link: ./guides/example/
       icon: right-arrow
     - text: Read the Starlight docs
       link: https://starlight.astro.build


### PR DESCRIPTION
Fixes broken links when deployed on a subpath.