### PR TITLE
Fix localisation of Expressive Code UI

### DIFF
--- a/.changeset/modern-dragons-reply.md
+++ b/.changeset/modern-dragons-reply.md
@@ -2,4 +2,4 @@
 "@astrojs/starlight": patch
 ---
 
-Fixes localisation of code block UI elements
+Fixes localisation of code block UI elements when using the Sätteri Markdown processor

--- a/.changeset/modern-dragons-reply.md
+++ b/.changeset/modern-dragons-reply.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fixes localisation of code block UI elements

--- a/packages/starlight/__tests__/expressive-code/preprocessor.test.ts
+++ b/packages/starlight/__tests__/expressive-code/preprocessor.test.ts
@@ -1,0 +1,218 @@
+import type { ExpressiveCodeTheme, StyleVariant } from 'astro-expressive-code';
+import { describe, expect, test, vi } from 'vitest';
+import { getStarlightEcConfigPreprocessor } from '../../integrations/expressive-code/preprocessor';
+import { StarlightConfigSchema, type StarlightUserConfig } from '../../utils/user-config';
+
+describe('getStarlightEcConfigPreprocessor()', () => {
+	test('warns when using `useStarlightUiThemeColors` with a single theme', async () => {
+		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		await preprocessEcConfig({ themes: ['starlight-light'], useStarlightUiThemeColors: true });
+
+		expect(consoleWarnSpy).toHaveBeenCalledWith(
+			expect.stringContaining(
+				'Using the config option "useStarlightUiThemeColors: true" with a single theme is not recommended.'
+			)
+		);
+
+		consoleWarnSpy.mockRestore();
+	});
+});
+
+describe('Expressive Code config', () => {
+	describe('themeCssSelector()', () => {
+		test('returns a custom theme selector for a single custom theme', async () => {
+			const config = await preprocessEcConfig();
+			if (typeof config.themeCssSelector !== 'function') {
+				throw new Error('Expected `themeCssSelector` to be a function');
+			}
+
+			const selector = config.themeCssSelector({ name: 'test-theme' } as ExpressiveCodeTheme, {
+				styleVariants: [],
+			});
+
+			expect(selector).toBe("[data-theme='test-theme']");
+		});
+
+		test('returns Starlight theme switcher-compatible selectors for a dark/light theme pair', async () => {
+			const config = await preprocessEcConfig();
+			if (typeof config.themeCssSelector !== 'function') {
+				throw new Error('Expected `themeCssSelector` to be a function');
+			}
+
+			const darkStyle = { theme: { name: 'test-theme', type: 'dark' } } as StyleVariant;
+			const lightStyle = { theme: { name: 'test-theme-light', type: 'light' } } as StyleVariant;
+			const context = { styleVariants: [darkStyle, lightStyle] };
+
+			const darkSelector = config.themeCssSelector(darkStyle.theme, context);
+			expect(darkSelector).toBe("[data-theme='dark']");
+			const lightSelector = config.themeCssSelector(lightStyle.theme, context);
+			expect(lightSelector).toBe("[data-theme='light']");
+		});
+
+		test('returns theme name selector if dark/light toggle is disabled', async () => {
+			const config = await preprocessEcConfig({ useStarlightDarkModeSwitch: false });
+			if (typeof config.themeCssSelector !== 'function') {
+				throw new Error('Expected `themeCssSelector` to be a function');
+			}
+
+			const darkStyle = { theme: { name: 'test-theme', type: 'dark' } } as StyleVariant;
+			const lightStyle = { theme: { name: 'test-theme-light', type: 'light' } } as StyleVariant;
+
+			const selector = config.themeCssSelector(darkStyle.theme, {
+				styleVariants: [darkStyle, lightStyle],
+			});
+
+			expect(selector).toBe("[data-theme='test-theme']");
+		});
+
+		test('returns theme name selector for additional themes', async () => {
+			const config = await preprocessEcConfig();
+			if (typeof config.themeCssSelector !== 'function') {
+				throw new Error('Expected `themeCssSelector` to be a function');
+			}
+
+			const darkStyle = { theme: { name: 'test-theme-dark', type: 'dark' } } as StyleVariant;
+			const lightStyle = { theme: { name: 'test-theme-light', type: 'light' } } as StyleVariant;
+			const thirdStyle = { theme: { name: 'test-theme-third', type: 'dark' } } as StyleVariant;
+			const fourthStyle = { theme: { name: 'test-theme-fourth', type: 'light' } } as StyleVariant;
+			const context = { styleVariants: [darkStyle, lightStyle, thirdStyle, fourthStyle] };
+
+			expect(config.themeCssSelector(darkStyle.theme, context)).toBe("[data-theme='dark']");
+			expect(config.themeCssSelector(lightStyle.theme, context)).toBe("[data-theme='light']");
+			expect(config.themeCssSelector(thirdStyle.theme, context)).toBe(
+				"[data-theme='test-theme-third']"
+			);
+			expect(config.themeCssSelector(fourthStyle.theme, context)).toBe(
+				"[data-theme='test-theme-fourth']"
+			);
+		});
+	});
+
+	describe('getBlockLocale()', () => {
+		/** Utility to create a stub of the object shape expected by `getBlockLocale()`. */
+		const CodeInput = ({ path, url }: { path: string; url?: URL }) => ({
+			input: { code: '', language: 'ts' },
+			file: { cwd: '', data: {}, path, url },
+		});
+
+		test('gets the root locale when an absolute file URL is passed', async () => {
+			const config = await preprocessEcConfig();
+			const locale = config.getBlockLocale?.(
+				CodeInput({ path: '/path/to/docs/doc.md', url: new URL('file:///path/to/docs/doc.md') })
+			);
+			expect(locale).toBe('en');
+		});
+
+		test('gets a non-root locale when an absolute file URL is passed', async () => {
+			const config = await preprocessEcConfig();
+			const locale = config.getBlockLocale?.(
+				CodeInput({
+					path: '/path/to/docs/fr/doc.md',
+					url: new URL('file:///path/to/docs/fr/doc.md'),
+				})
+			);
+			expect(locale).toBe('fr');
+		});
+
+		test('gets the root locale when no file URL is passed', async () => {
+			const config = await preprocessEcConfig();
+			const locale = await config.getBlockLocale?.(CodeInput({ path: '/path/to/docs/doc.md' }));
+			expect(locale).toBe('en');
+		});
+
+		test('gets a non-root locale when no file URL is passed', async () => {
+			const config = await preprocessEcConfig();
+			const locale = await config.getBlockLocale?.(CodeInput({ path: '/path/to/docs/fr/doc.md' }));
+			expect(locale).toBe('fr');
+		});
+
+		test('gets the root locale for a file in the docs when Astro.url is passed', async () => {
+			const config = await preprocessEcConfig();
+			const locale = await config.getBlockLocale?.(
+				CodeInput({ path: 'doc.md', url: new URL('https://example.com/doc.md') })
+			);
+			expect(locale).toBe('en');
+		});
+
+		test('gets a non-root locale for a file in the docs when Astro.url is passed', async () => {
+			const config = await preprocessEcConfig();
+			const locale = await config.getBlockLocale?.(
+				CodeInput({ path: 'fr/doc.md', url: new URL('https://example.com/fr/doc.md') })
+			);
+			expect(locale).toBe('fr');
+		});
+	});
+
+	describe('customizeTheme()', () => {
+		test('uses custom theme returned from `customizeTheme()`', async () => {
+			const config = await preprocessEcConfig({
+				customizeTheme: () => {
+					return { name: 'custom-theme' } as ExpressiveCodeTheme;
+				},
+			});
+			const customizedTheme = config.customizeTheme?.({
+				name: 'original-theme',
+				colors: {},
+				styleOverrides: {},
+			} as ExpressiveCodeTheme);
+			expect(customizedTheme?.name).toBe('custom-theme');
+		});
+
+		test('uses mutated theme from `customizeTheme()`', async () => {
+			const config = await preprocessEcConfig({
+				customizeTheme: (theme: ExpressiveCodeTheme) => {
+					theme.name = 'custom-theme';
+				},
+			});
+			const customizedTheme = config.customizeTheme?.({
+				name: 'original-theme',
+				colors: {},
+				styleOverrides: {},
+			} as ExpressiveCodeTheme);
+			expect(customizedTheme?.name).toBe('custom-theme');
+		});
+
+		test('is a no-op if `customizeTheme()` function is not set and `applyStarlightUiThemeColors` is false', async () => {
+			const config = await preprocessEcConfig({ applyStarlightUiThemeColors: false });
+			const theme = { name: 'my-theme', colors: {}, styleOverrides: {} } as ExpressiveCodeTheme;
+			const customizedTheme = config.customizeTheme?.(theme);
+			expect(customizedTheme).toBe(theme);
+		});
+	});
+});
+
+/** Preprocess an Expressive Code config using the Starlight preprocessor. */
+async function preprocessEcConfig(ecConfig: unknown = {}) {
+	const [starlightConfig, useTranslations] = getStarlightConfigAndUseTranslations({
+		root: { label: 'English', lang: 'en' },
+		fr: { label: 'French', lang: 'fr' },
+	});
+	const configPreprocessor = getStarlightEcConfigPreprocessor({
+		docsPath: '/path/to/docs/',
+		starlightConfig,
+		useTranslations,
+	});
+	// @ts-expect-error — We’re skipping some properties of `astroConfig`.
+	return await configPreprocessor({ ecConfig, astroConfig: {} });
+}
+
+function getUseTranslations(exists: boolean = true) {
+	const t = () => 'test UI string';
+	t.exists = vi.fn().mockReturnValue(exists);
+	return vi.fn().mockReturnValue(t);
+}
+
+function getStarlightConfigAndUseTranslations(
+	locales: StarlightUserConfig['locales'],
+	defaultLocale?: StarlightUserConfig['defaultLocale']
+) {
+	return [
+		StarlightConfigSchema.parse({
+			title: 'Expressive Code Translations Test',
+			locales,
+			defaultLocale,
+		}),
+		getUseTranslations(),
+	] as const;
+}

