### PR TITLE
Add starlight-pydocs and starlight-quiz

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -243,6 +243,16 @@ Extend your site with official plugins supported by the Starlight team and commu
 		title="starlight-agentready"
 		description="Submit your docs to AgentReady after every build, making them queryable by AI agents via MCP."
 	/>
+	<LinkCard
+		href="https://github.com/ewels/starlight-pydocs"
+		title="starlight-pydocs"
+		description="Automated Python API docs for Astro and Starlight, using static analysis."
+	/>
+	<LinkCard
+		href="https://github.com/ewels/starlight-quiz"
+		title="starlight-quiz"
+		description="Interactive quizzes for Astro and Starlight, authored in markdown with full progress tracking."
+	/>
 </CardGrid>
 
 ## Community tools and integrations
@@ -331,15 +341,5 @@ These community tools and integrations can be used to add features to your Starl
 		href="https://github.com/pixelizing/axiom-studio-for-starlight"
 		title="Axiom Studio for Starlight"
 		description="A local-first browser editor for editing Markdown and MDX pages, managing frontmatter, and previewing Starlight docs without touching raw files."
-	/>
-	<LinkCard
-		href="https://github.com/ewels/starlight-pydocs"
-		title="starlight-pydocs"
-		description="Automated Python API docs for Astro and Starlight, using static analysis."
-	/>
-	<LinkCard
-		href="https://github.com/ewels/starlight-quiz"
-		title="starlight-quiz"
-		description="Interactive quizzes for Astro and Starlight, authored in markdown with full progress tracking."
 	/>
 </CardGrid>

--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -332,4 +332,14 @@ These community tools and integrations can be used to add features to your Starl
 		title="Axiom Studio for Starlight"
 		description="A local-first browser editor for editing Markdown and MDX pages, managing frontmatter, and previewing Starlight docs without touching raw files."
 	/>
+	<LinkCard
+		href="https://github.com/ewels/starlight-pydocs"
+		title="starlight-pydocs"
+		description="Automated Python API docs for Astro and Starlight, using static analysis."
+	/>
+	<LinkCard
+		href="https://github.com/ewels/starlight-quiz"
+		title="starlight-quiz"
+		description="Interactive quizzes for Astro and Starlight, authored in markdown with full progress tracking."
+	/>
 </CardGrid>


### PR DESCRIPTION
#### Description

Adds new LinkCard entries for two new plugins to the starlight [community plugins](https://starlight.astro.build/resources/plugins/) section:

- [starlight-pydocs](https://github.com/ewels/starlight-pydocs), a Starlight version of [mkdocstrings](https://mkdocstrings.github.io/) that uses Griffe for Python static analysis and then builds the Starlight pages from that JSON.
- [starlight-quiz](https://github.com/ewels/starlight-quiz), a Starlight version of [mkdocs-quiz](https://ewels.github.io/mkdocs-quiz/)

Convention seemed to be to link the GitHub source repositories, so that's what I did. If you prefer, I can link the docs websites instead:

- https://ewels.github.io/starlight-pydocs/
- https://ewels.github.io/starlight-quiz/

Thank you for Astro and Starlight! 🌟 