### PR TITLE
docs: move `starlight-md-txt` to plugins

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -224,6 +224,11 @@ Extend your site with official plugins supported by the Starlight team and commu
 		description="Starlight plugin to create a recipe website."
 	/>
 	<LinkCard
+		href="https://github.com/max-ostapenko/starlight-md-txt"
+		title="starlight-md-txt"
+		description="Expose your Starlight documentation pages as raw, agent-friendly Markdown at .md.txt URLs."
+	/>
+	<LinkCard
 		href="https://github.com/TechDocsStudio/starlight-biel"
 		title="starlight-biel"
 		description="Add an Ask AI chatbot that answers from your content, powered by Biel.ai."
@@ -311,11 +316,6 @@ These community tools and integrations can be used to add features to your Starl
 		href="https://github.com/trueberryless-org/starlight-contributor-list"
 		title="starlight-contributor-list"
 		description="Display a list of all contributors to your project."
-	/>
-	<LinkCard
-		href="https://github.com/max-ostapenko/starlight-md-txt"
-		title="starlight-md-txt"
-		description="Expose your Starlight documentation pages as raw, agent-friendly Markdown at .md.txt URLs."
 	/>
 	<LinkCard
 		href="https://github.com/pixelizing/axiom-studio-for-starlight"


### PR DESCRIPTION
#### Description

This PR moves the `starlight-md-txt` from the "Community tools" to the "Community plugins" section because it is a Starlight plugin. I think it was added to the wrong section because of a little misinterpretation of ["end of the list"](https://github.com/withastro/starlight/pull/3964#pullrequestreview-4522472586) in #3964. 

> Errare humanum est - Seneca the Younger[^1]

I discovered this coincidentally while I wanted to update the German translation because funnily enough, in #3996 I accidentally added the entry to the "Community plugins" in the DE version by mistake 😆 
Well, if that isn't what you'd call a blessing in disguise... 😅 

[^1]: https://en.wiktionary.org/wiki/errare_humanum_est