### PR TITLE
Refactor `getCollectionPosixPath()`

### DIFF
--- a/.changeset/wet-signs-bake.md
+++ b/.changeset/wet-signs-bake.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Refactors internal file path handling for Starlight content collections.

--- a/packages/starlight/utils/collection-fs.ts
+++ b/packages/starlight/utils/collection-fs.ts
@@ -15,7 +15,6 @@ export function resolveCollectionPath(collection: StarlightCollection, srcDir: U
 }
 
 export function getCollectionPosixPath(collection: StarlightCollection, srcDir: URL) {
-	// TODO: when Astro minimum Node.js version is >= 20.13.0, refactor to use the `fileURLToPath`
-	// second optional argument to enforce POSIX paths by setting `windows: false`.
-	return fileURLToPath(getCollectionUrl(collection, srcDir)).replace(/\\/g, '/');
+	// Return POSIX path with leading slash even on Windows, e.g. `/C:/project/src/content/docs/`.
+	return fileURLToPath(getCollectionUrl(collection, srcDir), { windows: false });
 }


### PR DESCRIPTION
#### Description

While working on #3926, I stumbled upon a todo comment related to Node.js version that this PR addresses as the minimum Node.js version supported by Astro is now `22.12.0` and the `windows` option for `fileURLToPath()` is [available since `22.1.0`](https://nodejs.org/api/url.html#urlfileurltopathurl-options).