### PR TITLE
perf: clean up language select lifecycle

### DIFF
--- a/packages/starlight/components/LanguageSelect.astro
+++ b/packages/starlight/components/LanguageSelect.astro
@@ -31,26 +31,43 @@ function localizedPathname(locale: string | undefined): string {
 
 <script>
 	class StarlightLanguageSelect extends HTMLElement {
-		constructor() {
-			super();
+		private controller: AbortController | undefined;
+
+		connectedCallback() {
+			this.controller?.abort();
+			this.controller = new AbortController();
+			const { signal } = this.controller;
 			const select = this.querySelector('select');
 			if (select) {
-				select.addEventListener('change', (e) => {
-					if (e.currentTarget instanceof HTMLSelectElement) {
-						window.location.pathname = e.currentTarget.value;
-					}
-				});
-				window.addEventListener('pageshow', (event) => {
-					if (!event.persisted) return;
-					// If the page was loaded from a cache, the language select selected index might not be
-					// in sync with the current page.
-					const markupSelectedIndex =
-						select.querySelector<HTMLOptionElement>('option[selected]')?.index;
-					if (markupSelectedIndex !== select.selectedIndex) {
-						select.selectedIndex = markupSelectedIndex ?? 0;
-					}
-				});
+				select.addEventListener(
+					'change',
+					(e) => {
+						if (e.currentTarget instanceof HTMLSelectElement) {
+							window.location.pathname = e.currentTarget.value;
+						}
+					},
+					{ signal }
+				);
+				window.addEventListener(
+					'pageshow',
+					(event) => {
+						if (!event.persisted) return;
+						// If the page was loaded from a cache, the language select selected index might not be
+						// in sync with the current page.
+						const markupSelectedIndex =
+							select.querySelector<HTMLOptionElement>('option[selected]')?.index;
+						if (markupSelectedIndex !== select.selectedIndex) {
+							select.selectedIndex = markupSelectedIndex ?? 0;
+						}
+					},
+					{ signal }
+				);
 			}
+		}
+
+		disconnectedCallback() {
+			this.controller?.abort();
+			this.controller = undefined;
 		}
 	}
 	customElements.define('starlight-lang-select', StarlightLanguageSelect);


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Language selector listeners now attach when the component connects and are removed when it disconnects. This prevents `change` and `pageshow` handlers from accumulating across client-side navigations.

This change is more a proposal. It doesn't affect Starlight today, however if this component is placed inside a `ClientRouter`, the event handlers aren't cleaned after a navigation, so they leak. If you are interested, I have more PRs similar to this. 


<!-- New features should first be discussed and approved by maintainers in GitHub or Discord discussions. -->
<!-- If this PR adds a new public-facing feature, uncomment the line below and include a link to the relevant discussion. -->
<!-- - [x] This PR adds a new feature which has been discussed and approved [here](link to GitHub or Discord discussion). -->

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
