### PR TITLE
Use a page-specific counter for `<Tabs>`  IDs

### DIFF
--- a/.changeset/long-adults-wave.md
+++ b/.changeset/long-adults-wave.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/starlight': patch
+---
+
+Internal refactor: numbered `id` attributes in the `<Tabs>` component now increment from `1` on each page instead of using a global counter

--- a/.changeset/long-adults-wave.md
+++ b/.changeset/long-adults-wave.md
@@ -2,4 +2,4 @@
 '@astrojs/starlight': patch
 ---
 
-Internal refactor: numbered `id` attributes in the `<Tabs>` component now increment from `1` on each page instead of using a global counter
+Internal refactor: numbered `id` attributes in the `<Tabs>` component are now page-specific instead of using a global counter

--- a/packages/starlight/__tests__/markdown-processor/rehype-tabs.test.ts
+++ b/packages/starlight/__tests__/markdown-processor/rehype-tabs.test.ts
@@ -38,12 +38,12 @@ test('tab items are processed', () => {
 	const { panels, html } = processPanels(input, 0);
 
 	expect(html).toMatchInlineSnapshot(
-		`"<div id="tab-panel-0" aria-labelledby="tab-0" role="tabpanel" tabindex="0"><p>Random paragraph</p></div>"`
+		`"<div id="tab-panel-0-0" aria-labelledby="tab-0-0" role="tabpanel" tabindex="0"><p>Random paragraph</p></div>"`
 	);
 	expect(panels).toHaveLength(1);
 	expect(panels?.[0]?.label).toBe(label);
-	expect(panels?.[0]?.panelId).toMatchInlineSnapshot('"tab-panel-0"');
-	expect(panels?.[0]?.tabId).toMatchInlineSnapshot('"tab-0"');
+	expect(panels?.[0]?.panelId).toMatchInlineSnapshot(`"tab-panel-0-0"`);
+	expect(panels?.[0]?.tabId).toMatchInlineSnapshot(`"tab-0-0"`);
 	expect(panels?.[0]?.icon).not.toBeDefined();
 });
 
