### PR TITLE
docs: add starlight-custom-navigation to plugins showcase

### DIFF
--- a/docs/src/content/docs/resources/plugins.mdx
+++ b/docs/src/content/docs/resources/plugins.mdx
@@ -253,6 +253,11 @@ Extend your site with official plugins supported by the Starlight team and commu
 		title="starlight-quiz"
 		description="Interactive quizzes for Astro and Starlight, authored in markdown with full progress tracking."
 	/>
+	<LinkCard
+		href="https://frostybee.github.io/starlight-custom-navigation/"
+		title="starlight-custom-navigation"
+		description="Add side navigation strips, floating buttons, keyboard shortcuts, and swipe gestures for moving between pages."
+	/>
 </CardGrid>
 
 ## Community tools and integrations


### PR DESCRIPTION
 Adds [starlight-custom-navigation](https://github.com/frostybee/starlight-custom-navigation) to  the community plugins list.

This plugin adds side navigation strips, floating buttons, keyboard shortcuts, and swipe gestures  for moving between pages.
