### PR TITLE
Update `size-limit` config

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,13 @@
     {
       "name": "/index.html",
       "path": "examples/basics/dist/index.html",
-      "limit": "8 kB",
+      "limit": "7 kB",
+      "gzip": true
+    },
+    {
+      "name": "/guides/example/index.html",
+      "path": "examples/basics/dist/guides/example/index.html",
+      "limit": "7 kB",
       "gzip": true
     },
     {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

We noticed while working on #4121 that our current size limit checks won’t reflect changes to the page sidebars because we test against the start template’s landing page.

This PR adds one of the example guide pages in the starter template to our size limit checks so we also track changes in size to the more standard documentation page layouts as suggested by @trueberryless.

While there I’ve also slightly reduced the size limit for the HTML pages to be a bit closer to the current output sizes and trigger a failure earlier if those increase.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
