### PR TITLE
Refactor Sätteri RTL code support plugin

### DIFF
--- a/.changeset/modern-phones-work.md
+++ b/.changeset/modern-phones-work.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Fixes processing of code examples in RTL languages when using Astro’s Sätteri Markdown processor

--- a/packages/starlight/integrations/satteri.ts
+++ b/packages/starlight/integrations/satteri.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import { satteriHeadingIdsPlugin } from '@astrojs/markdown-satteri';
-import type { Element, Properties } from 'hast';
+import type { Properties } from 'hast';
 import type { Paragraph } from 'mdast';
 import { directiveToMarkdown } from 'mdast-util-directive';
 import { toMarkdown } from 'mdast-util-to-markdown';

--- a/packages/starlight/integrations/satteri.ts
+++ b/packages/starlight/integrations/satteri.ts
@@ -136,39 +136,37 @@ function serializeDirective(node: Parameters<typeof toMarkdown>[0]): string {
 	return md.at(-1) === '\n' ? md.slice(0, -1) : md;
 }
 
-function satteriRtlCodeSupportPlugin(allowedPaths: string[]): () => HastPluginDefinition {
-	return () => {
-		return {
-			name: 'starlight-rtl-code-support',
-			element: [
-				{
-					filter: ['pre'],
-					visit(node, ctx) {
-						if (!shouldTransformPath(ctx.fileURL, allowedPaths)) return;
-						if (node.properties && 'dir' in node.properties) return;
-						ctx.setProperty(node, 'dir', 'ltr');
-					},
+function satteriRtlCodeSupportPlugin(allowedPaths: string[]): HastPluginDefinition {
+	return {
+		name: 'starlight-rtl-code-support',
+		element: [
+			{
+				filter: ['pre'],
+				visit(node, ctx) {
+					if (!shouldTransformPath(ctx.fileURL, allowedPaths)) return;
+					if (node.properties && 'dir' in node.properties) return;
+					ctx.setProperty(node, 'dir', 'ltr');
 				},
-				{
-					filter: ['code'],
-					visit(node, ctx) {
-						if (!shouldTransformPath(ctx.fileURL, allowedPaths)) return;
-						const parent = ctx.parent(node);
-						if (parent?.type === 'element' && parent.tagName === 'pre') return;
-						if (node.properties && 'dir' in node.properties) return;
-						ctx.setProperty(node, 'dir', 'auto');
-					},
-				},
-			],
-			// Shiki runs ahead of us and replaces the highlighted `<pre>` element with a raw HTML
-			// node, so the `pre` element visitor above never sees it. Patch the raw markup instead.
-			raw(node, ctx) {
-				if (!shouldTransformPath(ctx.fileURL, allowedPaths)) return undefined;
-				const value = ltrRawPre(node.value);
-				if (value === null) return undefined;
-				return { type: 'raw', value };
 			},
-		};
+			{
+				filter: ['code'],
+				visit(node, ctx) {
+					if (!shouldTransformPath(ctx.fileURL, allowedPaths)) return;
+					const parent = ctx.parent(node);
+					if (parent?.type === 'element' && parent.tagName === 'pre') return;
+					if (node.properties && 'dir' in node.properties) return;
+					ctx.setProperty(node, 'dir', 'auto');
+				},
+			},
+		],
+		// Shiki runs ahead of us and replaces the highlighted `<pre>` element with a raw HTML
+		// node, so the `pre` element visitor above never sees it. Patch the raw markup instead.
+		raw(node, ctx) {
+			if (!shouldTransformPath(ctx.fileURL, allowedPaths)) return undefined;
+			const value = ltrRawPre(node.value);
+			if (value === null) return undefined;
+			return { type: 'raw', value };
+		},
 	};
 }
 

--- a/packages/starlight/integrations/satteri.ts
+++ b/packages/starlight/integrations/satteri.ts
@@ -138,12 +138,6 @@ function serializeDirective(node: Parameters<typeof toMarkdown>[0]): string {
 
 function satteriRtlCodeSupportPlugin(allowedPaths: string[]): () => HastPluginDefinition {
 	return () => {
-		// HACK: Sätteri currently does not expose a way to either know the parent of a node, or
-		// skipping a subtree visit. To work around this, we manually track the source spans of `<pre>`
-		// elements and skip applying `dir="auto"` to `<code>` elements inside those spans. This is:
-		// bad, because it means that it won't work for nodes without positions (e.g. generated nodes),
-		// but it's as good as it gets right now.
-		const preSpans: Array<[number, number]> = [];
 		return {
 			name: 'starlight-rtl-code-support',
 			element: [
@@ -151,8 +145,6 @@ function satteriRtlCodeSupportPlugin(allowedPaths: string[]): () => HastPluginDe
 					filter: ['pre'],
 					visit(node, ctx) {
 						if (!shouldTransformPath(ctx.fileURL, allowedPaths)) return;
-						const span = nodeSpan(node);
-						if (span) preSpans.push(span);
 						if (node.properties && 'dir' in node.properties) return;
 						ctx.setProperty(node, 'dir', 'ltr');
 					},
@@ -161,7 +153,8 @@ function satteriRtlCodeSupportPlugin(allowedPaths: string[]): () => HastPluginDe
 					filter: ['code'],
 					visit(node, ctx) {
 						if (!shouldTransformPath(ctx.fileURL, allowedPaths)) return;
-						if (isInsideSpan(nodeSpan(node), preSpans)) return;
+						const parent = ctx.parent(node);
+						if (parent?.type === 'element' && parent.tagName === 'pre') return;
 						if (node.properties && 'dir' in node.properties) return;
 						ctx.setProperty(node, 'dir', 'auto');
 					},
@@ -177,18 +170,6 @@ function satteriRtlCodeSupportPlugin(allowedPaths: string[]): () => HastPluginDe
 			},
 		};
 	};
-}
-
-/** The source byte span of a node, or `null` when it carries no position (e.g. a generated node). */
-function nodeSpan(node: { position?: Element['position'] }): [number, number] | null {
-	const start = node.position?.start.offset;
-	const end = node.position?.end.offset;
-	return typeof start === 'number' && typeof end === 'number' ? [start, end] : null;
-}
-
-function isInsideSpan(span: [number, number] | null, spans: Array<[number, number]>): boolean {
-	if (!span) return false;
-	return spans.some(([start, end]) => span[0] >= start && span[1] <= end);
 }
 
 const rawPreOpenTag = /<pre(?=[\s>])[^>]*>/;

--- a/packages/starlight/integrations/satteri.ts
+++ b/packages/starlight/integrations/satteri.ts
@@ -1,12 +1,13 @@
 import { fileURLToPath } from 'node:url';
 import { satteriHeadingIdsPlugin } from '@astrojs/markdown-satteri';
-import type { Properties } from 'hast';
+import type { Parents, Properties } from 'hast';
 import type { Paragraph } from 'mdast';
 import { directiveToMarkdown } from 'mdast-util-directive';
 import { toMarkdown } from 'mdast-util-to-markdown';
 import type {
 	HastPluginDefinition,
 	HastPluginInput,
+	HastVisitorContext,
 	MdastPluginInput,
 	MdastPluginDefinition,
 } from 'satteri';
@@ -151,11 +152,13 @@ function satteriRtlCodeSupportPlugin(allowedPaths: string[]): HastPluginDefiniti
 			{
 				filter: ['code'],
 				visit(node, ctx) {
-					if (!shouldTransformPath(ctx.fileURL, allowedPaths)) return;
-					const parent = ctx.parent(node);
-					if (parent?.type === 'element' && parent.tagName === 'pre') return;
-					if (node.properties && 'dir' in node.properties) return;
-					ctx.setProperty(node, 'dir', 'auto');
+					if (
+						shouldTransformPath(ctx.fileURL, allowedPaths) &&
+						!(node.properties && 'dir' in node.properties) &&
+						!hasPreParent(node, ctx)
+					) {
+						ctx.setProperty(node, 'dir', 'auto');
+					}
 				},
 			},
 		],
@@ -168,6 +171,18 @@ function satteriRtlCodeSupportPlugin(allowedPaths: string[]): HastPluginDefiniti
 			return { type: 'raw', value };
 		},
 	};
+}
+
+/**
+ * Check if any parent of `child` is a `<pre>` element by walking up the tree.
+ */
+function hasPreParent(child: Readonly<Parents> | undefined, ctx: HastVisitorContext): boolean {
+	while (child) {
+		const parent: Readonly<Parents> | undefined = ctx.parent(child);
+		if (parent?.type === 'element' && parent.tagName === 'pre') return true;
+		child = parent;
+	}
+	return false;
 }
 
 const rawPreOpenTag = /<pre(?=[\s>])[^>]*>/;


### PR DESCRIPTION
#### Description

- Fixes our Sätteri plugin for supporting code in RTL documents in newer versions of Astro
- Fixes the failing test in #4113 
- Sätteri now has a `ctx.parent()` we can use to get parents so we can remove the more convoluted code for working this out. Strictly speaking these do not work 1:1 — before, we’d skip applying attributes to a `<code>` element even if it was deeply nested in a `<pre>` whereas now we only skip if the `<code>` is a direct child of the `<pre>`. However, in practice, I think this covers all the scenarios we were intending?
- Existing tests here should pass, showing that the changes work for people on older versions of Astro. And I ran the changes against #4113 too to ensure it fixes the failing test there.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
