### PR TITLE
Allow `Page` component to be overridden

### DIFF
--- a/.changeset/loose-pugs-grow.md
+++ b/.changeset/loose-pugs-grow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': minor
+---
+
+Adds support for overriding Starlight’s `Page` component

--- a/docs/src/content/docs/guides/overriding-components.mdx
+++ b/docs/src/content/docs/guides/overriding-components.mdx
@@ -150,3 +150,47 @@ const isHomepage = Astro.locals.starlightRoute.id === '';
 ```
 
 Learn more about conditional rendering in [Astro’s Template Syntax guide](https://docs.astro.build/en/basics/astro-syntax/#dynamic-html).
+
+## Override the whole page
+
+You can completely replace Starlight’s UI and bring your own frontend implementation by overriding the `Page` component:
+
+```js {4}
+starlight({
+	title: 'My Docs with Custom Frontend',
+	components: {
+		Page: './src/MyPage.astro',
+	},
+}),
+```
+
+Your page component can then take full control of the page HTML while using Starlight’s [data model](/guides/route-data/) and routing logic.
+A page override removes all of Starlight’s built-in templating and CSS, giving you total control over the output.
+
+You can also choose to conditionally render Starlight’s built-in page component if you only want to use your custom UI for some pages.
+This works the same way as [conditional overrides for other components](#only-override-on-specific-pages):
+
+```astro title="src/MyPage.astro"
+---
+import DefaultPage from '@astrojs/starlight/components/Page.astro';
+
+const isHomepage = Astro.locals.starlightRoute.id === '';
+---
+
+{!isHomepage ? (
+	// Render a default docs page
+	<DefaultPage><slot/></DefaultPage>
+) : (
+	// Render a fully custom page
+	<html>
+		<head>
+			<!--...-->
+		</head>
+		<body>
+			<!--...-->
+			<slot />
+			<!--...-->
+		</body>
+	</html>
+)}
+```

--- a/docs/src/content/docs/reference/overrides.md
+++ b/docs/src/content/docs/reference/overrides.md
@@ -12,6 +12,19 @@ Learn more in the [Guide to Overriding Components](/guides/overriding-components
 
 ## Components
 
+### Page
+
+#### `Page`
+
+**Default component:** [`Page.astro`](https://github.com/withastro/starlight/blob/main/packages/starlight/components/Page.astro)
+
+Parent component for all page HTML, including `<head>` and `<body>`.
+
+:::caution
+Overriding this component removes **all** of Starlight’s default rendering behaviour.
+Use it only if you intend to use Starlight as a “headless” data framework and implement your own frontend.
+:::
+
 ### Head
 
 These components are rendered inside each page’s `<head>` element.

--- a/packages/starlight/__tests__/basics/config-errors.test.ts
+++ b/packages/starlight/__tests__/basics/config-errors.test.ts
@@ -30,6 +30,7 @@ test('parses bare minimum valid config successfully', () => {
 		    "MobileMenuFooter": "@astrojs/starlight/components/MobileMenuFooter.astro",
 		    "MobileMenuToggle": "@astrojs/starlight/components/MobileMenuToggle.astro",
 		    "MobileTableOfContents": "@astrojs/starlight/components/MobileTableOfContents.astro",
+		    "Page": "@astrojs/starlight/components/Page.astro",
 		    "PageFrame": "@astrojs/starlight/components/PageFrame.astro",
 		    "PageSidebar": "@astrojs/starlight/components/PageSidebar.astro",
 		    "PageTitle": "@astrojs/starlight/components/PageTitle.astro",

--- a/packages/starlight/routes/common.astro
+++ b/packages/starlight/routes/common.astro
@@ -1,6 +1,6 @@
 ---
 import { render } from 'astro:content';
-import Page from '../components/Page.astro';
+import Page from 'virtual:starlight/components/Page';
 import { getRoute, useRouteData } from '../utils/routing/data';
 import { attachRouteDataAndRunMiddleware } from '../utils/routing/middleware';
 

--- a/packages/starlight/schemas/components.ts
+++ b/packages/starlight/schemas/components.ts
@@ -3,6 +3,17 @@ import { z } from 'astro/zod';
 export function ComponentConfigSchema() {
 	return z
 		.object({
+			/**
+			 * Parent component for all page HTML, including `<head>` and `<body>`.
+			 *
+			 * **⚠️ CAUTION:** Overriding this component removes **all** of Starlight’s default rendering
+			 * behaviour. Use it only if you intend to use Starlight as a “headless” data framework and
+			 * implement your own frontend.
+			 *
+			 * @see {@link https://github.com/withastro/starlight/blob/main/packages/starlight/components/Page.astro `Page` default implementation}
+			 */
+			Page: z.string().default('@astrojs/starlight/components/Page.astro'),
+
 			/*
 			HEAD ----------------------------------------------------------------------------------------
 			*/

--- a/packages/starlight/virtual-internal.d.ts
+++ b/packages/starlight/virtual-internal.d.ts
@@ -28,6 +28,10 @@ declare module 'virtual:starlight/pagefind-config' {
 	>;
 }
 
+declare module 'virtual:starlight/components/Page' {
+	const Page: typeof import('./components/Page.astro').default;
+	export default Page;
+}
 declare module 'virtual:starlight/components/Banner' {
 	const Banner: typeof import('./components/Banner.astro').default;
 	export default Banner;


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- This PR is a preview of officially supporting “headless” use of Starlight where users can override the entire HTML rendering step with a custom Astro component that consumes Starlight’s data layer.
- Sharing it to gather early feedback.
- Docs preview: https://deploy-preview-4014--astro-starlight.netlify.app/guides/overriding-components/#override-the-whole-page
- Preview release:
  ```sh
  pnpm add https://pkg.pr.new/withastro/starlight/@astrojs/starlight@4014
  ```
- Really basic demo project: https://stackblitz.com/edit/github-peilyxr6?file=astro.config.mjs,src%2FMyPage.astro&on=stackblitz

#### Context

When we added the overrides feature in https://github.com/withastro/starlight/pull/709 we avoided adding this as it can be a “big hammer” to take over the entirety of page rendering including `<head>` content etc. We reckoned that a big reason for picking Starlight was to get a well tested, accessible, battle hardened and SEO-ready frontend, so completely replacing it might not be something people would need. And due to some of the complexities of a wholesale override we opted not to consider it at that time.

For most users that remains the case, but we have seen adoption in some more complex sites where Starlight’s data and routing layers are attractive foundations but where users want full control over the final rendering step for various reasons. Officially supporting this would give them that.

There may be some details to iron out. For example, user components (like `<Aside>`, `<Tabs>` etc.) should ideally work even when “ejecting” to a custom page component. We’ll likely need to tweak some CSS imports to ensure Starlight’s base layer of CSS variables is available to these (currently these components assume the CSS base layer will be available via the page component).

I’ve added some docs for now, but we can also discuss if the extra section in the “Overriding components” guide is necessary — the override process for the full page is identical to other components, just with a bigger impact around what it does.