### PR TITLE
Support links with any protocol in sidebars

### DIFF
--- a/.changeset/every-breads-camp.md
+++ b/.changeset/every-breads-camp.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes support for links containing a protocol like `mailto:` in the sidebar

--- a/packages/starlight/__tests__/sidebar/navigation-attributes.test.ts
+++ b/packages/starlight/__tests__/sidebar/navigation-attributes.test.ts
@@ -215,6 +215,14 @@ describe('getSidebar', () => {
 			    "label": "API (deprecated)",
 			    "type": "group",
 			  },
+			  {
+			    "attrs": {},
+			    "badge": undefined,
+			    "href": "mailto:me@example.com",
+			    "isCurrent": false,
+			    "label": "E-mail me",
+			    "type": "link",
+			  },
 			]
 		`);
 	});

--- a/packages/starlight/__tests__/sidebar/navigation-badges.test.ts
+++ b/packages/starlight/__tests__/sidebar/navigation-badges.test.ts
@@ -185,6 +185,14 @@ describe('getSidebar', () => {
 			    "label": "API (deprecated)",
 			    "type": "group",
 			  },
+			  {
+			    "attrs": {},
+			    "badge": undefined,
+			    "href": "mailto:me@example.com",
+			    "isCurrent": false,
+			    "label": "E-mail me",
+			    "type": "link",
+			  },
 			]
 		`);
 	});

--- a/packages/starlight/__tests__/sidebar/navigation-hidden.test.ts
+++ b/packages/starlight/__tests__/sidebar/navigation-hidden.test.ts
@@ -157,6 +157,14 @@ describe('getSidebar', () => {
 			    "label": "API (deprecated)",
 			    "type": "group",
 			  },
+			  {
+			    "attrs": {},
+			    "badge": undefined,
+			    "href": "mailto:me@example.com",
+			    "isCurrent": false,
+			    "label": "E-mail me",
+			    "type": "link",
+			  },
 			]
 		`);
 	});

--- a/packages/starlight/__tests__/sidebar/navigation-order.test.ts
+++ b/packages/starlight/__tests__/sidebar/navigation-order.test.ts
@@ -168,6 +168,14 @@ describe('getSidebar', () => {
 			    "label": "API (deprecated)",
 			    "type": "group",
 			  },
+			  {
+			    "attrs": {},
+			    "badge": undefined,
+			    "href": "mailto:me@example.com",
+			    "isCurrent": false,
+			    "label": "E-mail me",
+			    "type": "link",
+			  },
 			]
 		`);
 	});

--- a/packages/starlight/__tests__/sidebar/navigation-unicode.test.ts
+++ b/packages/starlight/__tests__/sidebar/navigation-unicode.test.ts
@@ -168,6 +168,14 @@ describe('getSidebar', () => {
 			    "label": "API (deprecated)",
 			    "type": "group",
 			  },
+			  {
+			    "attrs": {},
+			    "badge": undefined,
+			    "href": "mailto:me@example.com",
+			    "isCurrent": false,
+			    "label": "E-mail me",
+			    "type": "link",
+			  },
 			]
 		`);
 	});

--- a/packages/starlight/__tests__/sidebar/navigation.test.ts
+++ b/packages/starlight/__tests__/sidebar/navigation.test.ts
@@ -192,6 +192,14 @@ describe('getSidebar', () => {
 			    "label": "API (deprecated)",
 			    "type": "group",
 			  },
+			  {
+			    "attrs": {},
+			    "badge": undefined,
+			    "href": "mailto:me@example.com",
+			    "isCurrent": false,
+			    "label": "E-mail me",
+			    "type": "link",
+			  },
 			]
 		`);
 	});

--- a/packages/starlight/__tests__/sidebar/vitest.config.ts
+++ b/packages/starlight/__tests__/sidebar/vitest.config.ts
@@ -50,5 +50,10 @@ export default defineVitestConfig({
 			label: 'API (deprecated)',
 			items: [{ autogenerate: { directory: '/Deprecated API/' } }],
 		},
+		// A link using the `mailto:` protocol.
+		{
+			label: 'E-mail me',
+			link: 'mailto:me@example.com',
+		},
 	],
 });

--- a/packages/starlight/utils/navigation.ts
+++ b/packages/starlight/utils/navigation.ts
@@ -33,7 +33,7 @@ import type {
 	SidebarAutogenerateRouteData,
 } from './routing/types';
 import { localeToLang, localizedFilePath, slugToPathname } from './slugs';
