### PR TITLE
Remove duplicate '**/examples/' entry

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,7 +17,6 @@ export default defineConfig(
 		'**/examples/',
 		'**/dist/',
 		'**/build/',
-		'**/examples/',
 	]),
 
 	// Setup Node.js globals from `globalThis` (does not include CommonJS arguments).


### PR DESCRIPTION
Removed duplicate entry for '**/examples/' in the ESLint config.
