### PR TITLE
Fix i18n of default aside titles when using an Astro i18n config

### DIFF
--- a/.changeset/spotty-donkeys-shave.md
+++ b/.changeset/spotty-donkeys-shave.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fixes localisation of default aside titles and other translated UI when relying on an Astro `i18n` configuration instead of Starlight’s own `locales` option

--- a/packages/starlight/__tests__/markdown-processor/asides.test.ts
+++ b/packages/starlight/__tests__/markdown-processor/asides.test.ts
@@ -6,11 +6,18 @@ import type { MdastPluginDefinition } from 'satteri';
 import { describe, expect, test, vi } from 'vitest';
 import { remarkDirectivesRestoration } from '../../integrations/remark-asides';
 import { satteriDirectivesRestoration, starlightSatteriPlugins } from '../../integrations/satteri';
-import { starlightRemarkPlugins } from '../../integrations/remark-rehype';
+import { starlightRehypePlugins, starlightRemarkPlugins } from '../../integrations/remark-rehype';
 import type { StarlightUserConfig } from '../../utils/user-config';
-import { BuiltInDefaultLocale } from '../../utils/i18n';
+import { BuiltInDefaultLocale, processI18nConfig } from '../../utils/i18n';
+import { runPlugins } from '../../utils/plugins';
+import { createTestPluginContext } from '../test-plugin-utils';
 import { createPluginTestOptions, docFileURL } from '../test-utils';
