### PR TITLE
Fix union schema `extend` regression

### DIFF
--- a/.changeset/rich-falcons-warn.md
+++ b/.changeset/rich-falcons-warn.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes a regression when using a union to [extend](https://starlight.astro.build/reference/frontmatter/#extend) Starlight’s `docsSchema()`.

--- a/packages/starlight/__tests__/basics/schema.test-d.ts
+++ b/packages/starlight/__tests__/basics/schema.test-d.ts
@@ -71,4 +71,17 @@ describe('docs schema', () => {
 		expectTypeOf(parsed).toExtend<PartialDocsSchemaOutput>();
 		expectTypeOf(parsed.sidebar.custom).toBeNumber();
 	});
+
+	test('docs schema should parse to expected shape when extending with a union of objects', () => {
+		const baseSchema = z.object({ type: z.literal('base').optional().default('base') });
+		const extendedSchema = baseSchema.extend({ type: z.literal('extended'), name: z.string() });
+
+		const schema = docsSchema({ extend: z.union([baseSchema, extendedSchema]) })({
+			image: () => ({}) as any,
+		});
+		const parsed = schema.parse({});
+
+		expectTypeOf(parsed.type).toEqualTypeOf<'base' | 'extended'>();
+		if (parsed.type === 'extended') expectTypeOf(parsed.name).toBeString();
+	});
 });

