### PR TITLE
docs: fix broken/outdated external links

### DIFF
--- a/docs/src/content/docs/de/reference/configuration.mdx
+++ b/docs/src/content/docs/de/reference/configuration.mdx
@@ -588,7 +588,7 @@ interface HeadConfig {
 
 Legt fest, ob in der Fußzeile angezeigt werden soll, wann die Seite zuletzt aktualisiert wurde.
 
-Standardmäßig verwendet diese Funktion die Git-Historie deines Repositorys und kann auf einigen Bereitstellungs&shy;plattformen, die [shallow clones](https://git-scm.com/docs/git-clone/de#git-clone---depthltTiefegt) durchführen, nicht genau sein. Eine Seite kann diese Einstellung oder das Git-basierte Datum mit dem [`lastUpdated` Frontmatter-Feld](/de/reference/frontmatter/#lastupdated) überschreiben.
+Standardmäßig verwendet diese Funktion die Git-Historie deines Repositorys und kann auf einigen Bereitstellungs&shy;plattformen, die [shallow clones](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt) durchführen, nicht genau sein. Eine Seite kann diese Einstellung oder das Git-basierte Datum mit dem [`lastUpdated` Frontmatter-Feld](/de/reference/frontmatter/#lastupdated) überschreiben.
 
 ### `pagination`
 

--- a/docs/src/content/docs/es/resources/themes.mdx
+++ b/docs/src/content/docs/es/resources/themes.mdx
@@ -45,7 +45,7 @@ Instala un tema creado por la comunidad para personalizar rápidamente la aparie
 		{
 			title: 'Catppuccin for Starlight',
 			description: 'Suave tema pastel para Starlight.',
-			href: 'https://catppuccin-starlight.otterlord.dev/',
+			href: 'https://starlight.catppuccin.com/',
 			previews: { light: 'catppuccin-light.png', dark: 'catppuccin-dark.png' },
 		},
 		{


### PR DESCRIPTION
#### Description

While auditing the docs site for broken external links, I found two outdated URLs in translated pages. Both fixes align the translated pages with the URLs already used in the English docs.

**1. `de/reference/configuration.mdx` — git-clone docs link (404)**
The `git clone --depth` link pointed to `https://git-scm.com/docs/git-clone/de`, but git-scm.com has no German translation of the docs, so the page returns HTTP 404. This now points to the English anchor (`https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt`) already used by the English, Spanish, French, Korean, Russian, and Chinese versions of the same paragraph.

**2. `es/resources/themes.mdx` — Catppuccin for Starlight theme link (dead domain)**
The theme entry pointed to `https://catppuccin-starlight.otterlord.dev/`, which no longer resolves (DNS NXDOMAIN, verified via three independent networks). This now points to the official `https://starlight.catppuccin.com/` address already used in the English themes page.

**Verification**
- Both replacement URLs return HTTP 200.
- Before/after: `pnpm linkcheck` in `docs/` passes with all internal links valid and 629 pages built successfully.

Note: no changeset added since this PR only touches `docs/*` per the contributing guide.