### PR TITLE
Remove pagehide event from sidebar persistence script

### DIFF
--- a/.changeset/whole-beds-add.md
+++ b/.changeset/whole-beds-add.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Simplifies Starlight’s client-side sidebar state persistence script slightly

--- a/packages/starlight/components-internals/SidebarPersistState.ts
+++ b/packages/starlight/components-internals/SidebarPersistState.ts
@@ -69,4 +69,3 @@ target?.addEventListener('click', (event) => {
 addEventListener('visibilitychange', () => {
 	if (document.visibilityState === 'hidden') updateState();
 });
-addEventListener('pageHide', updateState);


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #4083
- Closes #4084
- This PR removes our use of the `pagehide` event in our sidebar state persistence script.
- As spotted in #4083 this has never been working as intended due to a typo as `pageHide` in the event name.
- We could fix the casing, but AFAICT we do not need the event at all:
  1. It hasn’t been firing for 1 year without anyone noticing.
  2. The main reason for `pagehide` was due to Safari’s partial `visibilitychange` support. According to [MDN’s data](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event#browser_compatibility) Safari fixed this in April 2021 (v14.1 on desktop, v14.5 on mobile), so we no longer need `pagehide` to cover those older browsers which fall outside of our [browser support matrix](https://github.com/withastro/starlight/blob/main/CONTRIBUTING.md#understanding-starlight).
  3. As noted in #4083, even if it _had_ been cased properly, it wouldn’t have fixed their specific issue. It was just a detail they noticed in passing.