### PR TITLE
Fix hidden heading anchor links

### DIFF
--- a/.changeset/public-lamps-invent.md
+++ b/.changeset/public-lamps-invent.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/starlight": patch
+---
+
+Fixes a layout issue and anchor links appearing for hidden headings, e.g. footnote headings, when `markdown.headingLinks` is enabled or the `<AnchorHeading>` component is used.

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -3,6 +3,28 @@ title: Getting Started
 description: Learn how to start building your next documentation site with Starlight by Astro.
 ---
 
+:::danger[TODO(HiDeoo)]
+
+- Remove changes to this page.
+
+:::
+
+## Test
+
+This is a sentence with a footnote reference.[^1]
+
+[^1]: A reference.
+
+import AnchorHeading from '@astrojs/starlight/components/AnchorHeading.astro';
+
+<AnchorHeading level="2" id="test" hidden>
+	Test
+</AnchorHeading>
+
+This sentence is preceded by a `<AnchorHeading>` component with the `hidden` attribute.
+
+---
+
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 Starlight is a full-featured documentation theme built on top of the [Astro](https://astro.build) framework.

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -3,28 +3,6 @@ title: Getting Started
 description: Learn how to start building your next documentation site with Starlight by Astro.
 ---
 
-:::danger[TODO(HiDeoo)]
-
-- Remove changes to this page.
-
-:::
-
-## Test
-
-This is a sentence with a footnote reference.[^1]
-
-[^1]: A reference.
-
-import AnchorHeading from '@astrojs/starlight/components/AnchorHeading.astro';
-
-<AnchorHeading level="2" id="test" hidden>
-	Test
-</AnchorHeading>
-
-This sentence is preceded by a `<AnchorHeading>` component with the `hidden` attribute.
-
----
-
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 Starlight is a full-featured documentation theme built on top of the [Astro](https://astro.build) framework.

--- a/packages/starlight/style/anchor-links.css
+++ b/packages/starlight/style/anchor-links.css
@@ -45,6 +45,11 @@ how we do it.
 		line-height: var(--sl-line-height-headings);
 	}
 
+	/* If the heading is hidden, remove the wrapper's box to avoid unwanted spacing. */
+	.sl-markdown-content .sl-heading-wrapper:has(> :first-child:is(.sr-only, [hidden])) {
+		display: contents;
+	}
+
 	/* We need to apply the same rule we use for heading spacing to the parent wrapper. */
 	.sl-markdown-content
 		:not(h1, h2, h3, h4, h5, h6, .sl-heading-wrapper)
@@ -75,7 +80,7 @@ how we do it.
 	/* ======================================================
    HEADING
    ====================================================== */
-	.sl-markdown-content .sl-heading-wrapper > :first-child {
+	.sl-markdown-content .sl-heading-wrapper > :first-child:not([hidden]) {
 		display: inline;
 		/* Apply end-of-line padding to the heading element. */
 		padding-inline-end: var(--sl-anchor-icon-space);
@@ -94,6 +99,13 @@ how we do it.
 		/* Prevent double clicks on the last word (or single word) of a heading to include an extra new
      line in Chrome and Safari. */
 		display: inline-flex;
+	}
+
+	/* Hide anchor links for headings that are hidden. */
+	.sl-markdown-content
+		.sl-heading-wrapper:has(> :first-child:is(.sr-only, [hidden]))
+		> .sl-anchor-link {
+		display: none;
 	}
 
 	/* Increase clickable area for anchor links with a pseudo element that doesn’t impact layout. */


### PR DESCRIPTION
#### Description

<!-- New features should first be discussed and approved by maintainers in GitHub or Discord discussions. -->
<!-- If this PR adds a new public-facing feature, uncomment the line below and include a link to the relevant discussion. -->
<!-- - [x] This PR adds a new feature which has been discussed and approved [here](link to GitHub or Discord discussion). -->

- Closes #4165

This PR fixes an issue with anchor links and hidden headings (e.g. footnote headings).

This PR does not use the approach from https://github.com/withastro/starlight/pull/4166 to prevent heading links to be added at the Markdown processor level:

- A user could have some custom CSS or client-side JS to show such headings at some point in time
- The issue also appears when using the `<AnchorHeading>` component

Instead, this PR uses CSS to properly hide anchor links for hidden headings.

#### Remaining tasks

- [x] Address all `TODO(HiDeoo)` comments