--- a/packages/starlight/__tests__/expressive-code/preprocessor.test.ts
+++ b/packages/starlight/__tests__/expressive-code/preprocessor.test.ts
@@ -1,8 +1,13 @@
+import { unified } from '@astrojs/markdown-remark';
+import { satteri } from '@astrojs/markdown-satteri';
 import type { ExpressiveCodeTheme, StyleVariant } from 'astro-expressive-code';
+import { astroExpressiveCode } from 'astro-expressive-code';
 import { describe, expect, test, vi } from 'vitest';
 import type { StarlightExpressiveCodeOptions } from '../../integrations/expressive-code';
 import { getStarlightEcConfigPreprocessor } from '../../integrations/expressive-code/preprocessor';
+import { getCollectionPosixPath } from '../../utils/collection-fs';
 import { StarlightConfigSchema, type StarlightUserConfig } from '../../utils/user-config';
+import { createPluginTestOptions, docFileURL } from '../test-utils';
 
 describe('getStarlightEcConfigPreprocessor()', () => {
 	test('warns when using `useStarlightUiThemeColors` with a single theme', async () => {
@@ -179,6 +184,59 @@ describe('Expressive Code config', () => {
 			const theme = { name: 'my-theme', colors: {}, styleOverrides: {} } as ExpressiveCodeTheme;
 			const customizedTheme = config.customizeTheme?.(theme);
 			expect(customizedTheme).toStrictEqual({ name: 'my-theme', colors: {}, styleOverrides: {} });
+		});
+	});
+});
+
+describe('processors', () => {
+	const processors = [
+		{ name: 'Sätteri', create: () => satteri() },
+		{ name: 'Unified', create: () => unified() },
+	];
+
+	describe.for(processors)('$name', ({ create }) => {
+		test('localizes Expressive Code UI', async () => {
+			const userConfig: StarlightUserConfig = {
+				title: 'Expressive Code',
+				locales: {
+					root: { label: 'English', lang: 'en' },
+					fr: { label: 'French', lang: 'fr' },
+				},
+			};
+
+			const { astroConfig, useTranslations } = await createPluginTestOptions(userConfig);
+			const starlightConfig = StarlightConfigSchema.parse(userConfig);
+
+			const processor = create();
+
+			const ecIntegration = astroExpressiveCode({
+				customConfigPreprocessors: {
+					preprocessAstroIntegrationConfig: getStarlightEcConfigPreprocessor({
+						docsPath: getCollectionPosixPath('docs', astroConfig.srcDir),
+						starlightConfig,
+						useTranslations,
+					}),
+					preprocessComponentConfig: '',
+				},
+			});
+
+			await ecIntegration.hooks['astro:config:setup']({
+				config: {
+					root: astroConfig.root,
+					integrations: [ecIntegration],
+					markdown: { processor },
+				},
+				addWatchFile: () => {},
+				updateConfig: () => {},
+			});
+
+			const renderer = await processor.createRenderer({ syntaxHighlight: false });
+
+			const result = await renderer.render('```js\nconsole.log("bonjour")\n```', {
+				fileURL: docFileURL('fr/index.md'),
+			});
+
+			expect(result.code).toContain('title="Copier dans le presse-papiers"');
 		});
 	});
 });

