### PR TITLE
fix(a11y): trap focus within mobile sidebar when menu is open

### DIFF
--- a/.changeset/fix-mobile-menu-focus-trap.md
+++ b/.changeset/fix-mobile-menu-focus-trap.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Trap focus within the mobile sidebar when the menu is open. Pressing Tab or Shift+Tab now cycles through the toggle button and all sidebar links without escaping to the rest of the page.

--- a/packages/starlight/components/MobileMenuToggle.astro
+++ b/packages/starlight/components/MobileMenuToggle.astro
@@ -28,6 +28,9 @@ import Icon from '../user-components/Icon.astro';
 			if (parentNav) {
 				parentNav.addEventListener('keyup', (e) => this.closeOnEscape(e));
 			}
+
+			// Trap focus within the sidebar when the mobile menu is open.
+			document.addEventListener('keydown', (e) => this.handleKeyDown(e));
 		}
 
 		setExpanded(expanded: boolean) {
@@ -43,6 +46,38 @@ import Icon from '../user-components/Icon.astro';
 			if (e.code === 'Escape') {
 				this.setExpanded(false);
 				this.btn.focus();
+			}
+		}
+
+		private getSidebarFocusables(): HTMLElement[] {
+			const sidebar = document.getElementById('starlight__sidebar');
+			if (!sidebar) return [this.btn];
+			return [
+				this.btn,
+				...Array.from(
+					sidebar.querySelectorAll<HTMLElement>(
+						'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+					),
+				),
+			];
+		}
+
+		private handleKeyDown(e: KeyboardEvent) {
+			if (e.key !== 'Tab' || this.getAttribute('aria-expanded') !== 'true') return;
+			// On desktop the button is hidden via CSS; skip trapping so regular
+			// keyboard navigation is unaffected on wider viewports.
+			if (getComputedStyle(this.btn).display === 'none') return;
+
+			const focusables = this.getSidebarFocusables();
+			const first = focusables[0]!;
+			const last = focusables[focusables.length - 1]!;
+
+			if (e.shiftKey && document.activeElement === first) {
+				e.preventDefault();
+				last.focus();
+			} else if (!e.shiftKey && document.activeElement === last) {
+				e.preventDefault();
+				first.focus();
 			}
 		}
 	}


### PR DESCRIPTION
Tab and Shift+Tab currently escape the mobile sidebar and cycle through the rest of the page — this makes the menu unusable for keyboard-only users.

Added a handleKeyDown listener in StarlightMenuButton that intercepts Tab/Shift+Tab when the menu is expanded and loops focus between the toggle button and all focusable elements inside #starlight__sidebar. A getComputedStyle check skips the trap on desktop viewports where the toggle button is hidden and the sidebar is always visible.

Closes #2697