### PR TITLE
docs: deploy docs with built Starlight

### DIFF
--- a/docs/build-dist.mjs
+++ b/docs/build-dist.mjs
@@ -13,6 +13,9 @@ const docsPackageJson = new URL('package.json', docsDir);
 const tarballPath = join(tmpdir(), `starlight-${process.pid}.tgz`);
 const pnpmPath = process.env.npm_execpath ?? '';
 
+// Depending on the version, pnpm can be a JavaScript entry point or a standalone binary.
+const isPnpmJavaScript = /\.(?:c|m)?js$/i.test(pnpmPath);
+
 if (!pnpmPath || !process.env.npm_config_user_agent?.startsWith('pnpm/')) {
 	throw new Error('The script must be run using pnpm');
 }
@@ -53,5 +56,9 @@ try {
  * @param {...string} args - Arguments to pass to the pnpm command.
  */
 function runPnpm(cwd, ...args) {
-	execFileSync(process.execPath, [pnpmPath, ...args], { cwd, stdio: 'inherit' });
+	execFileSync(
+		isPnpmJavaScript ? process.execPath : pnpmPath,
+		isPnpmJavaScript ? [pnpmPath, ...args] : args,
+		{ cwd, stdio: 'inherit' }
+	);
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+# // TODO(HiDeoo) Remove
+[context.deploy-preview]
+  command = "cd docs && pnpm build:dist"


### PR DESCRIPTION
#### Description

<!-- New features should first be discussed and approved by maintainers in GitHub or Discord discussions. -->
<!-- If this PR adds a new public-facing feature, uncomment the line below and include a link to the relevant discussion. -->
<!-- - [x] This PR adds a new feature which has been discussed and approved [here](link to GitHub or Discord discussion). -->

As a follow-up to some discussion, this PR experiments with deploying the docs using a built version of Starlight.

To do that, we temporarily [overrides the Netlify build command using a configuration file](https://docs.netlify.com/build/configure-builds/file-based-configuration/) for deploy previews.

The PR also fixes an issue with the `build:dist` command where a same version of pnpm can be either a JavaScript entry point or a standalone binary (e.g. when using pnpm v12 as a package manager manager). I hit this issue locally as I now use pnpm v12 to automatically install pnpm v11.22.0 used in the monorepo but we would ultimately need the fix once switching the monorepo to pnpm v12.

If we want to move on with the approach, we should remove the override in this PR and instead update the Netlify build command.

#### Observations

- The override worked properly:
  <img width="694" height="153" alt="image" src="https://github.com/user-attachments/assets/fa51139a-bf0b-4858-b601-21a5517ca088" />
- The entire "Building" Netlify step took 1mn9s instead of 1mn for the previous deploy preview.
- Building Starlight and doing the pnpm shenanigans to use this version took 14s.

Difficult to properly compare with one deploy preview but the additional time is expected and seems totally reasonable.

#### Remaining tasks

- [x] Address `TODO(HiDeoo)` comments
- [x] Update Netlify build command to `cd docs && pnpm build:dist`