### PR TITLE
docs: add starlight-md-txt plugin

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -124,11 +124,6 @@ Extend your site with official plugins supported by the Starlight team and commu
 		description="Add llms.txt to your documentation site based on llmstxt.org."
 	/>
 	<LinkCard
-		href="https://github.com/maxostapenko/starlight-md-txt"
-		title="starlight-md-txt"
-		description="Expose your Starlight documentation pages as raw, agent-friendly Markdown at .md.txt URLs."
-	/>
-	<LinkCard
 		href="https://github.com/trueberryless-org/starlight-toc-overview-customizer"
 		title="starlight-toc-overview-customizer"
 		description="Tweak Starlight’s table of contents with customizable overview title."
@@ -321,5 +316,10 @@ These community tools and integrations can be used to add features to your Starl
 		href="https://github.com/trueberryless-org/starlight-contributor-list"
 		title="starlight-contributor-list"
 		description="Display a list of all contributors to your project."
+	/>
+	<LinkCard
+		href="https://github.com/max-ostapenko/starlight-md-txt"
+		title="starlight-md-txt"
+		description="Expose your Starlight documentation pages as raw, agent-friendly Markdown at .md.txt URLs."
 	/>
 </CardGrid>

--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -124,6 +124,11 @@ Extend your site with official plugins supported by the Starlight team and commu
 		description="Add llms.txt to your documentation site based on llmstxt.org."
 	/>
 	<LinkCard
+		href="https://github.com/maxostapenko/starlight-md-txt"
+		title="starlight-md-txt"
+		description="Expose your Starlight documentation pages as raw, agent-friendly Markdown at .md.txt URLs."
+	/>
+	<LinkCard
 		href="https://github.com/trueberryless-org/starlight-toc-overview-customizer"
 		title="starlight-toc-overview-customizer"
 		description="Tweak Starlight’s table of contents with customizable overview title."


### PR DESCRIPTION
Adds the starlight-md-txt plugin to the community plugins list. starlight-md-txt allows exposing documentation pages as raw, agent-friendly Markdown at .md.txt URLs.