### PR TITLE
Replace 3 outdated links to Astro Docs

### DIFF
--- a/docs/src/content/docs/guides/authoring-content.mdx
+++ b/docs/src/content/docs/guides/authoring-content.mdx
@@ -561,7 +561,7 @@ Starlight supports all other Markdown authoring syntax, such as lists and tables
 
 ## Advanced Markdown and MDX configuration
 
-Starlight renders Markdown and MDX using Astro’s configurable [`markdown.processor`](https://docs.astro.build/en/reference/configuration-reference/#markdownprocessor). You can add support for custom syntax and behavior by passing plugins and options to your configured processor. See [“Markdown Plugins”](https://docs.astro.build/en/guides/markdown-content/#markdown-plugins) in the Astro docs to learn more.
+Starlight renders Markdown and MDX using Astro’s configurable [`markdown.processor`](https://docs.astro.build/en/reference/configuration-reference/#markdownprocessor). You can add support for custom syntax and behavior by passing plugins and options to your configured processor. See [“Markdown processor plugins”](https://docs.astro.build/en/guides/markdown-content/#markdown-processor-plugins) in the Astro docs to learn more.
 
 ## Markdoc
 

--- a/docs/src/content/docs/guides/i18n.mdx
+++ b/docs/src/content/docs/guides/i18n.mdx
@@ -332,10 +332,10 @@ The value for `feature` must be set in an options object passed as the second ar
 
 ```astro {3}
 <!-- src/components/Example.astro -->
-<a href="https://docs.astro.build/en/guides/astro-db/">
-	{Astro.locals.t('link.astro.custom', { feature: 'Astro DB' })}
+<a href="https://docs.astro.build/en/guides/actions/">
+	{Astro.locals.t('link.astro.custom', { feature: 'Astro Actions' })}
 </a>
-<!-- Renders: <a href="...">Astro documentation for Astro DB</a> -->
+<!-- Renders: <a href="...">Astro documentation for Astro Actions</a> -->
 ```
 
 See the [i18next documentation](https://www.i18next.com/overview/api#t) for more information on how to use the `t()` function with interpolation, formatting, and more.

--- a/docs/src/content/docs/reference/plugins.md
+++ b/docs/src/content/docs/reference/plugins.md
@@ -331,7 +331,7 @@ The example above will log a message that includes a built-in UI string for the 
 
 Call `absolutePathToLang()` with an absolute file path to get the language for that file.
 
-This can be particularly useful when adding [remark or rehype plugins](https://docs.astro.build/en/guides/markdown-content/#markdown-plugins) to process Markdown or MDX files.
+This can be particularly useful when adding [remark or rehype plugins](https://docs.astro.build/en/guides/markdown-content/#markdown-processor-plugins) to process Markdown or MDX files.
 The [virtual file format](https://github.com/vfile/vfile) used by these plugins includes the [absolute path](https://github.com/vfile/vfile#filepath) of the file being processed, which can be used with `absolutePathToLang()` to determine the language of the file.
 The returned language can be used with the [`useTranslations()`](#usetranslations) helper to get UI strings for that language.
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Replace "Markdown plugins" links

We have recently updated the Markdown guide in Astro Docs (https://github.com/withastro/docs/pull/14297) and the section was renamed "Markdown processor plugins". There was two occurrences in Starlight docs.

- Replace an example using Astro DB

Astro DB has been removed in Astro 7 (https://github.com/withastro/docs/pull/13985) and the Astro DB guide now redirects to the integration page with an aside saying "Removed". I think it is better to use an example that is still relevant.
