### PR TITLE
Remove `minimumReleaseAgeExclude` from workspace

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,18 +25,3 @@ peerDependencyRules:
 
 # Prevent installing packages published in the last 3 days
 minimumReleaseAge: 4320
-minimumReleaseAgeExclude:
-  - astro
-  - '@astrojs/markdown-satteri'
-  - '@astrojs/mdx'
-  - '@astrojs/node'
-  - '@astrojs/markdoc'
-  - '@bruits/*'
-  - satteri
-  - '@expressive-code/*'
-  - 'expressive-code'
-  - 'astro-expressive-code'
-  - 'rehype-expressive-code'
-  - 'starlight-links-validator'
-  - '@napi-rs/wasm-runtime'
-  - '@tybys/wasm-util'


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description
We had to introduce quite a few packages to `minimumReleaseAgeExclude` when co-ordinating the release alongside Astro v7 but should now be safe to remove this. This change helps protect us from accidentally installing a newer version of one of these packages unintentionally.