@@ -54,14 +54,14 @@ test('only first item is not hidden', () => {
 
 	expect(panels).toHaveLength(3);
 	expect(html).toMatchInlineSnapshot(
-		`"<div id="tab-panel-1" aria-labelledby="tab-1" role="tabpanel" tabindex="0"><div>One</div></div><div id="tab-panel-2" aria-labelledby="tab-2" role="tabpanel" tabindex="0" hidden><div>Two</div></div><div id="tab-panel-3" aria-labelledby="tab-3" role="tabpanel" tabindex="0" hidden><div>Three</div></div>"`
+		`"<div id="tab-panel-1-0" aria-labelledby="tab-1-0" role="tabpanel" tabindex="0"><div>One</div></div><div id="tab-panel-1-1" aria-labelledby="tab-1-1" role="tabpanel" tabindex="0" hidden><div>Two</div></div><div id="tab-panel-1-2" aria-labelledby="tab-1-2" role="tabpanel" tabindex="0" hidden><div>Three</div></div>"`
 	);
 	const tabPanels = extractTabPanels(html);
 	expect(tabPanels).toMatchInlineSnapshot(`
 		[
-		  "<div id="tab-panel-1" aria-labelledby="tab-1" role="tabpanel" tabindex="0"><div>One</div></div>",
-		  "<div id="tab-panel-2" aria-labelledby="tab-2" role="tabpanel" tabindex="0" hidden><div>Two</div></div>",
-		  "<div id="tab-panel-3" aria-labelledby="tab-3" role="tabpanel" tabindex="0" hidden><div>Three</div></div>",
+		  "<div id="tab-panel-1-0" aria-labelledby="tab-1-0" role="tabpanel" tabindex="0"><div>One</div></div>",
+		  "<div id="tab-panel-1-1" aria-labelledby="tab-1-1" role="tabpanel" tabindex="0" hidden><div>Two</div></div>",
+		  "<div id="tab-panel-1-2" aria-labelledby="tab-1-2" role="tabpanel" tabindex="0" hidden><div>Three</div></div>",
 		]
 	`);
 	expect(tabPanels.map((tabPanel) => tabPanel.includes('hidden'))).toEqual([false, true, true]);
@@ -73,12 +73,12 @@ test('applies incrementing ID and aria-labelledby to each tab item', () => {
 	const { panels, html } = processPanels(input, 1);
 
 	// IDs are incremented globally to ensure they are unique, so we need to extract from the panel data.
-	const firstTabIdMatches = panels?.[0]?.tabId.match(/^tab-(\d)+$/);
+	const firstTabIdMatches = panels?.[0]?.tabId.match(/^tab-1-(\d)+$/);
 	const firstTabId = parseInt(firstTabIdMatches![1]!, 10);
 
 	extractTabPanels(html).forEach((tabPanel, index) => {
-		expect(tabPanel).includes(`id="tab-panel-${firstTabId + index}"`);
-		expect(tabPanel).includes(`aria-labelledby="tab-${firstTabId + index}"`);
+		expect(tabPanel).includes(`id="tab-panel-1-${firstTabId + index}"`);
+		expect(tabPanel).includes(`aria-labelledby="tab-1-${firstTabId + index}"`);
 	});
 });
 
@@ -93,7 +93,7 @@ test('applies tabindex="0" to tab items without focusable content', () => {
 	].join('');
 	const { html } = processPanels(input, 7);
 	expect(html).toMatchInlineSnapshot(
-		`"<div id="tab-panel-7" aria-labelledby="tab-7" role="tabpanel"><div><a href="/home/">Home</a></div></div><div id="tab-panel-8" aria-labelledby="tab-8" role="tabpanel" tabindex="0" hidden><div>Plain text</div></div><div id="tab-panel-9" aria-labelledby="tab-9" role="tabpanel" hidden><div><p><span><input type="text"></span></p></div></div>"`
+		`"<div id="tab-panel-7-0" aria-labelledby="tab-7-0" role="tabpanel"><div><a href="/home/">Home</a></div></div><div id="tab-panel-7-1" aria-labelledby="tab-7-1" role="tabpanel" tabindex="0" hidden><div>Plain text</div></div><div id="tab-panel-7-2" aria-labelledby="tab-7-2" role="tabpanel" hidden><div><p><span><input type="text"></span></p></div></div>"`
 	);
 	const tabPanels = extractTabPanels(html);
 	expect(tabPanels[0]).not.includes('tabindex="0"');
@@ -107,7 +107,7 @@ test('processes a tab item icon', () => {
 	const { panels, html } = processPanels(input, 10);
 
 	expect(html).toMatchInlineSnapshot(
-		`"<div id="tab-panel-10" aria-labelledby="tab-10" role="tabpanel" tabindex="0"><p>Random paragraph</p></div>"`
+		`"<div id="tab-panel-10-0" aria-labelledby="tab-10-0" role="tabpanel" tabindex="0"><p>Random paragraph</p></div>"`
 	);
 	expect(panels).toHaveLength(1);
 	expect(panels?.[0]?.icon).toBe(icon);

--- a/packages/starlight/__tests__/markdown-processor/rehype-tabs.test.ts
+++ b/packages/starlight/__tests__/markdown-processor/rehype-tabs.test.ts
@@ -19,14 +19,14 @@ const extractTabPanels = (html: string) => {
 };
 
 test('empty component returns no html or panels', () => {
-	const { panels, html } = processPanels('');
+	const { panels, html } = processPanels('', 1);
 	expect(html).toEqual('');
 	expect(panels).toEqual([]);
 });
 
 test('non-tab-item content is passed unchanged', () => {
 	const input = '<p>Random paragraph</p>';
-	const { panels, html } = processPanels(input);
+	const { panels, html } = processPanels(input, 1);
 	expect(html).toEqual(input);
 	expect(panels).toEqual([]);
 });
@@ -35,7 +35,7 @@ test('tab items are processed', () => {
 	const label = 'Test';
 	const slot = '<p>Random paragraph</p>';
 	const input = TabItem({ label, slot });
-	const { panels, html } = processPanels(input);
+	const { panels, html } = processPanels(input, 0);
 
 	expect(html).toMatchInlineSnapshot(
 		`"<div id="tab-panel-0" aria-labelledby="tab-0" role="tabpanel" tabindex="0"><p>Random paragraph</p></div>"`
@@ -50,7 +50,7 @@ test('tab items are processed', () => {
 test('only first item is not hidden', () => {
 	const labels = ['One', 'Two', 'Three'];
 	const input = labels.map((label) => TabItem({ label, slot: `<div>${label}</div>` })).join('');
-	const { panels, html } = processPanels(input);
+	const { panels, html } = processPanels(input, 1);
 
 	expect(panels).toHaveLength(3);
 	expect(html).toMatchInlineSnapshot(
@@ -70,7 +70,7 @@ test('only first item is not hidden', () => {
 test('applies incrementing ID and aria-labelledby to each tab item', () => {
 	const labels = ['One', 'Two', 'Three'];
 	const input = labels.map((label) => TabItem({ label, slot: `<div>${label}</div>` })).join('');
-	const { panels, html } = processPanels(input);
+	const { panels, html } = processPanels(input, 1);
 
 	// IDs are incremented globally to ensure they are unique, so we need to extract from the panel data.
 	const firstTabIdMatches = panels?.[0]?.tabId.match(/^tab-(\d)+$/);
@@ -91,7 +91,7 @@ test('applies tabindex="0" to tab items without focusable content', () => {
 			slot: `<div><p><span><input type="text"></span></p></div>`,
 		}),
 	].join('');
-	const { html } = processPanels(input);
+	const { html } = processPanels(input, 7);
 	expect(html).toMatchInlineSnapshot(
 		`"<div id="tab-panel-7" aria-labelledby="tab-7" role="tabpanel"><div><a href="/home/">Home</a></div></div><div id="tab-panel-8" aria-labelledby="tab-8" role="tabpanel" tabindex="0" hidden><div>Plain text</div></div><div id="tab-panel-9" aria-labelledby="tab-9" role="tabpanel" hidden><div><p><span><input type="text"></span></p></div></div>"`
 	);
@@ -104,7 +104,7 @@ test('applies tabindex="0" to tab items without focusable content', () => {
 test('processes a tab item icon', () => {
 	const icon = 'star';
 	const input = TabItem({ label: 'Test', slot: '<p>Random paragraph</p>', icon });
-	const { panels, html } = processPanels(input);
+	const { panels, html } = processPanels(input, 10);
 
 	expect(html).toMatchInlineSnapshot(
 		`"<div id="tab-panel-10" aria-labelledby="tab-10" role="tabpanel" tabindex="0"><p>Random paragraph</p></div>"`

--- a/packages/starlight/user-components/Tabs.astro
+++ b/packages/starlight/user-components/Tabs.astro
@@ -7,8 +7,6 @@ interface Props {
 }
 
 const { syncKey } = Astro.props;
-const panelHtml = await Astro.slots.render('default');
-const { html, panels } = processPanels(panelHtml);
 
 /**
  * Synced tabs are persisted across page using `localStorage`. The script used to restore the
@@ -37,6 +35,15 @@ if (isSynced) {
 	// @ts-expect-error - See above
 	Astro.locals[didRenderSyncedTabsRestoreScriptSymbol] = true
 }
+
+// Track how many <Tabs> have been rendered on the current page.
+const tabInstanceCountSymbol = Symbol.for('starlight:tab-instance-count');
+const tabInstanceCount
+// @ts-expect-error - Untyped as it’s a local and private API, see above.
+	= Astro.locals[tabInstanceCountSymbol] = ((Astro.locals[tabInstanceCountSymbol]) ?? 0) + 1;
+
+const panelHtml = await Astro.slots.render('default');
+const { html, panels } = processPanels(panelHtml, tabInstanceCount);
 ---
 
 {/* Inlined to avoid a flash of invalid active tab. */}

--- a/packages/starlight/user-components/Tabs.astro
+++ b/packages/starlight/user-components/Tabs.astro
@@ -8,39 +8,45 @@ interface Props {
 
 const { syncKey } = Astro.props;
 
-/**
- * Synced tabs are persisted across page using `localStorage`. The script used to restore the
- * active tab for a given sync key has a few requirements:
- *
- * - The script should only be included when at least one set of synced tabs is present on the page.
- * - The script should be inlined to avoid a flash of invalid active tab.
- * - The script should only be included once per page.
- *
- * To do so, we keep track of whether the script has been rendered using a variable stored using
- * `Astro.locals` which will be reset for each new page. The value is tracked using an untyped
- * symbol on purpose to avoid Starlight users to get autocomplete for it and avoid potential
- * clashes with user-defined variables.
- *
- * The restore script defines a custom element `starlight-tabs-restore` that will be included in
- * each set of synced tabs to restore the active tab based on the persisted value using the
- * `connectedCallback` lifecycle method. To ensure this callback can access all tabs and panels for
- * the current set of tabs, the script should be rendered before the tabs themselves.
- */
-const isSynced = syncKey !== undefined;
+// Some tab functionality has to be co-ordinated across multiple instances for each page. To do
+// this, we keep track of page-level state in symbol-keyed variables in `Astro.locals`, which is a
+// fresh object for each new page. The keys are not typed globally to avoid Starlight users
+// getting autocomplete for them and using symbols reduces the risk of potential clashes with
+// user-defined variables.
+//
+// We store data for:
+// 
+// - The number of tabs rendered on the current page, so that each set can have unique IDs.
+//
+// - Synced tabs, which are persisted across pages using `localStorage`. The script used to restore
+// the active tab for a given sync key has a few requirements:
+//   - The script should only be included when at least one set of synced tabs is present on the page.
+//   - The script should be inlined to avoid a flash of invalid active tab.
+//   - The script should only be included once per page.
+//
+//   The restore script defines a custom element `starlight-tabs-restore` that will be included in
+//   each set of synced tabs to restore the active tab based on the persisted value using the
+//   `connectedCallback` lifecycle method. To ensure this callback can access all tabs and panels for
+//   the current set of tabs, the script should be rendered before the tabs themselves.
+
 const didRenderSyncedTabsRestoreScriptSymbol = Symbol.for('starlight:did-render-synced-tabs-restore-script');
-// @ts-expect-error - See above
-const shouldRenderSyncedTabsRestoreScript = isSynced && Astro.locals[didRenderSyncedTabsRestoreScriptSymbol] !== true;
+const tabInstanceCountSymbol = Symbol.for('starlight:tab-instance-count');
+
+const locals = Astro.locals as App.Locals & {
+	[didRenderSyncedTabsRestoreScriptSymbol]?: boolean;
+	[tabInstanceCountSymbol]?: number;
+};
+
+const isSynced = syncKey !== undefined;
+const shouldRenderSyncedTabsRestoreScript =
+	isSynced && locals[didRenderSyncedTabsRestoreScriptSymbol] !== true;
 
 if (isSynced) {
-	// @ts-expect-error - See above
-	Astro.locals[didRenderSyncedTabsRestoreScriptSymbol] = true
+	locals[didRenderSyncedTabsRestoreScriptSymbol] = true;
 }
 
-// Track how many <Tabs> have been rendered on the current page.
-const tabInstanceCountSymbol = Symbol.for('starlight:tab-instance-count');
-const tabInstanceCount
-// @ts-expect-error - Untyped as it’s a local and private API, see above.
-	= Astro.locals[tabInstanceCountSymbol] = ((Astro.locals[tabInstanceCountSymbol]) ?? 0) + 1;
+locals[tabInstanceCountSymbol] ??= 0;
+const tabInstanceCount = locals[tabInstanceCountSymbol]++;
 
 const panelHtml = await Astro.slots.render('default');
 const { html, panels } = processPanels(panelHtml, tabInstanceCount);

--- a/packages/starlight/user-components/rehype-tabs.ts
+++ b/packages/starlight/user-components/rehype-tabs.ts
@@ -52,10 +52,13 @@ const tabsProcessor = rehype()
 		return (tree: Element, file) => {
 			file.data.panels = [];
 			let isFirst = true;
-			let count = file.data.index!;
+			let count = 0;
 			const getIDs = () => {
 				const id = count++;
-				return { panelId: 'tab-panel-' + id, tabId: 'tab-' + id };
+				return {
+					panelId: `tab-panel-${file.data.index}-${id}`,
+					tabId: `tab-${file.data.index}-${id}`,
+				};
 			};
 			visit(tree, 'element', (node) => {
 				if (node.tagName !== TabItemTagname || !node.properties) {

--- a/packages/starlight/user-components/rehype-tabs.ts
+++ b/packages/starlight/user-components/rehype-tabs.ts
@@ -2,6 +2,7 @@ import type { Element } from 'hast';
 import { select } from 'hast-util-select';
 import { rehype } from 'rehype';
 import { CONTINUE, SKIP, visit } from 'unist-util-visit';
+import { VFile } from 'vfile';
 import type { StarlightIcon } from '../components-internals/Icons';
 
 interface Panel {
@@ -14,6 +15,7 @@ interface Panel {
 declare module 'vfile' {
 	interface DataMap {
 		panels: Panel[];
+		index: number;
 	}
 }
 
@@ -39,12 +41,6 @@ const focusableElementSelectors = [
 	.map((selector) => `${selector}:not([hidden]):not([tabindex="-1"])`)
 	.join(',');
 
-let count = 0;
-const getIDs = () => {
-	const id = count++;
-	return { panelId: 'tab-panel-' + id, tabId: 'tab-' + id };
-};
-
 /**
  * Rehype processor to extract tab panel data and turn each
  * `<starlight-tab-item>` into a `<div>` with the necessary
@@ -56,6 +52,11 @@ const tabsProcessor = rehype()
 		return (tree: Element, file) => {
 			file.data.panels = [];
 			let isFirst = true;
+			let count = file.data.index!;
+			const getIDs = () => {
+				const id = count++;
+				return { panelId: 'tab-panel-' + id, tabId: 'tab-' + id };
+			};
 			visit(tree, 'element', (node) => {
 				if (node.tagName !== TabItemTagname || !node.properties) {
 					return CONTINUE;
@@ -104,9 +105,10 @@ const tabsProcessor = rehype()
  * Process tab panel items to extract data for the tab links and format
  * each tab panel correctly.
  * @param html Inner HTML passed to the `<Tabs>` component.
+ * @param index The index of the `<Tabs>` component on the page.
  */
-export const processPanels = (html: string) => {
-	const file = tabsProcessor.processSync({ value: html });
+export const processPanels = (html: string, index: number) => {
+	const file = tabsProcessor.processSync(new VFile({ value: html, data: { index } }));
 	return {
 		/** Data for each tab panel. */
 		panels: file.data.panels,


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

<!-- New features should first be discussed and approved by maintainers in GitHub or Discord discussions. -->
<!-- If this PR adds a new public-facing feature, uncomment the line below and include a link to the relevant discussion. -->
<!-- - [x] This PR adds a new feature which has been discussed and approved [here](link to GitHub or Discord discussion). -->

- Closes #4132  <!-- Add an issue number if this PR will close it. -->
- Uses a per-page counter so that the HTML output by `<Tabs>` does not change on one page as a side effect of adding/removing tabs in other pages.
- Before, tab HTML would include markup like `id="tab-panel-37"` indicating the 37th panel rendered during a build/dev session. These IDs now contain two indexes: one for the instance on the page, another for the panel within that instance, e.g. `id="tab-panel-1-3"` for the fourth panel in the second `<Tabs>` on a page (the counts are zero-indexed).
- Initially when reading #4132 I considered closing it as “working as intended” because tab IDs are an internal API detail and don’t matter too much. However, I think it’s valuable to fix as build systems that diff page content and upload changed files may benefit from this by not needing to reupload multiple files just because of a `<Tabs>` change on another page earlier in the build.
- Made this a patch as I don’t think there are any reasonable ways people could be using the current `id` format but happy to reconsider if someone knows of one.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
