### PR TITLE
[search] run onPageLoad also for Astro view transition

### DIFF
--- a/packages/starlight/components/Search.astro
+++ b/packages/starlight/components/Search.astro
@@ -60,7 +60,12 @@ if (project.trailingSlash === 'never') dataAttributes['data-strip-trailing-slash
 	 */
 }
 <script is:inline>
-	(() => {
+{
+	const onPageLoad = () => {
+		if (!shortcut.style.display) {
+			// Avoid running twice for the initial load
+			return;
+		}
 		const openBtn = document.querySelector('button[data-open-modal]');
 		const shortcut = openBtn?.querySelector('kbd');
 		if (!openBtn || !(shortcut instanceof HTMLElement)) return;
@@ -70,7 +75,11 @@ if (project.trailingSlash === 'never') dataAttributes['data-strip-trailing-slash
 			openBtn.setAttribute('aria-keyshortcuts', 'Meta+K');
 		}
 		shortcut.style.display = '';
-	})();
+	});
+
+	onPageLoad(); // For regular page loads
+	document.addEventListener("astro:page-load", onPageLoad); // For Astro's View Transition system
+}
 </script>
 
 <script>

--- a/packages/starlight/components/Search.astro
+++ b/packages/starlight/components/Search.astro
@@ -62,20 +62,20 @@ if (project.trailingSlash === 'never') dataAttributes['data-strip-trailing-slash
 <script is:inline>
 {
 	const onPageLoad = () => {
+		const openBtn = document.querySelector('button[data-open-modal]');
+		const shortcut = openBtn?.querySelector('kbd');
+		if (!openBtn || !(shortcut instanceof HTMLElement)) return;
 		if (!shortcut.style.display) {
 			// Avoid running twice for the initial load
 			return;
 		}
-		const openBtn = document.querySelector('button[data-open-modal]');
-		const shortcut = openBtn?.querySelector('kbd');
-		if (!openBtn || !(shortcut instanceof HTMLElement)) return;
 		const platformKey = shortcut.querySelector('kbd');
 		if (platformKey && /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)) {
 			platformKey.textContent = '⌘';
 			openBtn.setAttribute('aria-keyshortcuts', 'Meta+K');
 		}
 		shortcut.style.display = '';
-	});
+	};
 
 	onPageLoad(); // For regular page loads
 	document.addEventListener("astro:page-load", onPageLoad); // For Astro's View Transition system


### PR DESCRIPTION
#### Description

- Closes #3975
- Runs the same fn as before, but instead of just at page load, we run it for both the regular page load, and the virtual page loads related to View Transition

Before | After
-|-
<video src="https://github.com/user-attachments/assets/bc0a5074-1171-48ba-918a-aeab8f3d8e3a"> | <video src="https://github.com/user-attachments/assets/0b1f6250-fbea-4a20-a702-d14b90071b26">





