### PR TITLE
Add starlight-agentready plugin

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -238,6 +238,11 @@ Extend your site with official plugins supported by the Starlight team and commu
 		title="starlight-page-context-action"
 		description="Make utility actions like copy/view page as markdown, open in AI chat, and scroll to top always accessible in your docs."
 	/>
+	<LinkCard
+		href="https://github.com/AshutoshRaj97/agentready-mcp/tree/main/starlight-plugin"
+		title="starlight-agentready"
+		description="Submit your docs to AgentReady after every build, making them queryable by AI agents via MCP."
+	/>
 </CardGrid>
 
 ## Community tools and integrations


### PR DESCRIPTION
## What is this?

Adds [starlight-agentready](https://www.npmjs.com/package/starlight-agentready) to the community plugins list.

After each `astro build`, this plugin submits your docs site to [AgentReady](https://www.agentready.it.com) — a hosted MCP server that crawls your docs and makes them instantly queryable by AI agents (Claude, Cursor, Windsurf, and any MCP client) with cited, multi-page answers.

**npm:** https://www.npmjs.com/package/starlight-agentready  
**GitHub:** https://github.com/AshutoshRaj97/agentready-mcp/tree/main/starlight-plugin

## Usage

```js
import agentready from 'starlight-agentready'

export default defineConfig({
  site: 'https://docs.yoursite.com',
  integrations: [
    starlight({
      plugins: [agentready()],
    }),
  ],
})
```