### PR TITLE
[i18nIgnore] docs: update theme links

### DIFF
--- a/docs/src/content/docs/de/resources/themes.mdx
+++ b/docs/src/content/docs/de/resources/themes.mdx
@@ -78,7 +78,7 @@ Schau dir unten eine Vorschau aller Designs an oder probier sie interaktiv auf d
 		{
 			title: 'Starlight Next.js',
 			description: 'Starlight-Theme inspiriert von der Next.js-Dokumentation.',
-			href: 'https://starlight-theme-next.trueberryless.org/',
+			href: 'https://starlight-theme-next.netlify.app/',
 			previews: { light: 'next-light.png', dark: 'next-dark.png' },
 		},
 		{
@@ -118,7 +118,7 @@ Schau dir unten eine Vorschau aller Designs an oder probier sie interaktiv auf d
 		{
 			title: 'Starlight Rosé Pine',
 			description: 'Soho-Flair für Starlight.',
-			href: 'https://starlight-theme-rose-pine.trueberryless.org/',
+			href: 'https://starlight-theme-rose-pine.netlify.app/',
 			previews: { light: 'rose-pine-light.png', dark: 'rose-pine-dark.png' },
 		},
 		{

--- a/docs/src/content/docs/es/resources/themes.mdx
+++ b/docs/src/content/docs/es/resources/themes.mdx
@@ -77,7 +77,7 @@ Instala un tema creado por la comunidad para personalizar rápidamente la aparie
 			title: 'Starlight Next.js',
 			description:
 				'Tema de Starlight inspirado en la documentación de Next.js.',
-			href: 'https://starlight-theme-next.trueberryless.org/',
+			href: 'https://starlight-theme-next.netlify.app/',
 			previews: { light: 'next-light.png', dark: 'next-dark.png' },
 		},
 	]}

