### PR TITLE
docs: updates links validator and fix link

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -29,6 +29,6 @@
     "@playwright/test": "^1.59.1",
     "axe-playwright": "^2.2.2",
     "sitemapper": "^4.1.5",
-    "starlight-links-validator": "^0.25.1"
+    "starlight-links-validator": "^0.25.2"
   }
 }

--- a/docs/src/content/docs/fa/404.md
+++ b/docs/src/content/docs/fa/404.md
@@ -9,6 +9,6 @@ hero:
   actions:
     - text: بازگشت به صفحه اصلی
       icon: left-arrow
-      link: /
+      link: /fa/
       variant: primary
 ---

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5
       starlight-links-validator:
-        specifier: ^0.25.1
-        version: 0.25.1(@astrojs/starlight@packages+starlight)(astro@7.0.2(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.6.1)(yaml@2.8.3))
+        specifier: ^0.25.2
+        version: 0.25.2(@astrojs/starlight@packages+starlight)(astro@7.0.2(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.6.1)(yaml@2.8.3))
 
   examples/basics:
     dependencies:
@@ -3589,8 +3589,8 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  starlight-links-validator@0.25.1:
-    resolution: {integrity: sha512-49F1JRvaJmvKSnM/jPFTjDVVwDJBUJ78jZE+fOResTRwYSa8MzPQzsJlSS1FeolsdqAat1evAu//WgIm65uyzw==}
+  starlight-links-validator@0.25.2:
+    resolution: {integrity: sha512-RQiHkM8FHKermsjMkSb+uS/q50Dv5P0O0ECWKxJyTv4stuO8QTorIEKnITDDLEf9/xyg7M69arxiK2ola3OMqA==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@astrojs/starlight': '>=0.41.0'
@@ -8114,7 +8114,7 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  starlight-links-validator@0.25.1(@astrojs/starlight@packages+starlight)(astro@7.0.2(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.6.1)(yaml@2.8.3)):
+  starlight-links-validator@0.25.2(@astrojs/starlight@packages+starlight)(astro@7.0.2(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.12.4)(jiti@2.6.1)(yaml@2.8.3)):
     dependencies:
       '@astrojs/markdown-satteri': 0.3.2
       '@astrojs/starlight': link:packages/starlight


### PR DESCRIPTION
#### Description

This PR updates the links validator which includes a fix (and a regression test now) for validation of frontmatter-only pages with Sätteri. Turns out, in the meantime, we merged https://github.com/withastro/starlight/pull/3955 which introduced an invalid link matching this scenario, so this PR also fixes that invalid link.