### PR TITLE
Fix sidebar persistence on pagehide

### DIFF
--- a/.changeset/fix-sidebar-pagehide.md
+++ b/.changeset/fix-sidebar-pagehide.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fix sidebar state persistence when a page unloads.

--- a/packages/starlight/__tests__/components-internals/sidebar-persist-state.test.ts
+++ b/packages/starlight/__tests__/components-internals/sidebar-persist-state.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+const addEventListener = vi.fn();
+
+beforeEach(() => {
+	vi.resetModules();
+	addEventListener.mockReset();
+	vi.stubGlobal('addEventListener', addEventListener);
+	vi.stubGlobal('document', {
+		getElementById: vi.fn(),
+		visibilityState: 'visible',
+	});
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+test('stores sidebar state on the pagehide event', async () => {
+	// @ts-expect-error The client script intentionally has no exports.
+	await import('../../components-internals/SidebarPersistState');
+
+	expect(addEventListener).toHaveBeenCalledWith('pagehide', expect.any(Function));
+	expect(addEventListener).not.toHaveBeenCalledWith('pageHide', expect.any(Function));
+});

--- a/packages/starlight/__tests__/components-internals/vitest.config.ts
+++ b/packages/starlight/__tests__/components-internals/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({});

--- a/packages/starlight/components-internals/SidebarPersistState.ts
+++ b/packages/starlight/components-internals/SidebarPersistState.ts
@@ -69,4 +69,4 @@ target?.addEventListener('click', (event) => {
 addEventListener('visibilitychange', () => {
 	if (document.visibilityState === 'hidden') updateState();
 });
-addEventListener('pageHide', updateState);
+addEventListener('pagehide', updateState);


### PR DESCRIPTION
## Summary

- register the sidebar persistence handler for the correctly cased `pagehide` DOM event
- add a regression test that verifies the client script registers `pagehide`, not `pageHide`
- add a patch changeset for the user-visible persistence fix

## Root cause

The browser event is lowercase and case-sensitive. The existing `pageHide` listener never fired, so sidebar state was not saved through the intended unload lifecycle path.

## Validation

- `pnpm --filter @astrojs/starlight test --run` (602 tests passed)
- `pnpm exec eslint packages/starlight/components-internals/SidebarPersistState.ts packages/starlight/__tests__/components-internals/sidebar-persist-state.test.ts packages/starlight/__tests__/components-internals/vitest.config.ts`

`pnpm lint` and `pnpm typecheck` currently report pre-existing errors in untouched upstream files with this checkout's dependency set.

Closes #4083