--- a/packages/starlight/__tests__/expressive-code/preprocessor.test.ts
+++ b/packages/starlight/__tests__/expressive-code/preprocessor.test.ts
@@ -1,5 +1,6 @@
 import type { ExpressiveCodeTheme, StyleVariant } from 'astro-expressive-code';
 import { describe, expect, test, vi } from 'vitest';
+import type { StarlightExpressiveCodeOptions } from '../../integrations/expressive-code';
 import { getStarlightEcConfigPreprocessor } from '../../integrations/expressive-code/preprocessor';
 import { StarlightConfigSchema, type StarlightUserConfig } from '../../utils/user-config';
 
@@ -173,17 +174,17 @@ describe('Expressive Code config', () => {
 			expect(customizedTheme?.name).toBe('custom-theme');
 		});
 
-		test('is a no-op if `customizeTheme()` function is not set and `applyStarlightUiThemeColors` is false', async () => {
-			const config = await preprocessEcConfig({ applyStarlightUiThemeColors: false });
+		test('is a no-op if `customizeTheme()` function is not set and `useStarlightUiThemeColors` is false', async () => {
+			const config = await preprocessEcConfig({ useStarlightUiThemeColors: false });
 			const theme = { name: 'my-theme', colors: {}, styleOverrides: {} } as ExpressiveCodeTheme;
 			const customizedTheme = config.customizeTheme?.(theme);
-			expect(customizedTheme).toBe(theme);
+			expect(customizedTheme).toStrictEqual({ name: 'my-theme', colors: {}, styleOverrides: {} });
 		});
 	});
 });
 
 /** Preprocess an Expressive Code config using the Starlight preprocessor. */
