### PR TITLE
Add link to Astro install and setup guide on manual setup page

### DIFF
--- a/docs/src/content/docs/manual-setup.mdx
+++ b/docs/src/content/docs/manual-setup.mdx
@@ -10,7 +10,7 @@ If you want to add Starlight to an existing Astro project, this guide will expla
 
 ## Set up Starlight
 
-To follow this guide, you’ll need an existing Astro project.
+To follow this guide, you’ll need an [existing Astro project](https://docs.astro.build/en/install-and-setup/).
 
 ### Add the Starlight integration
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

EDIT: I removed the "fixes (issue number)", as that is a redirect issue and will be addressed separately (#3957).

I was doing a manual setup with an existing project to add Starlight. I first noticed the broken link for integrations, which this PR addresses. I also found I needed to setup Astro first, but there wasn't a link to it in the document.

This PR:
- ~~fixes the broken link for the integrations page on the manual setup page~~
- adds a link to the manual setup for Astro in the neighboring content
- ~~makes these changes across all translations with a manual-setup.mdx page~~

I made these changes by hand, but relied on AI to identify the correct text to update for adding the manual setup for Astro link. I checked with translation tools and they look correct, but I cannot say I have 100% confidence the added link encapsulates the correct text perfectly across all languages. I have tested this locally.

This is my first contribution to Astro - let me know if you have any suggestions. I can always remove the added link for Manual Setup of Astro if desired. I realize a discussion may have been warranted for that type of improvement.



