### PR TITLE
Add Expressive Code missing translations based on Astro Docs

### DIFF
--- a/.changeset/clean-breads-decide.md
+++ b/.changeset/clean-breads-decide.md
@@ -2,4 +2,4 @@
 "@astrojs/starlight": patch
 ---
 
-Adds the missing translations for Expressive Code in the following locales: `ar`, `de`, `hi`, `it`, `ja`, `ko`, `pt`, `zh-CN`, and `zh-TW`.
+Adds the missing translations for Expressive Code in the following locales: `ar`, `hi`, `it`, `ja`, `ko`, `pt`, `zh-CN`, and `zh-TW`.

--- a/.changeset/clean-breads-decide.md
+++ b/.changeset/clean-breads-decide.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Adds the missing translations for Expressive Code in the following locales: `ar`, `de`, `hi`, `it`, `ja`, `ko`, `pt`, `zh-CN`, and `zh-TW`.

--- a/packages/starlight/translations/ar.json
+++ b/packages/starlight/translations/ar.json
@@ -24,6 +24,9 @@
   "aside.tip": "نصيحة",
   "aside.caution": "تنبيه",
   "aside.danger": "تحذير",
+  "expressiveCode.terminalWindowFallbackTitle": "نافذة طرفيّة",
+  "expressiveCode.copyButtonTooltip": "نسخ إلى الحافظة",
+  "expressiveCode.copyButtonCopied": "تم النسخ!",
   "fileTree.directory": "Directory",
   "builtWithStarlight.label": "طوِّر بواسطة Starlight",
   "heading.anchorLabel": "Section titled “{{title}}”"

--- a/packages/starlight/translations/de.json
+++ b/packages/starlight/translations/de.json
@@ -24,9 +24,6 @@
   "aside.tip": "Tipp",
   "aside.caution": "Achtung",
   "aside.danger": "Gefahr",
-  "expressiveCode.terminalWindowFallbackTitle": "Terminal-Fenster",
-  "expressiveCode.copyButtonTooltip": "In Zwischenablage kopieren",
-  "expressiveCode.copyButtonCopied": "Kopiert!",
   "fileTree.directory": "Ordner",
   "builtWithStarlight.label": "Erstellt mit Starlight",
   "heading.anchorLabel": "Abschnitt betitelt „{{title}}“"

--- a/packages/starlight/translations/de.json
+++ b/packages/starlight/translations/de.json
@@ -24,6 +24,9 @@
   "aside.tip": "Tipp",
   "aside.caution": "Achtung",
   "aside.danger": "Gefahr",
+  "expressiveCode.terminalWindowFallbackTitle": "Terminal-Fenster",
+  "expressiveCode.copyButtonTooltip": "In Zwischenablage kopieren",
+  "expressiveCode.copyButtonCopied": "Kopiert!",
   "fileTree.directory": "Ordner",
   "builtWithStarlight.label": "Erstellt mit Starlight",
   "heading.anchorLabel": "Abschnitt betitelt „{{title}}“"

--- a/packages/starlight/translations/hi.json
+++ b/packages/starlight/translations/hi.json
@@ -24,6 +24,9 @@
   "aside.tip": "संकेत",
   "aside.caution": "सावधानी",
   "aside.danger": "खतरा",
+  "expressiveCode.terminalWindowFallbackTitle": "टर्मिनल विंडो",
+  "expressiveCode.copyButtonTooltip": "क्लिपबोर्ड पर कॉपी करें",
+  "expressiveCode.copyButtonCopied": "कॉपी हो गया!",
   "fileTree.directory": "Directory",
   "builtWithStarlight.label": "Starlight द्वारा निर्मित",
   "heading.anchorLabel": "Section titled “{{title}}”"

--- a/packages/starlight/translations/it.json
+++ b/packages/starlight/translations/it.json
@@ -24,6 +24,9 @@
   "aside.tip": "Consiglio",
   "aside.caution": "Attenzione",
   "aside.danger": "Pericolo",
+  "expressiveCode.terminalWindowFallbackTitle": "Finestra del terminale",
+  "expressiveCode.copyButtonTooltip": "Copia",
+  "expressiveCode.copyButtonCopied": "Copiato!",
   "fileTree.directory": "Directory",
   "builtWithStarlight.label": "Built with Starlight",
   "heading.anchorLabel": "Sezione intitolata “{{title}}”"

--- a/packages/starlight/translations/ja.json
+++ b/packages/starlight/translations/ja.json
@@ -24,6 +24,9 @@
   "aside.tip": "ヒント",
   "aside.caution": "注意",
   "aside.danger": "危険",
+  "expressiveCode.terminalWindowFallbackTitle": "ターミナルウィンドウ",
+  "expressiveCode.copyButtonTooltip": "クリップボードにコピー",
+  "expressiveCode.copyButtonCopied": "コピーしました！",
   "fileTree.directory": "ディレクトリ",
   "builtWithStarlight.label": "Starlightで作成",
   "heading.anchorLabel": "Section titled “{{title}}”"

--- a/packages/starlight/translations/ko.json
+++ b/packages/starlight/translations/ko.json
@@ -24,6 +24,9 @@
   "aside.tip": "팁",
   "aside.caution": "주의",
   "aside.danger": "위험",