-async function preprocessEcConfig(ecConfig: unknown = {}) {
+async function preprocessEcConfig(ecConfig: StarlightExpressiveCodeOptions = {}) {
 	const [starlightConfig, useTranslations] = getStarlightConfigAndUseTranslations({
 		root: { label: 'English', lang: 'en' },
 		fr: { label: 'French', lang: 'fr' },
@@ -193,8 +194,11 @@ async function preprocessEcConfig(ecConfig: unknown = {}) {
 		starlightConfig,
 		useTranslations,
 	});
-	// @ts-expect-error — We’re skipping some properties of `astroConfig`.
-	return await configPreprocessor({ ecConfig, astroConfig: {} });
+	return await configPreprocessor({
+		ecConfig,
+		// @ts-expect-error — We’re skipping some properties of `astroConfig`.
+		astroConfig: {},
+	});
 }
 
 function getUseTranslations(exists: boolean = true) {

--- a/packages/starlight/__tests__/expressive-code/theming.test.ts
+++ b/packages/starlight/__tests__/expressive-code/theming.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest';
+import {
+	applyStarlightUiThemeColors,
+	preprocessThemes,
+} from '../../integrations/expressive-code/theming';
+
+describe('preprocessThemes', () => {
+	test('returns the default theme objects when no options are provided', () => {
+		const result = preprocessThemes(undefined);
+		expect(result).toHaveLength(2);
+		expect(result).toMatchObject([{ name: 'Night Owl No Italics' }, { name: 'Night Owl Light' }]);
+	});
+
+	test('normalizes a single theme string into an array', () => {
+		// @ts-expect-error - The function handles this but does not allow it in the type signature.
+		const result = preprocessThemes('starlight-light');
+		expect(result).toHaveLength(1);
+		expect(result).toMatchObject([{ name: 'Night Owl Light' }]);
+	});
+
+	test('passes through Shiki built-in themes as strings', () => {
+		const result = preprocessThemes(['nord', 'github-light']);
+		expect(result).toEqual(['nord', 'github-light']);
+	});
+});
+
+describe('applyStarlightUiThemeColors', () => {
+	test('applies the correct colors to a dark theme', () => {
+		const [darkTheme] = preprocessThemes(['starlight-dark']);
+
+		// @ts-expect-error - In theory preprocessThemes can return other shapes, but it’s fine in this case.
+		const result = applyStarlightUiThemeColors(darkTheme);
+		expect(result.colors['titleBar.activeBackground']).toBe('var(--sl-color-black)');
+		expect(result.colors['editorGroupHeader.tabsBorder']).toBe(
+			'color-mix(in srgb, var(--sl-color-gray-5), transparent 25%)'
+		);
+	});
+
+	test('applies the correct colors to a light theme', () => {
+		const [lightTheme] = preprocessThemes(['starlight-light']);
+
+		// @ts-expect-error - In theory preprocessThemes can return other shapes, but it’s fine in this case.
+		const result = applyStarlightUiThemeColors(lightTheme);
+		expect(result.colors['titleBar.activeBackground']).toBe('var(--sl-color-gray-6)');
+		expect(result.colors['editorGroupHeader.tabsBorder']).toBe(
+			'color-mix(in srgb, var(--sl-color-gray-5), transparent 25%)'
+		);
+	});
+});

--- a/packages/starlight/__tests__/expressive-code/theming.test.ts
+++ b/packages/starlight/__tests__/expressive-code/theming.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest';
+import { ExpressiveCodeTheme } from 'astro-expressive-code';
 import {
 	applyStarlightUiThemeColors,
 	preprocessThemes,
@@ -28,7 +29,7 @@ describe('applyStarlightUiThemeColors', () => {
 	test('applies the correct colors to a dark theme', () => {
 		const [darkTheme] = preprocessThemes(['starlight-dark']);
 
-		// @ts-expect-error - In theory preprocessThemes can return other shapes, but it’s fine in this case.
+		expect.assert.instanceOf(darkTheme, ExpressiveCodeTheme);
 		const result = applyStarlightUiThemeColors(darkTheme);
 		expect(result.colors['titleBar.activeBackground']).toBe('var(--sl-color-black)');
 		expect(result.colors['editorGroupHeader.tabsBorder']).toBe(
@@ -39,7 +40,7 @@ describe('applyStarlightUiThemeColors', () => {
 	test('applies the correct colors to a light theme', () => {
 		const [lightTheme] = preprocessThemes(['starlight-light']);
 
-		// @ts-expect-error - In theory preprocessThemes can return other shapes, but it’s fine in this case.
+		expect.assert.instanceOf(lightTheme, ExpressiveCodeTheme);
 		const result = applyStarlightUiThemeColors(lightTheme);
 		expect(result.colors['titleBar.activeBackground']).toBe('var(--sl-color-gray-6)');
 		expect(result.colors['editorGroupHeader.tabsBorder']).toBe(

--- a/packages/starlight/__tests__/expressive-code/vitest.config.ts
+++ b/packages/starlight/__tests__/expressive-code/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineVitestConfig } from '../test-config';
+
+export default defineVitestConfig({ title: 'Expressive Code' });

--- a/packages/starlight/__tests__/i18n/translations-ec.test.ts
+++ b/packages/starlight/__tests__/i18n/translations-ec.test.ts
@@ -1,6 +1,5 @@
 import { pluginFramesTexts } from 'astro-expressive-code';
 import { afterEach, describe, expect, test, vi } from 'vitest';
-import { getBlockLocale } from '../../integrations/expressive-code/preprocessor';
 import { addTranslations } from '../../integrations/expressive-code/translations';
 import { StarlightConfigSchema, type StarlightUserConfig } from '../../utils/user-config';
 
@@ -105,79 +104,6 @@ describe('addTranslations', () => {
 		addTranslations(config, getUseTranslations(false));
 
 		expect(vi.mocked(pluginFramesTexts.overrideTexts)).not.toHaveBeenCalled();
-	});
-});
-
-describe('getBlockLocale', () => {
-	const [starlightConfig] = getStarlightConfigAndUseTranslations({
-		root: { label: 'English', lang: 'en' },
-		fr: { label: 'French', lang: 'fr' },
-	});
-
-	test('gets the root locale when an absolute file URL is passed', () => {
-		const locale = getBlockLocale({
-			starlightConfig,
-			docsPath: '/path/to/docs/',
-			file: {
-				path: '/path/to/docs/doc.md',
-				url: new URL('file:///path/to/docs/doc.md'),
-			},
-		});
-		expect(locale).toBe('en');
-	});
-
-	test('gets a non-root locale when an absolute file URL is passed', () => {
-		const locale = getBlockLocale({
-			starlightConfig,
-			docsPath: '/path/to/docs/',
-			file: {
-				path: '/path/to/docs/fr/doc.md',
-				url: new URL('file:///path/to/docs/fr/doc.md'),
-			},
-		});
-		expect(locale).toBe('fr');
-	});
-
-	test('gets the root locale when no file URL is passed', () => {
-		const locale = getBlockLocale({
-			starlightConfig,
-			docsPath: '/path/to/docs/',
-			file: { path: '/path/to/docs/doc.md' },
-		});
-		expect(locale).toBe('en');
-	});
-
-	test('gets a non-root locale when no file URL is passed', () => {
-		const locale = getBlockLocale({
-			starlightConfig,
-			docsPath: '/path/to/docs/',
-			file: { path: '/path/to/docs/fr/doc.md' },
-		});
-		expect(locale).toBe('fr');
-	});
-
-	test('gets the root locale for a file in the docs when Astro.url is passed', () => {
-		const locale = getBlockLocale({
-			starlightConfig,
-			docsPath: '/path/to/docs/',
-			file: {
-				path: 'doc.md',
-				url: new URL('https://example.com/doc.md'),
-			},
-		});
-		expect(locale).toBe('en');
-	});
-
-	test('gets a non-root locale for a file in the docs when Astro.url is passed', () => {
-		const locale = getBlockLocale({
-			starlightConfig,
-			docsPath: '/path/to/docs/',
-			file: {
-				path: 'fr/doc.md',
-				url: new URL('https://example.com/fr/doc.md'),
-			},
-		});
-		expect(locale).toBe('fr');
 	});
 });
 

--- a/packages/starlight/__tests__/i18n/translations-ec.test.ts
+++ b/packages/starlight/__tests__/i18n/translations-ec.test.ts
@@ -1,5 +1,5 @@
 import { pluginFramesTexts } from 'astro-expressive-code';
-import { afterEach, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { addTranslations } from '../../integrations/expressive-code/translations';
 import { StarlightConfigSchema, type StarlightUserConfig } from '../../utils/user-config';
 
@@ -15,94 +15,96 @@ vi.mock('astro-expressive-code', async () => {
 	};
 });
 
-afterEach(() => {
-	vi.clearAllMocks();
-});
-
-test('adds default english translations with no i18n config', () => {
-	const [config, useTranslations] = getStarlightConfigAndUseTranslations(undefined);
-
-	addTranslations(config, useTranslations);
-
-	expect(getExpressiveCodeOverriddenLanguages()).toEqual(['en']);
-});
-
-test('adds translations in a monolingual site with english as root locale', () => {
-	const [config, useTranslations] = getStarlightConfigAndUseTranslations({
-		root: { label: 'English', lang: 'en' },
+describe('addTranslations', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
 	});
 
-	addTranslations(config, useTranslations);
+	test('adds default english translations with no i18n config', () => {
+		const [config, useTranslations] = getStarlightConfigAndUseTranslations(undefined);
 
-	expect(getExpressiveCodeOverriddenLanguages()).toEqual(['en']);
-});
+		addTranslations(config, useTranslations);
 
-test('adds translations in a monolingual site with french as root locale', () => {
-	const [config, useTranslations] = getStarlightConfigAndUseTranslations({
-		root: { label: 'Français', lang: 'fr' },
+		expect(getExpressiveCodeOverriddenLanguages()).toEqual(['en']);
 	});
 
-	addTranslations(config, useTranslations);
+	test('adds translations in a monolingual site with english as root locale', () => {
+		const [config, useTranslations] = getStarlightConfigAndUseTranslations({
+			root: { label: 'English', lang: 'en' },
+		});
 
-	expect(getExpressiveCodeOverriddenLanguages()).toEqual(['fr']);
-});
+		addTranslations(config, useTranslations);
 
-test('add translations in a multilingual site with english as root locale', () => {
-	const [config, useTranslations] = getStarlightConfigAndUseTranslations({
-		root: { label: 'English', lang: 'en' },
-		fr: { label: 'French' },
+		expect(getExpressiveCodeOverriddenLanguages()).toEqual(['en']);
 	});
 
-	addTranslations(config, useTranslations);
+	test('adds translations in a monolingual site with french as root locale', () => {
+		const [config, useTranslations] = getStarlightConfigAndUseTranslations({
+			root: { label: 'Français', lang: 'fr' },
+		});
 
-	expect(getExpressiveCodeOverriddenLanguages()).toEqual(['en', 'fr']);
-});
+		addTranslations(config, useTranslations);
 
-test('add translations in a multilingual site with french as root locale', () => {
-	const [config, useTranslations] = getStarlightConfigAndUseTranslations({
-		root: { label: 'French', lang: 'fr' },
-		ru: { label: 'Русский', lang: 'ru' },
+		expect(getExpressiveCodeOverriddenLanguages()).toEqual(['fr']);
 	});
 
-	addTranslations(config, useTranslations);
-
-	expect(getExpressiveCodeOverriddenLanguages()).toEqual(['fr', 'ru']);
-});
-
-test('add translations in a multilingual site with english as default locale', () => {
-	const [config, useTranslations] = getStarlightConfigAndUseTranslations(
-		{
-			en: { label: 'English', lang: 'en' },
+	test('add translations in a multilingual site with english as root locale', () => {
+		const [config, useTranslations] = getStarlightConfigAndUseTranslations({
+			root: { label: 'English', lang: 'en' },
 			fr: { label: 'French' },
-		},
-		'en'
-	);
+		});
 
-	addTranslations(config, useTranslations);
+		addTranslations(config, useTranslations);
 
-	expect(getExpressiveCodeOverriddenLanguages()).toEqual(['en', 'fr']);
-});
+		expect(getExpressiveCodeOverriddenLanguages()).toEqual(['en', 'fr']);
+	});
 
-test('add translations in a multilingual site with french as default locale', () => {
-	const [config, useTranslations] = getStarlightConfigAndUseTranslations(
-		{
-			fr: { label: 'French', lang: 'fr' },
+	test('add translations in a multilingual site with french as root locale', () => {
+		const [config, useTranslations] = getStarlightConfigAndUseTranslations({
+			root: { label: 'French', lang: 'fr' },
 			ru: { label: 'Русский', lang: 'ru' },
-		},
-		'fr'
-	);
+		});
 
-	addTranslations(config, useTranslations);
+		addTranslations(config, useTranslations);
 
-	expect(getExpressiveCodeOverriddenLanguages()).toEqual(['fr', 'ru']);
-});
+		expect(getExpressiveCodeOverriddenLanguages()).toEqual(['fr', 'ru']);
+	});
 
-test('does not add translations if the label does not exist', () => {
-	const [config] = getStarlightConfigAndUseTranslations(undefined);
+	test('add translations in a multilingual site with english as default locale', () => {
+		const [config, useTranslations] = getStarlightConfigAndUseTranslations(
+			{
+				en: { label: 'English', lang: 'en' },
+				fr: { label: 'French' },
+			},
+			'en'
+		);
 
-	addTranslations(config, getUseTranslations(false));
+		addTranslations(config, useTranslations);
 
-	expect(vi.mocked(pluginFramesTexts.overrideTexts)).not.toHaveBeenCalled();
+		expect(getExpressiveCodeOverriddenLanguages()).toEqual(['en', 'fr']);
+	});
+
+	test('add translations in a multilingual site with french as default locale', () => {
+		const [config, useTranslations] = getStarlightConfigAndUseTranslations(
+			{
+				fr: { label: 'French', lang: 'fr' },
+				ru: { label: 'Русский', lang: 'ru' },
+			},
+			'fr'
+		);
+
+		addTranslations(config, useTranslations);
+
+		expect(getExpressiveCodeOverriddenLanguages()).toEqual(['fr', 'ru']);
+	});
+
+	test('does not add translations if the label does not exist', () => {
+		const [config] = getStarlightConfigAndUseTranslations(undefined);
+
+		addTranslations(config, getUseTranslations(false));
+
+		expect(vi.mocked(pluginFramesTexts.overrideTexts)).not.toHaveBeenCalled();
+	});
 });
 
 function getUseTranslations(exists: boolean = true) {

--- a/packages/starlight/__tests__/i18n/translations-ec.test.ts
+++ b/packages/starlight/__tests__/i18n/translations-ec.test.ts
@@ -1,5 +1,6 @@
 import { pluginFramesTexts } from 'astro-expressive-code';
 import { afterEach, describe, expect, test, vi } from 'vitest';
+import { getBlockLocale } from '../../integrations/expressive-code/preprocessor';
 import { addTranslations } from '../../integrations/expressive-code/translations';
 import { StarlightConfigSchema, type StarlightUserConfig } from '../../utils/user-config';
 
@@ -104,6 +105,79 @@ describe('addTranslations', () => {
 		addTranslations(config, getUseTranslations(false));
 
 		expect(vi.mocked(pluginFramesTexts.overrideTexts)).not.toHaveBeenCalled();
+	});
+});
+
+describe('getBlockLocale', () => {
+	const [starlightConfig] = getStarlightConfigAndUseTranslations({
+		root: { label: 'English', lang: 'en' },
+		fr: { label: 'French', lang: 'fr' },
+	});
+
+	test('gets the root locale when an absolute file URL is passed', () => {
+		const locale = getBlockLocale({
+			starlightConfig,
+			docsPath: '/path/to/docs/',
+			file: {
+				path: '/path/to/docs/doc.md',
+				url: new URL('file:///path/to/docs/doc.md'),
+			},
+		});
+		expect(locale).toBe('en');
+	});
+
+	test('gets a non-root locale when an absolute file URL is passed', () => {
+		const locale = getBlockLocale({
+			starlightConfig,
+			docsPath: '/path/to/docs/',
+			file: {
+				path: '/path/to/docs/fr/doc.md',
+				url: new URL('file:///path/to/docs/fr/doc.md'),
+			},
+		});
+		expect(locale).toBe('fr');
+	});
+
+	test('gets the root locale when no file URL is passed', () => {
+		const locale = getBlockLocale({
+			starlightConfig,
+			docsPath: '/path/to/docs/',
+			file: { path: '/path/to/docs/doc.md' },
+		});
+		expect(locale).toBe('en');
+	});
+
+	test('gets a non-root locale when no file URL is passed', () => {
+		const locale = getBlockLocale({
+			starlightConfig,
+			docsPath: '/path/to/docs/',
+			file: { path: '/path/to/docs/fr/doc.md' },
+		});
+		expect(locale).toBe('fr');
+	});
+
+	test('gets the root locale for a file in the docs when Astro.url is passed', () => {
+		const locale = getBlockLocale({
+			starlightConfig,
+			docsPath: '/path/to/docs/',
+			file: {
+				path: 'doc.md',
+				url: new URL('https://example.com/doc.md'),
+			},
+		});
+		expect(locale).toBe('en');
+	});
+
+	test('gets a non-root locale for a file in the docs when Astro.url is passed', () => {
+		const locale = getBlockLocale({
+			starlightConfig,
+			docsPath: '/path/to/docs/',
+			file: {
+				path: 'fr/doc.md',
+				url: new URL('https://example.com/fr/doc.md'),
+			},
+		});
+		expect(locale).toBe('fr');
 	});
 });
 

--- a/packages/starlight/__tests__/i18n/translations-ec.test.ts
+++ b/packages/starlight/__tests__/i18n/translations-ec.test.ts
@@ -1,5 +1,5 @@
 import { pluginFramesTexts } from 'astro-expressive-code';
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, expect, test, vi } from 'vitest';
 import { addTranslations } from '../../integrations/expressive-code/translations';
 import { StarlightConfigSchema, type StarlightUserConfig } from '../../utils/user-config';
 
@@ -15,96 +15,94 @@ vi.mock('astro-expressive-code', async () => {
 	};
 });
 
-describe('addTranslations', () => {
-	afterEach(() => {
-		vi.clearAllMocks();
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+test('adds default english translations with no i18n config', () => {
+	const [config, useTranslations] = getStarlightConfigAndUseTranslations(undefined);
+
+	addTranslations(config, useTranslations);
+
+	expect(getExpressiveCodeOverriddenLanguages()).toEqual(['en']);
+});
+
+test('adds translations in a monolingual site with english as root locale', () => {
+	const [config, useTranslations] = getStarlightConfigAndUseTranslations({
+		root: { label: 'English', lang: 'en' },
 	});
 
-	test('adds default english translations with no i18n config', () => {
-		const [config, useTranslations] = getStarlightConfigAndUseTranslations(undefined);
+	addTranslations(config, useTranslations);
 
-		addTranslations(config, useTranslations);
+	expect(getExpressiveCodeOverriddenLanguages()).toEqual(['en']);
+});
 
-		expect(getExpressiveCodeOverriddenLanguages()).toEqual(['en']);
+test('adds translations in a monolingual site with french as root locale', () => {
+	const [config, useTranslations] = getStarlightConfigAndUseTranslations({
+		root: { label: 'Français', lang: 'fr' },
 	});
 
-	test('adds translations in a monolingual site with english as root locale', () => {
-		const [config, useTranslations] = getStarlightConfigAndUseTranslations({
-			root: { label: 'English', lang: 'en' },
-		});
+	addTranslations(config, useTranslations);
 
-		addTranslations(config, useTranslations);
+	expect(getExpressiveCodeOverriddenLanguages()).toEqual(['fr']);
+});
 
-		expect(getExpressiveCodeOverriddenLanguages()).toEqual(['en']);
+test('add translations in a multilingual site with english as root locale', () => {
+	const [config, useTranslations] = getStarlightConfigAndUseTranslations({
+		root: { label: 'English', lang: 'en' },
+		fr: { label: 'French' },
 	});
 
-	test('adds translations in a monolingual site with french as root locale', () => {
-		const [config, useTranslations] = getStarlightConfigAndUseTranslations({
-			root: { label: 'Français', lang: 'fr' },
-		});
+	addTranslations(config, useTranslations);
 
-		addTranslations(config, useTranslations);
+	expect(getExpressiveCodeOverriddenLanguages()).toEqual(['en', 'fr']);
+});
 
-		expect(getExpressiveCodeOverriddenLanguages()).toEqual(['fr']);
+test('add translations in a multilingual site with french as root locale', () => {
+	const [config, useTranslations] = getStarlightConfigAndUseTranslations({
+		root: { label: 'French', lang: 'fr' },
+		ru: { label: 'Русский', lang: 'ru' },
 	});
 
-	test('add translations in a multilingual site with english as root locale', () => {
-		const [config, useTranslations] = getStarlightConfigAndUseTranslations({
-			root: { label: 'English', lang: 'en' },
+	addTranslations(config, useTranslations);
+
+	expect(getExpressiveCodeOverriddenLanguages()).toEqual(['fr', 'ru']);
+});
+
+test('add translations in a multilingual site with english as default locale', () => {
+	const [config, useTranslations] = getStarlightConfigAndUseTranslations(
+		{
+			en: { label: 'English', lang: 'en' },
 			fr: { label: 'French' },
-		});
+		},
+		'en'
+	);
 
-		addTranslations(config, useTranslations);
+	addTranslations(config, useTranslations);
 
-		expect(getExpressiveCodeOverriddenLanguages()).toEqual(['en', 'fr']);
-	});
+	expect(getExpressiveCodeOverriddenLanguages()).toEqual(['en', 'fr']);
+});
 
-	test('add translations in a multilingual site with french as root locale', () => {
-		const [config, useTranslations] = getStarlightConfigAndUseTranslations({
-			root: { label: 'French', lang: 'fr' },
+test('add translations in a multilingual site with french as default locale', () => {
+	const [config, useTranslations] = getStarlightConfigAndUseTranslations(
+		{
+			fr: { label: 'French', lang: 'fr' },
 			ru: { label: 'Русский', lang: 'ru' },
-		});
+		},
+		'fr'
+	);
 
-		addTranslations(config, useTranslations);
+	addTranslations(config, useTranslations);
 
-		expect(getExpressiveCodeOverriddenLanguages()).toEqual(['fr', 'ru']);
-	});
+	expect(getExpressiveCodeOverriddenLanguages()).toEqual(['fr', 'ru']);
+});
 
-	test('add translations in a multilingual site with english as default locale', () => {
-		const [config, useTranslations] = getStarlightConfigAndUseTranslations(
-			{
-				en: { label: 'English', lang: 'en' },
-				fr: { label: 'French' },
-			},
-			'en'
-		);
+test('does not add translations if the label does not exist', () => {
+	const [config] = getStarlightConfigAndUseTranslations(undefined);
 
-		addTranslations(config, useTranslations);
+	addTranslations(config, getUseTranslations(false));
 
-		expect(getExpressiveCodeOverriddenLanguages()).toEqual(['en', 'fr']);
-	});
-
-	test('add translations in a multilingual site with french as default locale', () => {
-		const [config, useTranslations] = getStarlightConfigAndUseTranslations(
-			{
-				fr: { label: 'French', lang: 'fr' },
-				ru: { label: 'Русский', lang: 'ru' },
-			},
-			'fr'
-		);
-
-		addTranslations(config, useTranslations);
-
-		expect(getExpressiveCodeOverriddenLanguages()).toEqual(['fr', 'ru']);
-	});
-
-	test('does not add translations if the label does not exist', () => {
-		const [config] = getStarlightConfigAndUseTranslations(undefined);
-
-		addTranslations(config, getUseTranslations(false));
-
-		expect(vi.mocked(pluginFramesTexts.overrideTexts)).not.toHaveBeenCalled();
-	});
+	expect(vi.mocked(pluginFramesTexts.overrideTexts)).not.toHaveBeenCalled();
 });
 
 function getUseTranslations(exists: boolean = true) {

--- a/packages/starlight/integrations/expressive-code/preprocessor.ts
+++ b/packages/starlight/integrations/expressive-code/preprocessor.ts
@@ -105,22 +105,32 @@ export function getStarlightEcConfigPreprocessor({
 				},
 				...otherStyleOverrides,
 			},
-			getBlockLocale: ({ file }) => {
-				// When Expressive Code runs inside the `<Code>` component, it uses `Astro.url` to provide
-				// the file URL, so we can deduce the locale from that slug. This is different from the URL
-				// provided by Sätteri, which is a `file://` URL for the full absolute file path, so we
-				// ignore the `file.url` field for `file://` protocols so this branch only processes the
-				// `<Code>` component case.
-				if (file.url && file.url.protocol !== 'file:') {
-					const locale = slugToLocale(file.url.pathname.slice(1), starlightConfig);
-					return localeToLang(starlightConfig, locale);
-				}
-				// Note that EC cannot use the `absolutePathToLang` helper passed down to plugins as this callback
-				// is also called in the context of the `<Code>` component.
-				return absolutePathToLang(file.path, { docsPath, starlightConfig });
-			},
+			getBlockLocale: ({ file }) => getBlockLocale({ file, starlightConfig, docsPath }),
 			plugins,
 			...rest,
 		};
 	};
+}
+
+export function getBlockLocale({
+	file,
+	starlightConfig,
+	docsPath,
+}: {
+	file: { path: string; url?: URL | undefined };
+	starlightConfig: Pick<StarlightConfig, 'defaultLocale' | 'locales'>;
+	docsPath: string;
+}): string | undefined {
+	// When Expressive Code runs inside the `<Code>` component, it uses `Astro.url` to provide
+	// the file URL, so we can deduce the locale from that slug. This is different from the URL
+	// provided by Sätteri, which is a `file://` URL for the full absolute file path, so we
+	// ignore the `file.url` field for `file://` protocols so this branch only processes the
+	// `<Code>` component case.
+	if (file.url && file.url.protocol !== 'file:') {
+		const locale = slugToLocale(file.url.pathname.slice(1), starlightConfig);
+		return localeToLang(starlightConfig, locale);
+	}
+	// Note that EC cannot use the `absolutePathToLang` helper passed down to plugins as this callback
+	// is also called in the context of the `<Code>` component.
+	return absolutePathToLang(file.path, { docsPath, starlightConfig });
 }

--- a/packages/starlight/integrations/expressive-code/preprocessor.ts
+++ b/packages/starlight/integrations/expressive-code/preprocessor.ts
@@ -105,32 +105,22 @@ export function getStarlightEcConfigPreprocessor({
 				},
 				...otherStyleOverrides,
 			},
-			getBlockLocale: ({ file }) => getBlockLocale({ file, starlightConfig, docsPath }),
+			getBlockLocale: ({ file }) => {
+				// When Expressive Code runs inside the `<Code>` component, it uses `Astro.url` to provide
+				// the file URL, so we can deduce the locale from that slug. This is different from the URL
+				// provided by Sätteri, which is a `file://` URL for the full absolute file path, so we
+				// ignore the `file.url` field for `file://` protocols so this branch only processes the
+				// `<Code>` component case.
+				if (file.url && file.url.protocol !== 'file:') {
+					const locale = slugToLocale(file.url.pathname.slice(1), starlightConfig);
+					return localeToLang(starlightConfig, locale);
+				}
+				// Note that EC cannot use the `absolutePathToLang` helper passed down to plugins as this callback
+				// is also called in the context of the `<Code>` component.
+				return absolutePathToLang(file.path, { docsPath, starlightConfig });
+			},
 			plugins,
 			...rest,
 		};
 	};
-}
-
-export function getBlockLocale({
-	file,
-	starlightConfig,
-	docsPath,
-}: {
-	file: { path: string; url?: URL | undefined };
-	starlightConfig: Pick<StarlightConfig, 'defaultLocale' | 'locales'>;
-	docsPath: string;
-}): string | undefined {
-	// When Expressive Code runs inside the `<Code>` component, it uses `Astro.url` to provide
-	// the file URL, so we can deduce the locale from that slug. This is different from the URL
-	// provided by Sätteri, which is a `file://` URL for the full absolute file path, so we
-	// ignore the `file.url` field for `file://` protocols so this branch only processes the
-	// `<Code>` component case.
-	if (file.url && file.url.protocol !== 'file:') {
-		const locale = slugToLocale(file.url.pathname.slice(1), starlightConfig);
-		return localeToLang(starlightConfig, locale);
-	}
-	// Note that EC cannot use the `absolutePathToLang` helper passed down to plugins as this callback
-	// is also called in the context of the `<Code>` component.
-	return absolutePathToLang(file.path, { docsPath, starlightConfig });
 }

--- a/packages/starlight/integrations/expressive-code/preprocessor.ts
+++ b/packages/starlight/integrations/expressive-code/preprocessor.ts
@@ -106,7 +106,12 @@ export function getStarlightEcConfigPreprocessor({
 				...otherStyleOverrides,
 			},
 			getBlockLocale: ({ file }) => {
-				if (file.url) {
+				// When Expressive Code runs inside the `<Code>` component, it uses `Astro.url` to provide
+				// the file URL, so we can deduce the locale from that slug. This is different from the URL
+				// provided by Sätteri, which is a `file://` URL for the full absolute file path, so we
+				// ignore the `file.url` field for `file://` protocols so this branch only processes the
+				// `<Code>` component case.
+				if (file.url && file.url.protocol !== 'file:') {
 					const locale = slugToLocale(file.url.pathname.slice(1), starlightConfig);
 					return localeToLang(starlightConfig, locale);
 				}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- When adding support for the Sätteri Markdown processor, we missed that because Sätteri provides a URL in its file object, we were treating it with the same logic we used for the `<Code>` component when trying to detect the locale (which passes `Astro.url`). Because the assumptions are quite different this broke localisation of Expressive Code code blocks when using with the Sätteri processor.
- This PR fixes that by detecting Sätteri’s `file://` URLs and ignoring them.
- I’ve added some new unit tests for `getBlockLocale()` although I’m a bit conflicted because these test don’t actually check the interface between real world inputs and the `getBlockLocale()` method, so I suppose a future change to the `file` object passed by a Markdown processor could still cause a similar regression, but at least this is better than nothing.
- Doing this also brought these files newly into view for Vitest, so dropped our coverage down. I’ve added some additional tests for other parts of the Expressive Code config processing logic to keep coverage high.

(It might be best to hide whitespace changes while reviewing the tests because I wrapped some existing tests in this file in a `describe()` block but otherwise they are unchanged.)

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