-import { isAbsoluteUrl } from './url';
+import { hasProtocol } from './url';
 import type { StarlightConfig } from './user-config';
 
 const DirKey = Symbol('DirKey');
@@ -120,7 +120,7 @@ function entriesFromAutogenerateConfig(
 /** Create a link entry from a manual link item in user config. */
 function linkFromSidebarLinkItem(item: SidebarLinkItem, locale: string | undefined) {
 	let href = item.link;
-	if (!isAbsoluteUrl(href)) {
+	if (!hasProtocol(href)) {
 		href = ensureLeadingSlash(href);
 		// Inject current locale into link.
 		if (locale) href = '/' + locale + href;
@@ -188,7 +188,7 @@ function makeSidebarLink(
 	opts: MakeLinkOptions & { autogenerate: SidebarAutogenerateRouteData }
 ): SidebarAutoLink;
 function makeSidebarLink({ attrs, badge, href, label, autogenerate }: MakeLinkOptions) {
-	if (!isAbsoluteUrl(href)) {
+	if (!hasProtocol(href)) {
 		href = formatPath(href);
 	}
 	return makeLink({ label, href, badge, attrs, autogenerate });

--- a/packages/starlight/utils/url.ts
+++ b/packages/starlight/utils/url.ts
@@ -1,12 +1,8 @@
 const HTTPProtocolRegEx = /^https?:\/\//;
+const ProtocolRegEx = /^[a-z][a-z\d+.-]*:/i;
 
 /** Check if a string starts with one of `http://` or `https://`. */
 export const isAbsoluteUrl = (link: string) => HTTPProtocolRegEx.test(link);
 
 /** Check if a string contains a protocol (e.g., `http:`, `https:`, `mailto:`). */
-export const hasProtocol = (link: string) => {
-	const colonIndex = link.indexOf(':');
-	if (colonIndex === -1) return false;
-	const slashIndex = link.indexOf('/');
-	return slashIndex === -1 || colonIndex < slashIndex;
-};
+export const hasProtocol = (link: string) => ProtocolRegEx.test(link);

--- a/packages/starlight/utils/url.ts
+++ b/packages/starlight/utils/url.ts
@@ -2,3 +2,6 @@ const HTTPProtocolRegEx = /^https?:\/\//;
 
 /** Check if a string starts with one of `http://` or `https://`. */
 export const isAbsoluteUrl = (link: string) => HTTPProtocolRegEx.test(link);
+
+/** Check if a string contains a protocol (e.g., `http:`, `https:`, `mailto:`). */
+export const hasProtocol = (link: string) => link.includes(':');

--- a/packages/starlight/utils/url.ts
+++ b/packages/starlight/utils/url.ts
@@ -4,4 +4,9 @@ const HTTPProtocolRegEx = /^https?:\/\//;
 export const isAbsoluteUrl = (link: string) => HTTPProtocolRegEx.test(link);
 
 /** Check if a string contains a protocol (e.g., `http:`, `https:`, `mailto:`). */
-export const hasProtocol = (link: string) => link.includes(':');
+export const hasProtocol = (link: string) => {
+	const colonIndex = link.indexOf(':');
+	if (colonIndex === -1) return false;
+	const slashIndex = link.indexOf('/');
+	return slashIndex === -1 || colonIndex < slashIndex;
+};


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes #4051
- Currently we special case `http(s)://` links in the sidebar and treat everything else as a relative link, prefixing locales, slashes, etc.
- This PR switches to check if the link contains any protocol component instead of only checking for an HTTP protocol so that protocols like `mailto:` or even app protocols like `vscode://` are supported.
- ~~The implementation may look a bit funny but is essentially doing `/^[^\/]*:/.test()`, i.e. checking if a colon is present in the first segment of a link (`/foo:bar` is a valid relative link, but `foo:bar` is treated as a protocol `foo:`). This implementation seems to be an order of magnitude faster than the current regular expression we use. I ran a [little benchmark](https://jsbm.dev/FxO0fLgzTXLLD) that showed this running about 15x faster than the regular expression, which may matter given sidebars can be a performance-sensitive area.~~
- There is still one use of `isAbsoluteUrl()` in the code base, but it’s for the favicon URL, so I’ve left that as is — other protocols aren’t relevant there ~~and it isn’t performance sensitive in the same way the sidebar is~~.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->