--- a/docs/src/content/docs/fr/resources/themes.mdx
+++ b/docs/src/content/docs/fr/resources/themes.mdx
@@ -78,7 +78,7 @@ Découvrez ci-dessous un aperçu de tous les thèmes ou essayez-les de manière 
 		{
 			title: 'Starlight Next.js',
 			description: 'Thème Starlight inspiré par la documentation de Next.js.',
-			href: 'https://starlight-theme-next.trueberryless.org/',
+			href: 'https://starlight-theme-next.netlify.app/',
 			previews: { light: 'next-light.png', dark: 'next-dark.png' },
 		},
 		{
@@ -117,7 +117,7 @@ Découvrez ci-dessous un aperçu de tous les thèmes ou essayez-les de manière 
 		{
 			title: 'Starlight Rosé Pine',
 			description: 'Ambiance Soho pour Starlight.',
-			href: 'https://starlight-theme-rose-pine.trueberryless.org/',
+			href: 'https://starlight-theme-rose-pine.netlify.app/',
 			previews: { light: 'rose-pine-light.png', dark: 'rose-pine-dark.png' },
 		},
 		{

--- a/docs/src/content/docs/ja/resources/themes.mdx
+++ b/docs/src/content/docs/ja/resources/themes.mdx
@@ -78,7 +78,7 @@ import ThemeGrid from '~/components/theme-grid.astro';
 		{
 			title: 'Starlight Next.js',
 			description: 'Next.jsのドキュメントに着想を得たStarlightテーマです。',
-			href: 'https://starlight-theme-next.trueberryless.org/',
+			href: 'https://starlight-theme-next.netlify.app/',
 			previews: { light: 'next-light.png', dark: 'next-dark.png' },
 		},
 		{
@@ -118,7 +118,7 @@ import ThemeGrid from '~/components/theme-grid.astro';
 		{
 			title: 'Starlight Rosé Pine',
 			description: 'StarlightにSohoの雰囲気を。',
-			href: 'https://starlight-theme-rose-pine.trueberryless.org/',
+			href: 'https://starlight-theme-rose-pine.netlify.app/',
 			previews: { light: 'rose-pine-light.png', dark: 'rose-pine-dark.png' },
 		},
 	]}

--- a/docs/src/content/docs/ko/resources/themes.mdx
+++ b/docs/src/content/docs/ko/resources/themes.mdx
@@ -77,7 +77,7 @@ import ThemeGrid from '~/components/theme-grid.astro';
 		{
 			title: 'Starlight Next.js',
 			description: 'Next.js 문서에서 영감을 받은 Starlight 테마',
-			href: 'https://starlight-theme-next.trueberryless.org/',
+			href: 'https://starlight-theme-next.netlify.app/',
 			previews: { light: 'next-light.png', dark: 'next-dark.png' },
 		},
 		{
@@ -117,7 +117,7 @@ import ThemeGrid from '~/components/theme-grid.astro';
 		{
 			title: 'Starlight Rosé Pine',
 			description: 'Starlight를 위한 Soho 감성',
-			href: 'https://starlight-theme-rose-pine.trueberryless.org/',
+			href: 'https://starlight-theme-rose-pine.netlify.app/',
 			previews: { light: 'rose-pine-light.png', dark: 'rose-pine-dark.png' },
 		},
 		{

--- a/docs/src/content/docs/resources/themes.mdx
+++ b/docs/src/content/docs/resources/themes.mdx
@@ -78,7 +78,7 @@ Preview a list of all themes below or try them out interactively on the [Starlig
 		{
 			title: 'Starlight Next.js',
 			description: 'Starlight theme inspired by the Next.js docs.',
-			href: 'https://starlight-theme-next.trueberryless.org/',
+			href: 'https://starlight-theme-next.netlify.app/',
 			previews: { light: 'next-light.png', dark: 'next-dark.png' },
 		},
 		{
@@ -118,7 +118,7 @@ Preview a list of all themes below or try them out interactively on the [Starlig
 		{
 			title: 'Starlight Rosé Pine',
 			description: 'Soho vibes for Starlight.',
-			href: 'https://starlight-theme-rose-pine.trueberryless.org/',
+			href: 'https://starlight-theme-rose-pine.netlify.app/',
 			previews: { light: 'rose-pine-light.png', dark: 'rose-pine-dark.png' },
 		},
 		{

--- a/docs/src/content/docs/ru/resources/themes.mdx
+++ b/docs/src/content/docs/ru/resources/themes.mdx
@@ -78,7 +78,7 @@ import ThemeGrid from '~/components/theme-grid.astro';
 		{
 			title: 'Starlight Next.js',
 			description: 'Тема Starlight, вдохновлённая документацией Next.js.',
-			href: 'https://starlight-theme-next.trueberryless.org/',
+			href: 'https://starlight-theme-next.netlify.app/',
 			previews: { light: 'next-light.png', dark: 'next-dark.png' },
 		},
 		{
@@ -118,7 +118,7 @@ import ThemeGrid from '~/components/theme-grid.astro';
 		{
 			title: 'Starlight Rosé Pine',
 			description: 'Сохо-атмосфера для Starlight.',
-			href: 'https://starlight-theme-rose-pine.trueberryless.org/',
+			href: 'https://starlight-theme-rose-pine.netlify.app/',
 			previews: { light: 'rose-pine-light.png', dark: 'rose-pine-dark.png' },
 		},
 		{

--- a/docs/src/content/docs/zh-cn/resources/themes.mdx
+++ b/docs/src/content/docs/zh-cn/resources/themes.mdx
@@ -76,7 +76,7 @@ import ThemeGrid from '~/components/theme-grid.astro';
 		{
 			title: 'Starlight Next.js',
 			description: 'Starlight 主题，灵感来源于 Next.js 文档。',
-			href: 'https://starlight-theme-next.trueberryless.org/',
+			href: 'https://starlight-theme-next.netlify.app/',
 			previews: { light: 'next-light.png', dark: 'next-dark.png' },
 		},
 		{
@@ -113,7 +113,7 @@ import ThemeGrid from '~/components/theme-grid.astro';
 		{
 			title: 'Starlight Rosé Pine',
 			description: 'Soho 风格的 Starlight 主题。',
-			href: 'https://starlight-theme-rose-pine.trueberryless.org/',
+			href: 'https://starlight-theme-rose-pine.netlify.app/',
 			previews: { light: 'rose-pine-light.png', dark: 'rose-pine-dark.png' },
 		},
 		{


### PR DESCRIPTION
#### Description

This PR updates all my theme website links across all languages to the generic `netlify.app` domain since I myself migrated from `trueberryless.org` to `felixs.dev`.