### PR TITLE
i18n(de): update links to Astro docs

### DIFF
--- a/docs/src/content/docs/de/guides/authoring-content.mdx
+++ b/docs/src/content/docs/de/guides/authoring-content.mdx
@@ -561,7 +561,7 @@ Starlight unterstützt alle anderen Markdown-Autorensyntaxen, wie Listen und Tab
 
 ## Erweiterte Markdown- und MDX-Konfiguration
 
-Starlight nutzt zum Rendern von Markdown- und MDX-Seiten Astros konfigurierbaren [Markdown-Prozessor](https://docs.astro.build/en/reference/configuration-reference/#markdownprocessor). Du kannst eine Unterstützung für eigene Syntax und Verhalten hinzufügen, indem du Plugins und Optionen an den konfigurierten Prozessor weiterreichst. Weitere Informationen findest du unter ["Markdown Plugins"](https://docs.astro.build/de/guides/markdown-content/#markdown-plugins) in der Astro-Dokumentation.
+Starlight nutzt zum Rendern von Markdown- und MDX-Seiten Astros konfigurierbaren [Markdown-Prozessor](https://docs.astro.build/de/reference/configuration-reference/#markdownprocessor). Du kannst eine Unterstützung für eigene Syntax und Verhalten hinzufügen, indem du Plugins und Optionen an den konfigurierten Prozessor weiterreichst. Weitere Informationen findest du unter ["Markdown-Prozessor-Plugins"](https://docs.astro.build/de/guides/markdown-content/#markdown-processor-plugins) in der Astro-Dokumentation.
 
 ## Markdoc
 

--- a/docs/src/content/docs/de/guides/i18n.mdx
+++ b/docs/src/content/docs/de/guides/i18n.mdx
@@ -332,10 +332,10 @@ Der Wert für `feature` muss in einem Optionsobjekt gesetzt werden, das als zwei
 
 ```astro {3}
 <!-- src/components/Example.astro -->
-<a href="https://docs.astro.build/en/guides/astro-db/">
-	{Astro.locals.t('link.astro.custom', { feature: 'Astro DB' })}
+<a href="https://docs.astro.build/en/guides/actions/">
+	{Astro.locals.t('link.astro.custom', { feature: 'Astro Actions' })}
 </a>
-<!-- Rendert: <a href="...">Astro-Dokumentation für Astro DB</a> -->
+<!-- Rendert: <a href="...">Astro-Dokumentation für Astro Actions</a> -->
 ```
 
 In der [i18next-Dokumentation](https://www.i18next.com/overview/api#t) findest du weitere Informationen darüber, wie du die Funktion `t()` mit Interpolation, Formatierung und mehr verwenden kannst.

--- a/docs/src/content/docs/de/reference/plugins.md
+++ b/docs/src/content/docs/de/reference/plugins.md
@@ -333,7 +333,7 @@ Im obigen Beispiel wird eine Meldung protokolliert, die einen integrierten UI-St
 
 Rufe `absolutePathToLang()` mit einem absoluten Dateipfad auf, um die Sprache für diese Datei zu erhalten.
 
-Dies kann besonders nützlich sein, wenn du [remark oder rehype Plugins](https://docs.astro.build/de/guides/markdown-content/#markdown-plugins) hinzufügst, um Markdown- oder MDX-Dateien zu verarbeiten.
+Dies kann besonders nützlich sein, wenn du [remark oder rehype Plugins](https://docs.astro.build/de/guides/markdown-content/#markdown-processor-plugins) hinzufügst, um Markdown- oder MDX-Dateien zu verarbeiten.
 Das von diesen Plugins verwendete [virtuelle Dateiformat](https://github.com/vfile/vfile) enthält den [absoluten Pfad](https://github.com/vfile/vfile#filepath) der zu verarbeitenden Datei, der mit `absolutePathToLang()` verwendet werden kann, um die Sprache der Datei zu bestimmen.
 Die zurückgegebene Sprache kann mit dem Helfer [`useTranslations()`](#usetranslations) verwendet werden, um UI-Strings für diese Sprache zu erhalten.
 


### PR DESCRIPTION
#### Description

This PR updates the German translation of 3 pages in total, which included outdated links to Astro's documentation -- as originally discovered and updated by Armand in #4120 

I decided to keep the links localized (linking to `/de/` instead of `/en/`), although those pages are not yet translated, so the user stays localized in German nonetheless. The HTML fragments are kept valid in English tho.