### PR TITLE
i18n(de): update manual-setup.mdx

### DIFF
--- a/docs/src/content/docs/de/manual-setup.mdx
+++ b/docs/src/content/docs/de/manual-setup.mdx
@@ -10,7 +10,7 @@ Wie du Starlight zu einem bestehenden Astro-Projekt hinzufügst, wird in dieser 
 
 ## Starlight einrichten
 
-Um dieser Anleitung folgen zu können, benötigst du ein bestehendes Astro-Projekt.
+Um dieser Anleitung folgen zu können, benötigst du ein [bestehendes Astro-Projekt](https://docs.astro.build/de/install-and-setup/).
 
 ### Hinzufügen der Starlight-Integration
 


### PR DESCRIPTION
#### Description

This PR updates the German translation of `manual-setup.mdx` with the changes from #3958.
I decided to link to the `/de` route alto it is not translated in Astro docs yet, but if we will ever translate it (😅), we don't need to update it here. And currently, the English version is shown as fallback.