### PR TITLE
Use pinned version of `pkg-pr-new` for preview releases

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -88,4 +88,4 @@ jobs:
           # Note that `--compact` is used for shorter URLs but requires packages to be published on
           # npm. This means that it's not possible to publish a preview for a new package that has
           # not yet been published on npm.
-          pnpm dlx pkg-pr-new publish --pnpm --compact --packageManager=pnpm --no-template $PACKAGES
+          pnpm exec pkg-pr-new publish --pnpm --compact --packageManager=pnpm --no-template $PACKAGES

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "eslint": "^10.3.0",
     "eslint-config-prettier": "^10.1.8",
     "globals": "^17.6.0",
+    "pkg-pr-new": "^0.0.86",
     "prettier": "3.3.3",
     "prettier-plugin-astro": "^0.14.1",
     "size-limit": "^12.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       globals:
         specifier: ^17.6.0
         version: 17.6.0
+      pkg-pr-new:
+        specifier: ^0.0.86
+        version: 0.0.86
       prettier:
         specifier: 3.3.3
         version: 3.3.3
@@ -3284,6 +3287,10 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  pkg-pr-new@0.0.86:
+    resolution: {integrity: sha512-BwPsw/e1Be7F0SfpxhNc2VSxX7uHgCy46Ck+2Z/vqCwXoePhUBrX/VbcawpAlZgMvQe2iwGbZIQ6HSj9bmCk8A==}
+    hasBin: true
+
   playwright-core@1.61.1:
     resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
@@ -5549,7 +5556,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@24.12.4)(@vitest/coverage-v8@4.1.5)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3)
+      vitest: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(esbuild@0.28.0)(jiti@2.6.1)(yaml@2.8.3)
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -7690,6 +7697,8 @@ snapshots:
   picomatch@4.0.5: {}
 
   pify@4.0.1: {}
+
+  pkg-pr-new@0.0.86: {}
 
   playwright-core@1.61.1: {}
 


### PR DESCRIPTION
#### Description

While reviewing another PR, I noticed [we use `pnpm dlx`](https://github.com/withastro/starlight/blob/1e6d0feca6c9352d3bf4bd404921611a476779f4/.github/workflows/preview-release.yml#L91) to run `pkg-pr-new` for preview releases.

This is [not recommended](https://github.com/stackblitz-labs/pkg.pr.new/blob/main/README.md#publish-packages) because `pnpm dlx` would always resolves to the latest version which could have unexpected behavior due to some upstream breaking changes but also increases supply-chain risks.

> [!CAUTION]
> In CI environments, avoid `npx`, `pnpm dlx`, `yarn dlx`, and `bunx` for this step. Install `pkg-pr-new` as a dependency and execute it from the lockfile (`npm exec`, `pnpm exec`, `yarn`, or `bun run`).

This PR fixes that by installing `pkg-pr-new` as a dev dependency and running it using `pnpm exec`.