--- a/packages/starlight/__tests__/basics/schema.test.ts
+++ b/packages/starlight/__tests__/basics/schema.test.ts
@@ -372,4 +372,77 @@ describe('docsSchema', () => {
 		]]
 	`);
 	});
+
+	test('docs schema can be extended with a union of objects', () => {
+		const baseSchema = z.object({ type: z.literal('base').optional().default('base') });
+		const extendedSchema = baseSchema.extend({ type: z.literal('extended'), name: z.string() });
+
+		const schema = docsSchema({ extend: z.union([baseSchema, extendedSchema]) })({
+			image: () => ({}) as never,
+		});
+
+		const parsedBase = schema.parse({ title: 'Base' });
+		expect(parsedBase).toMatchInlineSnapshot(`
+        {
+          "draft": false,
+          "editUrl": true,
+          "head": [],
+          "pagefind": true,
+          "sidebar": {
+            "attrs": {},
+            "hidden": false,
+          },
+          "template": "doc",
+          "title": "Base",
+          "type": "base",
+        }
+  `);
+
+		const parsedExtended = schema.parse({ title: 'Extended', type: 'extended', name: 'test' });
+		expect(parsedExtended).toMatchInlineSnapshot(`
+			{
+			  "draft": false,
+			  "editUrl": true,
+			  "head": [],
+			  "name": "test",
+			  "pagefind": true,
+			  "sidebar": {
+			    "attrs": {},
+			    "hidden": false,
+			  },
+			  "template": "doc",
+			  "title": "Extended",
+			  "type": "extended",
+			}
+		`);
+	});
+
+	test('docs schema can be extended with a discriminated union of objects', () => {
+		const schema = docsSchema({
+			extend: z.discriminatedUnion('type', [
+				z.object({ type: z.literal('base') }),
+				z.object({ type: z.literal('extended'), name: z.string() }),
+			]),
+		})({
+			image: () => ({}) as never,
+		});
+
+		const parsed = schema.parse({ title: 'Extended', type: 'extended', name: 'test' });
+		expect(parsed).toMatchInlineSnapshot(`
+			{
+			  "draft": false,
+			  "editUrl": true,
+			  "head": [],
+			  "name": "test",
+			  "pagefind": true,
+			  "sidebar": {
+			    "attrs": {},
+			    "hidden": false,
+			  },
+			  "template": "doc",
+			  "title": "Extended",
+			  "type": "extended",
+			}
+		`);
+	});
 });

--- a/packages/starlight/schema.ts
+++ b/packages/starlight/schema.ts
@@ -115,7 +115,8 @@ const StarlightFrontmatterSchema = (context: SchemaContext) =>
 type DefaultSchema = ReturnType<typeof StarlightFrontmatterSchema>;
 
 /** Base subset of Zod types that we support passing to the `extend` option. */
-type BaseSchema<T extends z.ZodRawShape = z.ZodRawShape> = z.ZodObject<T>;
+type BaseObjectSchema = z.ZodObject<z.ZodRawShape, z.core.$ZodObjectConfig>;
+type BaseSchema = BaseObjectSchema | z.ZodUnion<readonly BaseObjectSchema[]>;
 
 /** Type that extends Starlight’s default schema with an optional, user-defined schema. */
 type ExtendedSchema<T extends BaseSchema = never> = [T] extends [never]

--- a/packages/starlight/utils/zodDeepMerge.ts
+++ b/packages/starlight/utils/zodDeepMerge.ts
@@ -10,17 +10,19 @@ export type DeepMergedSchema<Default extends z.core.$ZodType, User extends z.cor
 				? z.ZodDefault<DeepMergedSchema<UnwrappedSchema<Default>, WrappedSchema>>
 				: User extends z.ZodPrefault<infer WrappedSchema extends z.core.$ZodType>
 					? z.ZodPrefault<DeepMergedSchema<UnwrappedSchema<Default>, WrappedSchema>>
-					: UnwrappedSchema<Default> extends z.ZodObject<infer DefaultShape>
-						? User extends z.ZodObject<infer UserShape, infer UserConfig>
-							? z.ZodObject<DeepMergedShape<DefaultShape, UserShape>, UserConfig>
-							: User
-						: UnwrappedSchema<Default> extends z.ZodArray<
-									infer DefaultItemSchema extends z.core.$ZodType
-							  >
-							? User extends z.ZodArray<infer UserItemSchema extends z.core.$ZodType>
-								? z.ZodArray<DeepMergedSchema<DefaultItemSchema, UserItemSchema>>
+					: User extends z.ZodUnion<infer Users extends readonly z.core.$ZodType[]>
+						? z.ZodUnion<DeepMergedUnionMembers<UnwrappedSchema<Default>, Users>>
+						: UnwrappedSchema<Default> extends z.ZodObject<infer DefaultShape>
+							? User extends z.ZodObject<infer UserShape, infer UserConfig>
+								? z.ZodObject<DeepMergedShape<DefaultShape, UserShape>, UserConfig>
 								: User
-							: User;
+							: UnwrappedSchema<Default> extends z.ZodArray<
+										infer DefaultItemSchema extends z.core.$ZodType
+								  >
+								? User extends z.ZodArray<infer UserItemSchema extends z.core.$ZodType>
+									? z.ZodArray<DeepMergedSchema<DefaultItemSchema, UserItemSchema>>
+									: User
+								: User;
 
 /** Type-level equivalent of {@link unwrapSchema}. */
 type UnwrappedSchema<T extends z.core.$ZodType> =
@@ -48,6 +50,16 @@ type DeepMergedShape<Default extends z.ZodRawShape, User extends z.ZodRawShape> 
 			: never;
 };
 
+/** Merged union schemas where each union member is deep-merged with the default schema. */
+type DeepMergedUnionMembers<
+	Default extends z.core.$ZodType,
+	Users extends readonly z.core.$ZodType[],
+> = {
+	[Key in keyof Users]: Users[Key] extends z.core.$ZodType
+		? DeepMergedSchema<Default, Users[Key]>
+		: Users[Key];
+};
+
 export function deepMergeSchemas(defaultSchema: z.ZodType, userSchema: z.ZodType): z.ZodType {
 	const unwrappedDefaultSchema = unwrapSchema(defaultSchema);
 
@@ -56,6 +68,13 @@ export function deepMergeSchemas(defaultSchema: z.ZodType, userSchema: z.ZodType
 			...userSchema._zod.def,
 			innerType: deepMergeSchemas(unwrappedDefaultSchema, userSchema._zod.def.innerType),
 		} as Parameters<typeof userSchema.clone>[0]);
+	}
+
+	if (isZodUnion(userSchema)) {
+		return userSchema.clone({
+			...userSchema._zod.def,
+			options: userSchema.options.map((schema) => deepMergeSchemas(unwrappedDefaultSchema, schema)),
+		});
 	}
 
 	if (isZodObject(unwrappedDefaultSchema) && isZodObject(userSchema)) {
@@ -118,4 +137,8 @@ function isZodObject(schema: z.ZodType): schema is z.ZodObject<z.ZodRawShape> {
 
 function isZodArray(schema: z.ZodType): schema is z.ZodArray<z.ZodType> {
 	return schema._zod.def.type === 'array';
+}
+
+function isZodUnion(schema: z.ZodType): schema is z.ZodUnion<readonly z.ZodType[]> {
+	return schema._zod.def.type === 'union';
 }


### PR DESCRIPTION
#### Description

<!-- New features should first be discussed and approved by maintainers in GitHub or Discord discussions. -->
<!-- If this PR adds a new public-facing feature, uncomment the line below and include a link to the relevant discussion. -->
<!-- - [x] This PR adds a new feature which has been discussed and approved [here](link to GitHub or Discord discussion). -->

- Closes #4094

This PR fixes a regression introduced in #3936 for an edge case I definitely didn't think about: using a union to extend the `docs` schema.

To address this, after unwrapping (optional, nullable, etc.) the user-provided schema, we need to check if it's a union and if it is, we deep-merge each member of the union with the default schema.