### PR TITLE
Improve Sätteri import comment

### DIFF
--- a/packages/starlight/integrations/markdown-plugins.ts
+++ b/packages/starlight/integrations/markdown-plugins.ts
@@ -5,9 +5,10 @@ import type { MarkdownProcessorPluginOptions } from './markdown-process';
 import { starlightRehypePlugins, starlightRemarkPlugins } from './remark-rehype';
 
 // This file is imported by the Starlight integration that is used in Astro configuration files.
-// Astro loads its configuration using a temporary Vite module runner and closes it before running
-// integration hooks. If this dynamic import is started later from an integration hook, Vite tries
-// to resolve it through that closed runner and throw "Vite module runner has been closed".
+// When using Starlight, Astro loads its configuration using a temporary Vite module runner and
+// closes it before running integration hooks. If this dynamic import is started later from an
+// integration hook, Vite tries to resolve it through that closed runner and throw "Vite module
+// runner has been closed".
 // We start loading `./satteri` at the top level so Vite waits for it to resolve or fail while the
 // config runner is still running. This keeps the Sätteri integration optional as when
 // `@astrojs/markdown-satteri` is not installed, importing `./satteri` rejects and we resolve to it

--- a/packages/starlight/integrations/markdown-plugins.ts
+++ b/packages/starlight/integrations/markdown-plugins.ts
@@ -4,8 +4,14 @@ import { remarkDirectivesRestoration } from './asides';
 import type { MarkdownProcessorPluginOptions } from './markdown-process';
 import { starlightRehypePlugins, starlightRemarkPlugins } from './remark-rehype';
 
-// For some reason, trying to `await import("./satteri")` in the integration module causes a Vite
-// error about the module runner being closed. This shape works, not sure why!
+// This file is imported by the Starlight integration that is used in Astro configuration files.
+// Astro loads its configuration using a temporary Vite module runner and closes it before running
+// integration hooks. If this dynamic import is started later from an integration hook, Vite tries
+// to resolve it through that closed runner and throw "Vite module runner has been closed".
+// We start loading `./satteri` at the top level so Vite waits for it to resolve or fail while the
+// config runner is still running. This keeps the Sätteri integration optional as when
+// `@astrojs/markdown-satteri` is not installed, importing `./satteri` rejects and we resolve to it
+// `null`, which is later used to detect if Sätteri support is available or not.
 export const satteriIntegration = import('./satteri').catch(() => null);
 
 type SatteriIntegration = Awaited<typeof satteriIntegration>;


### PR DESCRIPTION
#### Description

Follow-up to https://github.com/withastro/starlight/pull/3923#discussion_r3380597541, this PR improves the comment describing how we import the Sätteri integration to workaround an Astro limitation.

The comment should be clear enough to explain the issue and the workaround. Regarding a potential fix in Astro for the underlying issue, I would definitelly need to think more about it. So far, the only idea I had is to have the Vite module runner used for loading the config to stay open instead of closing immediately, and return some kind of disposable. The disposable would be used to properly close it only when needed, e.g. after a build or when the dev server is closed, when the dev server is restarted, after a sync, etc. The `getViteConfig()` case would also need to be handled. On top of the extra cost of keeping the module runner open, it's also a lot of orchestration to pass around such disposable with the current architecture.

A workaround that I only briefly tested for fun is to by-pass Vite and rely on a native dynamic import to load `@astrojs/markdown-satteri`, e.g. using `() => new Function('return import("@astrojs/markdown-satteri")')` but that's definitely not something we want to do (even tho it seems to work) :sweat_smile: