### PR TITLE
fix(css): prevent TOC overflow with custom --sl-content-width

### DIFF
--- a/.changeset/fix-toc-overflow-custom-width.md
+++ b/.changeset/fix-toc-overflow-custom-width.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fix TOC overflowing the right edge of the viewport when a custom `--sl-content-width` value exceeds available space

--- a/.changeset/fix-toc-overflow-custom-width.md
+++ b/.changeset/fix-toc-overflow-custom-width.md
@@ -2,4 +2,4 @@
 "@astrojs/starlight": patch
 ---
 
-Fix TOC overflowing the right edge of the viewport when a custom `--sl-content-width` value exceeds available space
+Fixes the table of contents overflowing the right edge of the viewport when a custom `--sl-content-width` value exceeds available space

--- a/packages/starlight/components/TwoColumnContent.astro
+++ b/packages/starlight/components/TwoColumnContent.astro
@@ -21,8 +21,9 @@
 			.right-sidebar-container {
 				order: 2;
 				position: relative;
-				width: calc(
-					var(--sl-sidebar-width) + (100% - var(--sl-content-width) - var(--sl-sidebar-width)) / 2
+				width: max(
+					var(--sl-sidebar-width),
+					calc(var(--sl-sidebar-width) + (100% - var(--sl-content-width) - var(--sl-sidebar-width)) / 2)
 				);
 			}
 
@@ -45,8 +46,9 @@
 				--sl-content-margin-inline: auto 0;
 
 				order: 1;
-				width: calc(
-					var(--sl-content-width) + (100% - var(--sl-content-width) - var(--sl-sidebar-width)) / 2
+				width: min(
+					calc(100% - var(--sl-sidebar-width)),
+					calc(var(--sl-content-width) + (100% - var(--sl-content-width) - var(--sl-sidebar-width)) / 2)
 				);
 			}
 		}


### PR DESCRIPTION
Fixes #3513

When --sl-content-width is set to a value larger than the default, the
two-column layout at 72rem viewport can overflow. The calc() for
.main-pane resolves to a value exceeding the container width because
.right-sidebar-container's calculated width goes negative (clamped to
0 by CSS), leaving no room for the sidebar.

Fix: use max(var(--sl-sidebar-width), calc(...)) for the sidebar
container to ensure it never drops below its intended width, and
min(calc(100% - var(--sl-sidebar-width)), calc(...)) for the main pane
to ensure it never exceeds available space.