### PR TITLE
i18n(fr): update `plugins.mdx` and `themes.mdx`

### DIFF
--- a/docs/src/content/docs/fr/resources/plugins.mdx
+++ b/docs/src/content/docs/fr/resources/plugins.mdx
@@ -223,6 +223,11 @@ Les [modules d'extension](/fr/reference/plugins/) peuvent personnaliser la confi
 		title="starlight-recipes"
 		description="Module d'extension Starlight pour créer un site web de recettes."
 	/>
+	<LinkCard
+		href="https://github.com/TechDocsStudio/starlight-biel"
+		title="starlight-biel"
+		description="Ajouter un chatbot « Demander à l'IA » qui répond en utilisant votre contenu, propulsé par Biel.ai."
+	/>
 </CardGrid>
 
 ## Outils et intégrations communautaires

--- a/docs/src/content/docs/fr/resources/themes.mdx
+++ b/docs/src/content/docs/fr/resources/themes.mdx
@@ -158,7 +158,7 @@ Découvrez ci-dessous un aperçu de tous les thèmes ou essayez-les de manière 
 		{
 			title: 'Starlight mdBook',
 			description:
-				"Un thème qui reproduit l'apparence et l'ergonomie de mdBook de rust-lang, avec sa mise en page, son aspect chromé et ses cinq jeux de couleurs intégrés.",
+				"Un thème qui reproduit l'apparence et l'ergonomie de mdBook de rust-lang, avec sa mise en page, son interface et ses cinq jeux de couleurs intégrés.",
 			href: 'https://starlight-theme-mdbook.netlify.app/',
 			previews: { light: 'mdbook-light.png', dark: 'mdbook-dark.png' },
 		},

--- a/docs/src/content/docs/fr/resources/themes.mdx
+++ b/docs/src/content/docs/fr/resources/themes.mdx
@@ -155,6 +155,13 @@ Découvrez ci-dessous un aperçu de tous les thèmes ou essayez-les de manière 
 			href: 'https://axiaobo7788.github.io/starlight-material-design-theme/',
 			previews: { light: 'md3-light.png', dark: 'md3-dark.png' },
 		},
+		{
+			title: 'Starlight mdBook',
+			description:
+				"Un thème qui reproduit l'apparence et l'ergonomie de mdBook de rust-lang, avec sa mise en page, son aspect chromé et ses cinq jeux de couleurs intégrés.",
+			href: 'https://starlight-theme-mdbook.netlify.app/',
+			previews: { light: 'mdbook-light.png', dark: 'mdbook-dark.png' },
+		},
 	]}
 />
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

<!-- New features should first be discussed and approved by maintainers in GitHub or Discord discussions. -->
<!-- If this PR adds a new public-facing feature, uncomment the line below and include a link to the relevant discussion. -->
<!-- - [x] This PR adds a new feature which has been discussed and approved [here](link to GitHub or Discord discussion). -->

Adds changes from #4045 and #4039 to the French translation of `resources/plugins.mdx` and `resources/themes.mdx`.

I'm not 100% sure of "son aspect chromé" for "[with its layout,] chrome[, and]". I mean, with the other colors I don't really see any chrome so it's a bit odd... But, I'm sure this should not be "son chrome" in French as this is a [metal name](https://www.larousse.fr/dictionnaires/francais/chrome/15794).

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
