### PR TITLE
chore(starlight): update favicon guidance to align with modern best practices

### DIFF
--- a/packages/starlight/CHANGELOG.md
+++ b/packages/starlight/CHANGELOG.md
@@ -1461,7 +1461,7 @@
 
 - [#2156](https://github.com/withastro/starlight/pull/2156) [`904ad47`](https://github.com/withastro/starlight/commit/904ad47ea9588c0b1d8c583f3f04e4ae199474d9) Thanks [@delucis](https://github.com/delucis)! - Fixes builds for projects with a space in their pathname
 
-- [#2137](https://github.com/withastro/starlight/pull/2137) [`703903b`](https://github.com/withastro/starlight/commit/703903bb782c3fabd3fe914e40494c00f12ec945) Thanks [@cevdetardaharan](https://github.com/cevdetardaharan)! - Removes `twitter:title` and `twitter:description` meta tags from `<head>`
+- [#2137](https://github.com/withastro/starlight/pull/2137) [`703903b`](https://github.com/withastro/starlight/commit/703903bb782c3fabd3fe914e40494c00f12ec945) Thanks [@cevdetta](https://github.com/cevdetta)! - Removes `twitter:title` and `twitter:description` meta tags from `<head>`
 
 ## 0.25.2
 

--- a/packages/starlight/__tests__/absolute-favicon/absolute-favicon.test.ts
+++ b/packages/starlight/__tests__/absolute-favicon/absolute-favicon.test.ts
@@ -14,7 +14,7 @@ test('places the default favicon below any user provided icons', () => {
 		props: { ...routes[0]!, headings: [] },
 		context: getRouteDataTestContext(),
 	});
-	const faviconEntry = head.find((tag) => tag.tag === 'link' && tag.attrs?.rel === 'shortcut icon');
+	const faviconEntry = head.find((tag) => tag.tag === 'link' && tag.attrs?.rel === 'icon');
 
 	expect(faviconEntry?.attrs?.href).toBe('https://example.com/favicon.ico');
 });

--- a/packages/starlight/__tests__/head/head.test.ts
+++ b/packages/starlight/__tests__/head/head.test.ts
@@ -184,7 +184,7 @@ test('places the default favicon below any user provided icons', () => {
 	});
 
 	const defaultFaviconIndex = head.findIndex(
-		(tag) => tag.tag === 'link' && tag.attrs?.rel === 'shortcut icon'
+		(tag) => tag.tag === 'link' && tag.attrs?.rel === 'icon'
 	);
 	const userFaviconIndex = head.findIndex((tag) => tag.tag === 'link' && tag.attrs?.rel === 'icon');
 

--- a/packages/starlight/utils/head.ts
+++ b/packages/starlight/utils/head.ts
@@ -46,7 +46,7 @@ export function getHead(
 		{
 			tag: 'link',
 			attrs: {
-				rel: 'shortcut icon',
+				rel: 'icon',
 				href: isAbsoluteUrl(config.favicon.href)
 					? config.favicon.href
 					: fileWithBase(config.favicon.href),
@@ -224,7 +224,7 @@ function getImportance(entry: HeadConfig[number]) {
 			entry.tag === 'link' &&
 			entry.attrs &&
 			'rel' in entry.attrs &&
-			entry.attrs.rel === 'shortcut icon'
+			entry.attrs.rel === 'icon'
 		) {
 			return 70;
 		}


### PR DESCRIPTION
## Description

This PR updates the favicon implementation in Starlight to align with modern best practices as outlined in the updated guidance from Evil Martians:
[evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs#relshortcut](https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs#relshortcut)

### What does this PR change?

* Standardizes favicon link relation from `rel="shortcut icon"` to the modern, spec-aligned `rel="icon"` (WHATWG-recommended approach)
* Updates logic in `getHead()` to reflect this change
* Adjusts ordering and detection logic for favicon entries in the `<head>`
* Updates test expectations to match the new `rel="icon"` behavior
* Fixes a CHANGELOG contributor username inconsistency

### Why this change?

The `shortcut icon` relation is a legacy, non-standard value that is no longer recommended. Modern browser implementations and current best practices use `rel="icon"` consistently across formats (ICO, SVG, PNG), which simplifies favicon handling and improves spec compliance.

The referenced Evil Martians guide consolidates current favicon practices into a minimal, interoperable set of files and confirms that modern browsers do not require `shortcut` at all.

### Did you change something visual?

No visual changes are expected. This is a metadata/specification-level change only; favicon behavior remains the same across supported browsers.