### PR TITLE
Add Axiom Studio for Starlight to community tools

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -322,4 +322,9 @@ These community tools and integrations can be used to add features to your Starl
 		title="starlight-md-txt"
 		description="Expose your Starlight documentation pages as raw, agent-friendly Markdown at .md.txt URLs."
 	/>
+<LinkCard
+		href="https://agcttr.gumroad.com/l/axiom-studio-for-starlight"
+		title="Axiom Studio for Starlight"
+		description="A local-first browser editor for editing Markdown and MDX pages, managing frontmatter, and previewing Starlight docs without touching raw files."
+	/>
 </CardGrid>

--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -323,7 +323,7 @@ These community tools and integrations can be used to add features to your Starl
 		description="Expose your Starlight documentation pages as raw, agent-friendly Markdown at .md.txt URLs."
 	/>
 <LinkCard
-		href="https://agcttr.gumroad.com/l/axiom-studio-for-starlight"
+		href="https://github.com/pixelizing/axiom-studio-for-starlight"
 		title="Axiom Studio for Starlight"
 		description="A local-first browser editor for editing Markdown and MDX pages, managing frontmatter, and previewing Starlight docs without touching raw files."
 	/>


### PR DESCRIPTION
#### Description

- **What does this PR change? Give us a brief description.**
Hey everyone! 👋 I recently spent a couple of weeks building a local-first browser editor for Starlight called **Axiom Studio**. I originally built it to make my own MDX and frontmatter editing workflow easier and safer without needing any external CMS or database. 

Thought it might be useful for other indie makers and developers in the Astro ecosystem, so I added it to the community tools list in `plugins.mdx`. (I also included a short demo video on the link if you're curious to see how the local editing actually works in action). Let me know if the format looks good!

- **Did you change something visual? A before/after screenshot can be helpful.**
Nope, no visual changes to the docs themselves. Just added the new `<LinkCard>` to the bottom of the grid.