### PR TITLE
Fix typo, improve readability

### DIFF
--- a/docs/src/content/docs/de/guides/css-and-tailwind.mdx
+++ b/docs/src/content/docs/de/guides/css-and-tailwind.mdx
@@ -7,7 +7,7 @@ import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
 Du kannst deine Starlight-Website mit benutzerdefinierten CSS-Dateien gestalten oder das Starlight Tailwind-Plugin verwenden.
 
-Eine schnelle Möglichkeit, das Standardtheme deiner Website zu ändern, findest du unter [Cummunity-Themes](/de/resources/themes/).
+Wenn Du nach einer schnellen Möglichkeit suchst, das standardmäßige Aussehen deiner Website abzuändern, dann schau Dir die [Community-Themes](/de/resources/themes/) an.
 
 ## Benutzerdefinierte CSS-Styles (Stile)
 
@@ -79,7 +79,7 @@ Das Starlight Tailwind CSS wendet die folgende Konfiguration an:
 
 ### Erstelle ein neues Projekt mit Tailwind
 
-Starte ein neues Starlight-Projekt mit Tailwind CSS vorkonfiguriert, indem du `create astro` verwendest:
+Starte ein neues, mit Tailwind CSS vorkonfiguriertes Starlight-Projekt, indem du `create astro` verwendest:
 
 <Tabs syncKey="pkg">
 <TabItem label="npm">
@@ -107,7 +107,7 @@ yarn create astro --template starlight/tailwind
 
 ### Tailwind zu einem bestehenden Projekt hinzufügen
 
-Wenn du bereits eine Starlight-Website hast und Tailwind CSS hinzufügen möchtest, folge dieser Anleitung.
+Wenn dir bereits eine Starlight-Website vorliegt und Tailwind CSS hinzufügen möchtest, folge dieser Anleitung.
 
 <Steps>
 


### PR DESCRIPTION
This PR fixes a typo I spotted in the first place:

```
Cummunity-Themes -> Community-Themes
```

It also makes minor changes to 3 sentences to improve their readability.
