### PR TITLE
Use canonical /integrations/ URL on manual setup page

### DIFF
--- a/docs/src/content/docs/de/manual-setup.mdx
+++ b/docs/src/content/docs/de/manual-setup.mdx
@@ -14,7 +14,7 @@ Um dieser Anleitung folgen zu können, benötigst du ein bestehendes Astro-Proje
 
 ### Hinzufügen der Starlight-Integration
 
-Starlight ist eine [Astro-Integration](https://docs.astro.build/de/guides/integrations-guide/). Füge sie zu deiner Website hinzu, indem du den Befehl `astro add` im Projektstamm&shy;verzeichnis deines Projekts ausführst:
+Starlight ist eine [Astro-Integration](https://docs.astro.build/de/guides/integrations/). Füge sie zu deiner Website hinzu, indem du den Befehl `astro add` im Projektstamm&shy;verzeichnis deines Projekts ausführst:
 
 <Tabs syncKey="pkg">
     <TabItem label="npm">

--- a/docs/src/content/docs/es/manual-setup.mdx
+++ b/docs/src/content/docs/es/manual-setup.mdx
@@ -14,7 +14,7 @@ Para seguir esta guía, necesitarás un proyecto de Astro existente.
 
 ### Agregando la integración de Starlight
 
-Starlight es una [integración de Astro](https://docs.astro.build/es/guides/integrations-guide/). Agregala a tu sitio ejecutando el comando `astro add` en el directorio raíz de tu proyecto:
+Starlight es una [integración de Astro](https://docs.astro.build/es/guides/integrations/). Agregala a tu sitio ejecutando el comando `astro add` en el directorio raíz de tu proyecto:
 
 <Tabs syncKey="pkg">
     <TabItem label="npm">

--- a/docs/src/content/docs/fr/manual-setup.mdx
+++ b/docs/src/content/docs/fr/manual-setup.mdx
@@ -14,7 +14,7 @@ Pour suivre ce guide, vous aurez besoin d'un projet Astro existant.
 
 ### Ajouter l'intégration Starlight
 
-Starlight est une [intégration Astro](https://docs.astro.build/fr/guides/integrations-guide/). Ajoutez-la à votre site en exécutant la commande `astro add` dans le répertoire racine de votre projet :
+Starlight est une [intégration Astro](https://docs.astro.build/fr/guides/integrations/). Ajoutez-la à votre site en exécutant la commande `astro add` dans le répertoire racine de votre projet :
 
 <Tabs syncKey="pkg">
     <TabItem label="npm">

--- a/docs/src/content/docs/ja/manual-setup.mdx
+++ b/docs/src/content/docs/ja/manual-setup.mdx
@@ -13,7 +13,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ### Starlightインテグレーションの追加
 
-Starlightは[Astroのインテグレーション](https://docs.astro.build/ja/guides/integrations-guide/)です。プロジェクトのルートディレクトリで`astro add`コマンドを実行してサイトに追加します。
+Starlightは[Astroのインテグレーション](https://docs.astro.build/ja/guides/integrations/)です。プロジェクトのルートディレクトリで`astro add`コマンドを実行してサイトに追加します。
 
 <Tabs syncKey="pkg">
     <TabItem label="npm">

--- a/docs/src/content/docs/ko/manual-setup.mdx
+++ b/docs/src/content/docs/ko/manual-setup.mdx
@@ -13,7 +13,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ### Starlight 통합 추가
 
-Starlight는 [Astro 통합](https://docs.astro.build/ko/guides/integrations-guide/)입니다. 사이트에 이를 추가하기 위해 프로젝트의 루트 디렉터리에서 `astro add` 명령을 실행하세요.
+Starlight는 [Astro 통합](https://docs.astro.build/ko/guides/integrations/)입니다. 사이트에 이를 추가하기 위해 프로젝트의 루트 디렉터리에서 `astro add` 명령을 실행하세요.
 
 <Tabs syncKey="pkg">
     <TabItem label="npm">

--- a/docs/src/content/docs/manual-setup.mdx
+++ b/docs/src/content/docs/manual-setup.mdx
@@ -14,7 +14,7 @@ To follow this guide, you’ll need an [existing Astro project](https://docs.ast
 
 ### Add the Starlight integration
 
-Starlight is an [Astro integration](https://docs.astro.build/en/guides/integrations-guide/). Add it to your site by running the `astro add` command in your project’s root directory:
+Starlight is an [Astro integration](https://docs.astro.build/en/guides/integrations/). Add it to your site by running the `astro add` command in your project’s root directory:
 
 <Tabs syncKey="pkg">
     <TabItem label="npm">

--- a/docs/src/content/docs/ru/manual-setup.mdx
+++ b/docs/src/content/docs/ru/manual-setup.mdx
@@ -14,7 +14,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ### Интеграция Starlight
 
-Starlight является [интеграцией Astro](https://docs.astro.build/ru/guides/integrations-guide/). Добавьте её на ваш сайт, запустив команду `astro add` в корневой директории вашего проекта:
+Starlight является [интеграцией Astro](https://docs.astro.build/ru/guides/integrations/). Добавьте её на ваш сайт, запустив команду `astro add` в корневой директории вашего проекта:
 
 <Tabs syncKey="pkg">
     <TabItem label="npm">

--- a/docs/src/content/docs/zh-cn/manual-setup.mdx
+++ b/docs/src/content/docs/zh-cn/manual-setup.mdx
@@ -14,7 +14,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ### 添加 Starlight 集成
 
-Starlight 是一个 [Astro 集成](https://docs.astro.build/zh-cn/guides/integrations-guide/)。通过在项目的根目录中运行 `astro add` 命令将其添加到你的站点中：
+Starlight 是一个 [Astro 集成](https://docs.astro.build/zh-cn/guides/integrations/)。通过在项目的根目录中运行 `astro add` 命令将其添加到你的站点中：
 
 <Tabs syncKey="pkg">
     <TabItem label="npm">


### PR DESCRIPTION
Fixes #3957.

The link to the Astro "integrations" reference on the manual setup page was pointing at the legacy `/guides/integrations-guide/` path. That path was returning 404 due to a broken redirect in the Astro docs site.

The redirect itself has now been fixed upstream in [withastro/docs#14069](https://github.com/withastro/docs/pull/14069), so the existing link works again. This PR goes one step further and switches the link to the canonical `/guides/integrations/` URL so Starlight no longer depends on that redirect staying healthy.

## Changes

- `docs/src/content/docs/manual-setup.mdx` and the `de`, `es`, `fr`, `ja`, `ko`, `ru`, and `zh-cn` translations: the "Starlight is an Astro integration" link now uses `/<lang>/guides/integrations/` directly.

## Notes

- The Cloudflare adapter link on the same page (`/guides/integrations-guide/cloudflare/`) was checked and is the actual canonical URL for that page, not a redirect — left unchanged.
- The `uk` translation was intentionally skipped. `docs.astro.build/uk/guides/integrations/` does not exist yet (404), and the current file already links Astro docs at the `/en/` prefix as a fallback. Fixing that is a separate translation gap.
- `pnpm linkcheck` passes locally (592 pages built, all internal links valid). No changeset needed per `CONTRIBUTING.md` (docs-only change).
