### PR TITLE
Add support for new Pagefind ranking options

### DIFF
--- a/.changeset/sharp-falcons-write.md
+++ b/.changeset/sharp-falcons-write.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Updates Pagefind to v1.5 and adds support for Pagefind’s new [`diacriticSimilarity`](https://pagefind.app/docs/ranking/#configuring-diacritic-similarity) and [`metaWeights`](https://pagefind.app/docs/ranking/#configuring-metadata-weights) advanced ranking options

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -510,12 +510,7 @@ Set `pagefind` to an object to configure the Pagefind search client:
 
 ```ts
 interface PagefindOptions {
-	ranking?: {
-		pageLength?: number;
-		termFrequency?: number;
-		termSaturation?: number;
-		termSimilarity?: number;
-	};
+	ranking?: PagefindRankingOptions;
 	indexWeight?: number;
 	mergeIndex?: Array<{
 		bundlePath: string;
@@ -524,13 +519,17 @@ interface PagefindOptions {
 		baseUrl?: string;
 		mergeFilter?: Record<string, string | string[]>;
 		language?: string;
-		ranking?: {
-			pageLength?: number;
-			termFrequency?: number;
-			termSaturation?: number;
-			termSimilarity?: number;
-		};
+		ranking?: PagefindRankingOptions;
 	}>;
+}
+
+interface PagefindRankingOptions {
+	pageLength?: number;
+	termFrequency?: number;
+	termSaturation?: number;
+	termSimilarity?: number;
+	diacriticSimilarity?: number;
+	metaWeights?: Record<string, number>;
 }
 ```
 

--- a/packages/starlight/__tests__/basics/config-errors.test.ts
+++ b/packages/starlight/__tests__/basics/config-errors.test.ts
@@ -69,6 +69,7 @@ test('parses bare minimum valid config successfully', () => {
 		  },
 		  "pagefind": {
 		    "ranking": {
+		      "diacriticSimilarity": 0.8,
 		      "pageLength": 0.1,
 		      "termFrequency": 0.1,
 		      "termSaturation": 2,

--- a/packages/starlight/package.json
+++ b/packages/starlight/package.json
@@ -79,7 +79,7 @@
     "mdast-util-directive": "^3.1.0",
     "mdast-util-to-markdown": "^2.1.2",
     "mdast-util-to-string": "^4.0.0",
-    "pagefind": "^1.3.0",
+    "pagefind": "^1.5.2",
     "rehype": "^13.0.2",
     "rehype-format": "^5.0.1",
     "remark-directive": "^4.0.0",

--- a/packages/starlight/schemas/pagefind.ts
+++ b/packages/starlight/schemas/pagefind.ts
@@ -1,6 +1,7 @@
 import { z } from 'astro/zod';
 
 const indexWeightSchema = z.number().nonnegative().optional();
+
 const pagefindRankingWeightsSchema = z.object({
 	/**
 	 * Set Pagefind’s `pageLength` ranking option.
@@ -34,7 +35,24 @@ const pagefindRankingWeightsSchema = z.object({
 	 * @see https://pagefind.app/docs/ranking/#configuring-term-similarity
 	 */
 	termSimilarity: z.number().min(0).default(9),
+	/**
+	 * Set Pagefind’s `diacriticSimilarity` ranking option.
+	 *
+	 * The default value is `0.8` and values must be greater than or equal to `0`.
+	 *
+	 * @see https://pagefind.app/docs/ranking/#configuring-diacritic-similarity
+	 */
+	diacriticSimilarity: z.number().min(0).default(0.8),
+	/**
+	 * Set Pagefind’s `metaWeights` ranking option.
+	 *
+	 * This is a map of metadata keys to their corresponding weights, with a default value of `{ title: 5 }`.
+	 *
+	 * @see https://pagefind.app/docs/ranking/#configuring-metadata-weights
+	 */
+	metaWeights: z.record(z.string(), z.number().min(0)).optional(),
 });
+
 const pagefindIndexOptionsSchema = z.object({
 	/**
 	 * Overrides the URL path that Pagefind uses to load its search bundle

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,8 +237,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       pagefind:
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.5.2
+        version: 1.5.2
       rehype:
         specifier: ^13.0.2
         version: 13.0.2
@@ -1078,31 +1078,41 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
-  '@pagefind/darwin-arm64@1.3.0':
-    resolution: {integrity: sha512-365BEGl6ChOsauRjyVpBjXybflXAOvoMROw3TucAROHIcdBvXk9/2AmEvGFU0r75+vdQI4LJdJdpH4Y6Yqaj4A==}
+  '@pagefind/darwin-arm64@1.5.2':
+    resolution: {integrity: sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pagefind/darwin-x64@1.3.0':
-    resolution: {integrity: sha512-zlGHA23uuXmS8z3XxEGmbHpWDxXfPZ47QS06tGUq0HDcZjXjXHeLG+cboOy828QIV5FXsm9MjfkP5e4ZNbOkow==}
+  '@pagefind/darwin-x64@1.5.2':
+    resolution: {integrity: sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==}
     cpu: [x64]
     os: [darwin]
 
   '@pagefind/default-ui@1.3.0':
     resolution: {integrity: sha512-CGKT9ccd3+oRK6STXGgfH+m0DbOKayX6QGlq38TfE1ZfUcPc5+ulTuzDbZUnMo+bubsEOIypm4Pl2iEyzZ1cNg==}
 
-  '@pagefind/linux-arm64@1.3.0':
-    resolution: {integrity: sha512-8lsxNAiBRUk72JvetSBXs4WRpYrQrVJXjlRRnOL6UCdBN9Nlsz0t7hWstRk36+JqHpGWOKYiuHLzGYqYAqoOnQ==}
+  '@pagefind/freebsd-x64@1.5.2':
+    resolution: {integrity: sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@pagefind/linux-arm64@1.5.2':
+    resolution: {integrity: sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==}
     cpu: [arm64]
     os: [linux]
 
-  '@pagefind/linux-x64@1.3.0':
-    resolution: {integrity: sha512-hAvqdPJv7A20Ucb6FQGE6jhjqy+vZ6pf+s2tFMNtMBG+fzcdc91uTw7aP/1Vo5plD0dAOHwdxfkyw0ugal4kcQ==}
+  '@pagefind/linux-x64@1.5.2':
+    resolution: {integrity: sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==}
     cpu: [x64]
     os: [linux]
 
-  '@pagefind/windows-x64@1.3.0':
-    resolution: {integrity: sha512-BR1bIRWOMqkf8IoU576YDhij1Wd/Zf2kX/kCI0b2qzCKC8wcc2GQJaaRMCpzvCCrmliO4vtJ6RITp/AnoYUUmQ==}
+  '@pagefind/windows-arm64@1.5.2':
+    resolution: {integrity: sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pagefind/windows-x64@1.5.2':
+    resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
     cpu: [x64]
     os: [win32]
 
@@ -3003,8 +3013,8 @@ packages:
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
-  pagefind@1.3.0:
-    resolution: {integrity: sha512-8KPLGT5g9s+olKMRTU9LFekLizkVIu9tes90O1/aigJ0T5LmyPqTzGJrETnSw3meSYg58YH7JTzhTTW/3z6VAw==}
+  pagefind@1.5.2:
+    resolution: {integrity: sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==}
     hasBin: true
 
   parse-entities@4.0.1:
@@ -4778,21 +4788,27 @@ snapshots:
 
   '@oslojs/encoding@1.1.0': {}
 
-  '@pagefind/darwin-arm64@1.3.0':
+  '@pagefind/darwin-arm64@1.5.2':
     optional: true
 
-  '@pagefind/darwin-x64@1.3.0':
+  '@pagefind/darwin-x64@1.5.2':
     optional: true
 
   '@pagefind/default-ui@1.3.0': {}
 
-  '@pagefind/linux-arm64@1.3.0':
+  '@pagefind/freebsd-x64@1.5.2':
     optional: true
 
-  '@pagefind/linux-x64@1.3.0':
+  '@pagefind/linux-arm64@1.5.2':
     optional: true
 
-  '@pagefind/windows-x64@1.3.0':
+  '@pagefind/linux-x64@1.5.2':
+    optional: true
+
+  '@pagefind/windows-arm64@1.5.2':
+    optional: true
+
+  '@pagefind/windows-x64@1.5.2':
     optional: true
 
   '@playwright/test@1.59.1':
@@ -7209,13 +7225,15 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
-  pagefind@1.3.0:
+  pagefind@1.5.2:
     optionalDependencies:
-      '@pagefind/darwin-arm64': 1.3.0
-      '@pagefind/darwin-x64': 1.3.0
-      '@pagefind/linux-arm64': 1.3.0
-      '@pagefind/linux-x64': 1.3.0
-      '@pagefind/windows-x64': 1.3.0
+      '@pagefind/darwin-arm64': 1.5.2
+      '@pagefind/darwin-x64': 1.5.2
+      '@pagefind/freebsd-x64': 1.5.2
+      '@pagefind/linux-arm64': 1.5.2
+      '@pagefind/linux-x64': 1.5.2
+      '@pagefind/windows-arm64': 1.5.2
+      '@pagefind/windows-x64': 1.5.2
 
   parse-entities@4.0.1:
     dependencies:


### PR DESCRIPTION

#### Description

- Closes #3912 <!-- Add an issue number if this PR will close it. -->
- Closes #3916
- Updates the minimum version of Pagefind bundled with Starlight to 1.5.2
- Adds support for the new ranking options added in Pagefind v1.5
- In the end I decided **not** to make the config a `z.looseObject()` as discussed in https://github.com/withastro/starlight/issues/3912#issuecomment-4542875076. The issue with loose objects is you don’t get as good feedback for typos and I think maybe new properties are rare enough that we can keep up-to-date while providing clear diagnostics for people who typo a key name?