### PR TITLE
Remove 'starlight-utils' LinkCard from plugins documentation

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -59,11 +59,6 @@ Extend your site with official plugins supported by the Starlight team and commu
 		description="Add zoom capabilities to your documentation images."
 	/>
 	<LinkCard
-		href="https://github.com/lorenzolewis/starlight-utils"
-		title="starlight-utils"
-		description="Extend Starlight with a collection of common utilities."
-	/>
-	<LinkCard
 		href="https://github.com/trueberryless/starlight-view-modes"
 		title="starlight-view-modes"
 		description="Add different view mode capabilities to your documentation website."


### PR DESCRIPTION
Removed the LinkCard for 'starlight-utils' from the documentation as I no longer have time to maintain this (and it's very out of date). In the documentation site I offer some alternatives for the functionality that this package included.