### PR TITLE
i18n(de): bring outdated pages up to date

### DIFF
--- a/docs/src/content/docs/de/guides/authoring-content.mdx
+++ b/docs/src/content/docs/de/guides/authoring-content.mdx
@@ -561,7 +561,7 @@ Starlight unterstützt alle anderen Markdown-Autorensyntaxen, wie Listen und Tab
 
 ## Erweiterte Markdown- und MDX-Konfiguration
 
-Starlight verwendet Astros Markdown- und MDX-Renderer, der auf remark und rehype aufbaut. Du kannst eine Unterstützung für eigene Syntax und Verhalten hinzufügen, indem du `remarkPlugins` oder `rehypePlugins` in deiner Astro-Konfigurationsdatei hinzufügst. Weitere Informationen findest du unter ["Markdown konfigurieren"](https://docs.astro.build/de/guides/markdown-content/#markdown-plugins) in der Astro-Dokumentation.
+Starlight nutzt zum Rendern von Markdown- und MDX-Seiten Astros konfigurierbaren [Markdown-Prozessor](https://docs.astro.build/en/reference/configuration-reference/#markdownprocessor). Du kannst eine Unterstützung für eigene Syntax und Verhalten hinzufügen, indem du Plugins und Optionen an den konfigurierten Prozessor weiterreichst. Weitere Informationen findest du unter ["Markdown Plugins"](https://docs.astro.build/de/guides/markdown-content/#markdown-plugins) in der Astro-Dokumentation.
 
 ## Markdoc
 

--- a/docs/src/content/docs/de/reference/configuration.mdx
+++ b/docs/src/content/docs/de/reference/configuration.mdx
@@ -512,12 +512,7 @@ Setze `pagefind` auf ein Objekt, um den Pagefind-Suchclient zu konfigurieren:
 
 ```ts
 interface PagefindOptions {
-	ranking?: {
-		pageLength?: number;
-		termFrequency?: number;
-		termSaturation?: number;
-		termSimilarity?: number;
-	};
+	ranking?: PagefindRankingOptions;
 	indexWeight?: number;
 	mergeIndex?: Array<{
 		bundlePath: string;
@@ -526,13 +521,17 @@ interface PagefindOptions {
 		baseUrl?: string;
 		mergeFilter?: Record<string, string | string[]>;
 		language?: string;
-		ranking?: {
-			pageLength?: number;
-			termFrequency?: number;
-			termSaturation?: number;
-			termSimilarity?: number;
-		};
+		ranking?: PagefindRankingOptions;
 	}>;
+}
+
+interface PagefindRankingOptions {
+	pageLength?: number;
+	termFrequency?: number;
+	termSaturation?: number;
+	termSimilarity?: number;
+	diacriticSimilarity?: number;
+	metaWeights?: Record<string, number>;
 }
 ```
 


### PR DESCRIPTION
This PR brings two outdated German documentation pages up-to-date:

- `docs/src/content/docs/de/guides/authoring-content.mdx`
- `docs/src/content/docs/de/reference/configuration.mdx`