### PR TITLE
perf: avoid repeated sidebar subtree scans

### DIFF
--- a/packages/starlight/components/SidebarSublist.astro
+++ b/packages/starlight/components/SidebarSublist.astro
@@ -1,6 +1,5 @@
 ---
-import { flattenSidebar } from '../utils/navigation';
-import type { SidebarEntry } from '../utils/routing/types';
+import type { SidebarEntry, SidebarGroup } from '../utils/routing/types';
 import Icon from '../user-components/Icon.astro';
 import Badge from '../user-components/Badge.astro';
 import SidebarRestorePoint from './SidebarRestorePoint.astro';
@@ -8,9 +7,28 @@ import SidebarRestorePoint from './SidebarRestorePoint.astro';
 interface Props {
 	sublist: SidebarEntry[];
 	nested?: boolean;
+	currentGroups?: Set<SidebarGroup>;
 }
 
 const { sublist, nested } = Astro.props;
+let { currentGroups } = Astro.props;
+if (!currentGroups) {
+	currentGroups = new Set();
+	findCurrentGroups(sublist, currentGroups);
+}
+
+function findCurrentGroups(entries: SidebarEntry[], groups: Set<SidebarGroup>): boolean {
+	let containsCurrent = false;
+	for (const entry of entries) {
+		if (entry.type === 'link') {
+			containsCurrent ||= entry.isCurrent;
+		} else if (findCurrentGroups(entry.entries, groups)) {
+			groups.add(entry);
+			containsCurrent = true;
+		}
+	}
+	return containsCurrent;
+}
 ---
 
 <ul class:list={{ 'top-level': !nested }}>
@@ -34,9 +52,7 @@ const { sublist, nested } = Astro.props;
 						)}
 					</a>
 				) : (
-					<details
-						open={flattenSidebar(entry.entries).some((i) => i.isCurrent) || !entry.collapsed}
-					>
+					<details open={currentGroups.has(entry) || !entry.collapsed}>
 						<summary>
 							<span class="group-label">
 								<span class="large">{entry.label}</span>
@@ -51,7 +67,7 @@ const { sublist, nested } = Astro.props;
 							<Icon name="right-caret" class="caret" size="1.25rem" />
 						</summary>
 						<SidebarRestorePoint />
-						<Astro.self sublist={entry.entries} nested />
+						<Astro.self sublist={entry.entries} currentGroups={currentGroups} nested />
 					</details>
 				)}
 			</li>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

The sidebar now finds all groups containing the current page in one traversal. Previously, each group repeatedly flattened its subtree, causing unnecessary work for deeply nested sidebars.

Should save some memory and a bit of milliseconds. 

<!-- New features should first be discussed and approved by maintainers in GitHub or Discord discussions. -->
<!-- If this PR adds a new public-facing feature, uncomment the line below and include a link to the relevant discussion. -->
<!-- - [x] This PR adds a new feature which has been discussed and approved [here](link to GitHub or Discord discussion). -->

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