-import { createStarlightMarkdownProcessor, describeEachProcessor, nonDocFileURL } from './utils';
+import {
+	createStarlightMarkdownProcessor,
+	describeEachProcessor,
+	nonDocFileURL,
+	type ProcessorName,
+} from './utils';
 
 const starlightConfig = {
 	title: 'Asides Tests',
@@ -19,6 +26,47 @@ const starlightConfig = {
 } satisfies StarlightUserConfig;
 
 const types = ['note', 'tip', 'caution', 'danger'] as const;
+
+/**
+ * Builds a Markdown processor the same way the Starlight integration does for a project relying on
+ * Astro’s `i18n` configuration instead of Starlight’s own `locales` option.
+ */
+async function createAstroI18nMarkdownProcessor(name: ProcessorName) {
+	const srcDir = new URL('../_src/', import.meta.url);
+	const context = createTestPluginContext({
+		srcDir,
+		i18n: {
+			defaultLocale: 'id',
+			locales: ['id'],
+			routing: {
+				prefixDefaultLocale: false,
+				redirectToDefaultLocale: false,
+				fallbackType: 'redirect',
+			},
+		},
+	});
+	const pluginResult = await runPlugins({ title: 'Astro i18n Asides Tests' }, [], context);
+	const { starlightConfig } = processI18nConfig(pluginResult.starlightConfig, context.config.i18n);
+	const options = {
+		starlightConfig,
+		astroConfig: { root: new URL('../', import.meta.url), srcDir },
+		useTranslations: pluginResult.useTranslations,
+		absolutePathToLang: pluginResult.absolutePathToLang,
+	};
+
+	if (name === 'satteri') {
+		const { mdastPlugins, hastPlugins } = starlightSatteriPlugins(options);
+		return createSatteriMarkdownProcessor({
+			mdastPlugins: [...mdastPlugins, satteriDirectivesRestoration()],
+			hastPlugins,
+			features: { directive: true },
+		});
+	}
+	return createMarkdownProcessor({
+		remarkPlugins: [...starlightRemarkPlugins(options), remarkDirectivesRestoration],
+		rehypePlugins: [...starlightRehypePlugins(options)],
+	});
+}
 
 describeEachProcessor(
 	'asides',
@@ -141,6 +189,13 @@ describeEachProcessor(
 			});
 			const res = await ctx().render(':::note\nTest\n:::', { processor });
 			expect(res.code).includes('aria-label="Note"');
+		});
+
+		test('uses the locale from an Astro i18n config when Starlight has no locales config', async () => {
+			const processor = await createAstroI18nMarkdownProcessor(name);
+			const res = await ctx().render(':::note\nTest\n:::', { processor });
+			expect(res.code).includes('aria-label="Catatan"');
+			expect(res.code).includes('</svg>Catatan</p>');
 		});
 
 		test('transforms unhandled text directives back to their source', async () => {

--- a/packages/starlight/__tests__/plugins/astro-i18n.test.ts
+++ b/packages/starlight/__tests__/plugins/astro-i18n.test.ts
@@ -1,0 +1,73 @@
+import { fileURLToPath } from 'node:url';
+import type { AstroConfig } from 'astro';
+import { expect, test } from 'vitest';
+import { runPlugins } from '../../utils/plugins';
+import { createTestPluginContext } from '../test-plugin-utils';
+
+const docsUrl = new URL('../src/content/docs/', import.meta.url);
+
+function astroI18nConfig(
+	config: Pick<NonNullable<AstroConfig['i18n']>, 'defaultLocale' | 'locales'> &
+		Partial<Pick<NonNullable<AstroConfig['i18n']>, 'routing'>>
+): AstroConfig['i18n'] {
+	return {
+		routing: {
+			prefixDefaultLocale: false,
+			redirectToDefaultLocale: false,
+			fallbackType: 'redirect',
+		},
+		...config,
+	};
+}
+
+test('infers the lang of a page from a single-locale Astro i18n configuration', async () => {
+	const { useTranslations, absolutePathToLang } = await runPlugins(
+		{ title: 'Test Docs' },
+		[],
+		createTestPluginContext({ i18n: astroI18nConfig({ defaultLocale: 'id', locales: ['id'] }) })
+	);
+
+	const lang = absolutePathToLang(fileURLToPath(new URL('./index.md', docsUrl)));
+
+	expect(lang).toBe('id');
+	expect(useTranslations(lang)('aside.note')).toBe('Catatan');
+});
+
+test('infers the lang of a page from a multilingual Astro i18n configuration', async () => {
+	const { useTranslations, absolutePathToLang } = await runPlugins(
+		{ title: 'Test Docs' },
+		[],
+		createTestPluginContext({
+			i18n: astroI18nConfig({ defaultLocale: 'id', locales: ['id', 'fr'] }),
+		})
+	);
+
+	const rootLang = absolutePathToLang(fileURLToPath(new URL('./index.md', docsUrl)));
+	expect(rootLang).toBe('id');
+	expect(useTranslations(rootLang)('aside.note')).toBe('Catatan');
+
+	const frLang = absolutePathToLang(fileURLToPath(new URL('./fr/index.md', docsUrl)));
+	expect(frLang).toBe('fr');
+	expect(useTranslations(frLang)('aside.tip')).toBe('Astuce');
+});
+
+test('exposes the locales inferred from the Astro i18n configuration to plugins', async () => {
+	expect.assertions(2);
+
+	await runPlugins(
+		{ title: 'Test Docs' },
+		[
+			{
+				name: 'test-plugin',
+				hooks: {
+					'config:setup'({ useTranslations, absolutePathToLang }) {
+						const lang = absolutePathToLang(fileURLToPath(new URL('./index.md', docsUrl)));
+						expect(lang).toBe('id');
+						expect(useTranslations(lang)('aside.note')).toBe('Catatan');
+					},
+				},
+			},
+		],
+		createTestPluginContext({ i18n: astroI18nConfig({ defaultLocale: 'id', locales: ['id'] }) })
+	);
+});

--- a/packages/starlight/__tests__/test-plugin-utils.ts
+++ b/packages/starlight/__tests__/test-plugin-utils.ts
@@ -1,12 +1,14 @@
-import type { AstroIntegrationLogger } from 'astro';
+import type { AstroConfig, AstroIntegrationLogger } from 'astro';
 import { type StarlightPluginContext } from '../utils/plugins';
 
-export function createTestPluginContext(): StarlightPluginContext {
+export function createTestPluginContext(
+	config?: Partial<Pick<AstroConfig, 'i18n' | 'srcDir'>>
+): StarlightPluginContext {
 	return {
 		command: 'dev',
 		// @ts-expect-error - we don't provide a full Astro config but only what is needed for the
 		// plugins to run.
-		config: { srcDir: new URL('./src/', import.meta.url), integrations: [] },
+		config: { srcDir: new URL('./src/', import.meta.url), integrations: [], ...config },
 		isRestart: false,
 		logger: new TestAstroIntegrationLogger(),
 	};

--- a/packages/starlight/utils/plugins.ts
+++ b/packages/starlight/utils/plugins.ts
@@ -7,6 +7,7 @@ import {
 	type StarlightConfig,
 	type StarlightUserConfig,
 } from '../utils/user-config';
+import { processI18nConfig } from './i18n';
 import type { UserI18nSchema } from './translations';
 import { createTranslationSystemFromFs } from './translations-fs';
 import { absolutePathToLang as getAbsolutePathFromLang } from '../integrations/shared/absolutePathToLang';
@@ -25,10 +26,20 @@ export async function runPlugins(
 	// Validate the user-provided configuration.
 	let userConfig = starlightUserConfig;
 
-	let starlightConfig = parseWithFriendlyErrors(
-		StarlightConfigSchema,
-		userConfig,
-		'Invalid config passed to starlight integration'
+	/**
+	 * Merges any Astro i18n configuration into a Starlight configuration so that the locales
+	 * Starlight will actually use are known when creating the translation system and the
+	 * `absolutePathToLang()` helper below, and when passing the config down to plugins.
+	 */
+	const withAstroI18nConfig = (config: StarlightConfig) =>
+		processI18nConfig(config, context.config.i18n).starlightConfig;
+
+	let starlightConfig = withAstroI18nConfig(
+		parseWithFriendlyErrors(
+			StarlightConfigSchema,
+			userConfig,
+			'Invalid config passed to starlight integration'
+		)
 	);
 
 	// Validate the user-provided plugins configuration.
@@ -109,7 +120,7 @@ export async function runPlugins(
 
 				// If the updated config is valid, keep track of both the user config and parsed config.
 				userConfig = mergedUserConfig;
-				starlightConfig = mergedConfig;
+				starlightConfig = withAstroI18nConfig(mergedConfig);
 			},
 			addIntegration(integration) {
 				// Collect any Astro integrations added by the plugin.


### PR DESCRIPTION
#### Description

- Closes #3710

When a project configures languages through Astro's `i18n` option instead of Starlight's own `locales`, `:::note` and friends render their default titles in English rather than the configured language.

The cause is ordering in `astro:config:setup`. `runPlugins()` builds `useTranslations()` and `absolutePathToLang()` from the Starlight config as-is, and only after it returns does `index.ts` call `processI18nConfig()` to fold the Astro `i18n` locales in. So both helpers are created against a config whose default locale is still the built-in `en`, and the remark/rehype aside plugins — which receive exactly those two helpers — resolve every page to `en`.

I moved the `processI18nConfig()` merge into `runPlugins()` so the derived locales are in place before the translation system and `absolutePathToLang()` are created, and re-applied it after a plugin's `updateConfig()` so plugin-modified configs keep them. The call in `index.ts` still runs and is idempotent — `isUsingBuiltInDefaultLocale` is untouched by the merge, so it re-derives the same values and the "both Astro and Starlight i18n configured" guard still fires.

This also fixes the same class of bug for plugins, which previously got `en`-bound helpers in `config:setup`.

Tests: an aside test that renders `:::note` through the real plugin pipeline with an Astro `i18n` config of `defaultLocale: 'id'` and expects `Catatan` (for both the Markdown and Sätteri processors), plus `__tests__/plugins/astro-i18n.test.ts` covering single-locale, multilingual, and plugin-visible lang inference. `createTestPluginContext()` now accepts `i18n`/`srcDir` overrides. Reverting the `plugins.ts` change fails 5 of them; with it the full package suite is 636 passing across 91 files. ESLint and Prettier are clean on the touched files, and `astro check` reports no new errors in them.

#4078 was an earlier attempt at test coverage for this, but it only added a test and left the bug unfixed, so I closed it in favour of this.
