### PR TITLE
i18n(fr): update `resources/plugins.mdx`

### DIFF
--- a/docs/src/content/docs/fr/resources/plugins.mdx
+++ b/docs/src/content/docs/fr/resources/plugins.mdx
@@ -59,11 +59,6 @@ Les [modules d'extension](/fr/reference/plugins/) peuvent personnaliser la confi
 		description="Ajouter des fonctionnalités de zoom aux images de votre documentation."
 	/>
 	<LinkCard
-		href="https://github.com/lorenzolewis/starlight-utils"
-		title="starlight-utils"
-		description="Étendre Starlight avec une collection d'utilitaires courants."
-	/>
-	<LinkCard
 		href="https://github.com/trueberryless/starlight-view-modes"
 		title="starlight-view-modes"
 		description="Ajouter différents modes d'affichage à votre site web de documentation."
@@ -316,5 +311,15 @@ Ces outils et intégrations communautaires peuvent être utilisés pour ajouter 
 		href="https://github.com/trueberryless-org/starlight-contributor-list"
 		title="starlight-contributor-list"
 		description="Afficher la liste de tous les contributeurs de votre projet."
+	/>
+	<LinkCard
+		href="https://github.com/max-ostapenko/starlight-md-txt"
+		title="starlight-md-txt"
+		description="Exposer vos pages de documentation Starlight sous forme de Markdown brut adapté aux agents, via des URL se terminant par .md.txt."
+	/>
+	<LinkCard
+		href="https://github.com/pixelizing/axiom-studio-for-starlight"
+		title="Axiom Studio pour Starlight"
+		description="Un éditeur dans le navigateur fonctionnant localement pour modifier les pages Markdown et MDX, gérer le frontmatter et prévisualiser la documentation Starlight sans toucher aux fichiers sources."
 	/>
 </CardGrid>

--- a/docs/src/content/docs/fr/resources/plugins.mdx
+++ b/docs/src/content/docs/fr/resources/plugins.mdx
@@ -320,6 +320,6 @@ Ces outils et intégrations communautaires peuvent être utilisés pour ajouter 
 	<LinkCard
 		href="https://github.com/pixelizing/axiom-studio-for-starlight"
 		title="Axiom Studio pour Starlight"
-		description="Un éditeur dans le navigateur fonctionnant localement pour modifier les pages Markdown et MDX, gérer le frontmatter et prévisualiser la documentation Starlight sans toucher aux fichiers sources."
+		description="Un éditeur fonctionnant localement dans le navigateur pour modifier les pages Markdown et MDX, gérer le frontmatter et prévisualiser la documentation Starlight sans toucher aux fichiers sources."
 	/>
 </CardGrid>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description


<!-- New features should first be discussed and approved by maintainers in GitHub or Discord discussions. -->
<!-- If this PR adds a new public-facing feature, uncomment the line below and include a link to the relevant discussion. -->
<!-- - [x] This PR adds a new feature which has been discussed and approved [here](link to GitHub or Discord discussion). -->

Adds changes from #3964, #3993, and #3997 to the French translation of `resources/plugins.mdx`.

I tweaked a bit the translation for "local-first browser editor" (ie. "fonctionnant localement dans le navigateur" instead of something like "éditeur dans le navigateur privilégiant le fonctionnement en local" even if it could be more accurate) to shorten the card:
<img width="748" height="229" alt="" src="https://github.com/user-attachments/assets/cf5d46a6-e0eb-4b04-9e4a-3127f0d8a0f3" />


<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
