### PR TITLE
Ignore `PageFrame` when formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -23,6 +23,9 @@ packages/starlight/src/user-components/Tabs.astro
 packages/starlight/src/components/AnchorHeading.astro
 packages/starlight/__e2e__/fixtures/basics/src/content/docs/anchor-heading-component.mdx
 
+# Prettier chokes on a JS class in a <script> in a conditional expression in this component
+packages/starlight/src/components/PageFrame.astro
+
 # Malformed YAML file used for testing
 packages/starlight/__tests__/i18n/malformed-yaml-src/content/i18n/*.yml
 


### PR DESCRIPTION
This PR is aimed to temporarily fix formatting.

It’s currently broken due to a bug in Prettier’s parsing of the `PageFrame.astro` component. It does not like the JS `class` inside a `<script>` inside a conditional expression here:

https://github.com/withastro/starlight/blob/726a99bdded98fcbf45cb4effc1e05cf24c73586/packages/starlight/src/components/PageFrame.astro#L9-L42

As a workaround, this PR adds `PageFrame.astro` to our `.prettierignore` so it is skipped by formatting. We can remove this later in #4175.
