### PR TITLE
docs: add starlight-biel to community plugins

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -223,6 +223,11 @@ Extend your site with official plugins supported by the Starlight team and commu
 		title="starlight-recipes"
 		description="Starlight plugin to create a recipe website."
 	/>
+	<LinkCard
+		href="https://github.com/TechDocsStudio/starlight-biel"
+		title="starlight-biel"
+		description="Add an Ask AI chatbot that answers from your content, powered by Biel.ai."
+	/>
 </CardGrid>
 
 ## Community tools and integrations


### PR DESCRIPTION
Adds [starlight-biel](https://github.com/TechDocsStudio/starlight-biel) to the community plugins list: a plugin that adds an Ask AI chatbot answering from your site content, with citations to the source pages. Published on npm as [`starlight-biel`](https://www.npmjs.com/package/starlight-biel) with the `starlight-plugin` keyword. Added at the end of the list, matching the existing card format.