+  "expressiveCode.terminalWindowFallbackTitle": "터미널 창",
+  "expressiveCode.copyButtonTooltip": "클립보드로 복사",
+  "expressiveCode.copyButtonCopied": "복사 완료!",
   "fileTree.directory": "디렉터리",
   "builtWithStarlight.label": "이 웹사이트는 Starlight로 제작되었습니다.",
   "heading.anchorLabel": "섹션 제목: “{{title}}”"

--- a/packages/starlight/translations/pt.json
+++ b/packages/starlight/translations/pt.json
@@ -24,6 +24,9 @@
   "aside.tip": "Dica",
   "aside.caution": "Cuidado",
   "aside.danger": "Perigo",
+  "expressiveCode.terminalWindowFallbackTitle": "Janela do terminal",
+  "expressiveCode.copyButtonTooltip": "Copiar para área de transferência",
+  "expressiveCode.copyButtonCopied": "Copiado!",
   "fileTree.directory": "Directory",
   "builtWithStarlight.label": "Feito com Starlight",
   "heading.anchorLabel": "Seção intitulada “{{title}}”"

--- a/packages/starlight/translations/zh-CN.json
+++ b/packages/starlight/translations/zh-CN.json
@@ -24,6 +24,9 @@
   "aside.tip": "提示",
   "aside.caution": "警告",
   "aside.danger": "危险",
+  "expressiveCode.terminalWindowFallbackTitle": "终端窗口",
+  "expressiveCode.copyButtonTooltip": "复制到剪贴板",
+  "expressiveCode.copyButtonCopied": "复制成功！",
   "fileTree.directory": "文件夹",
   "builtWithStarlight.label": "基于 Starlight 构建",
   "heading.anchorLabel": "Section titled “{{title}}”"

--- a/packages/starlight/translations/zh-TW.json
+++ b/packages/starlight/translations/zh-TW.json
@@ -24,6 +24,9 @@
   "aside.tip": "提示",
   "aside.caution": "警告",
   "aside.danger": "危險",
+  "expressiveCode.terminalWindowFallbackTitle": "終端機視窗",
+  "expressiveCode.copyButtonTooltip": "複製到剪貼簿",
+  "expressiveCode.copyButtonCopied": "複製成功！",
   "fileTree.directory": "目錄",
   "builtWithStarlight.label": "Built with Starlight",
   "heading.anchorLabel": "Section titled “{{title}}”"


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Follow-up on https://github.com/withastro/docs/pull/14460#issuecomment-5402445200

Expressive Code only has English and German translations built-in. Astro Docs has more translations: we should take advantage of this to upstream the missing translations to Starlight.

I only included the missing ones: [`ar`](https://github.com/withastro/docs/blob/b9773d37fae129f1b807b2ce33a0932092a6aff0/src/content/i18n/ar.yml#L58-L60), [`de`](https://github.com/withastro/docs/blob/b9773d37fae129f1b807b2ce33a0932092a6aff0/src/content/i18n/de.yml#L60-L62), [`hi`](https://github.com/withastro/docs/blob/b9773d37fae129f1b807b2ce33a0932092a6aff0/src/content/i18n/hi.yml#L60-L62), [`it`](https://github.com/withastro/docs/blob/b9773d37fae129f1b807b2ce33a0932092a6aff0/src/content/i18n/it.yml#L60-L62), [`ja`](https://github.com/withastro/docs/blob/b9773d37fae129f1b807b2ce33a0932092a6aff0/src/content/i18n/ja.yml#L60-L62), [`ko`](https://github.com/withastro/docs/blob/b9773d37fae129f1b807b2ce33a0932092a6aff0/src/content/i18n/ko.yml#L60-L62), [`pt`](https://github.com/withastro/docs/blob/b9773d37fae129f1b807b2ce33a0932092a6aff0/src/content/i18n/pt-BR.yml#L60-L62), [`zh-CN`](https://github.com/withastro/docs/blob/b9773d37fae129f1b807b2ce33a0932092a6aff0/src/content/i18n/zh-CN.yml#L60-L62), and [`zh-TW`](https://github.com/withastro/docs/blob/b9773d37fae129f1b807b2ce33a0932092a6aff0/src/content/i18n/zh-TW.yml#L60-L62).

The following are not included:
- `es`: [Astro Docs](https://github.com/withastro/docs/blob/b9773d37fae129f1b807b2ce33a0932092a6aff0/src/content/i18n/es.yml#L61-L63) / [Starlight](https://github.com/withastro/starlight/blob/23207221169b31e0cc210451a39a19c80fa1f69e/packages/starlight/translations/es.json#L27-L29) (seems identical)
- `pl`: [Astro Docs](https://github.com/withastro/docs/blob/b9773d37fae129f1b807b2ce33a0932092a6aff0/src/content/i18n/pl.yml#L58-L60) / [Starlight](https://github.com/withastro/starlight/blob/23207221169b31e0cc210451a39a19c80fa1f69e/packages/starlight/translations/pl.json#L28-L30) (seems identical)
- `ru`: [Astro Docs](https://github.com/withastro/docs/blob/b9773d37fae129f1b807b2ce33a0932092a6aff0/src/content/i18n/ru.yml#L60-L62) / [Starlight](https://github.com/withastro/starlight/blob/23207221169b31e0cc210451a39a19c80fa1f69e/packages/starlight/translations/ru.json#L28-L30) (`expressiveCode.copyButtonTooltip` seems different)
- edit: I forgot about French... well, the Starlight translation looks better to me so... https://github.com/withastro/docs/pull/14477

And, I haven't checked if the translation are correct... I trust Astro Docs translators. 😅 

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->
