### PR TITLE
i18n(es): update `icons`, `i18n`, `using-components` & `resources/plugins`

### DIFF
--- a/docs/src/content/docs/es/components/using-components.mdx
+++ b/docs/src/content/docs/es/components/using-components.mdx
@@ -9,7 +9,7 @@ Los componentes te permiten reutilizar fácilmente un fragmento de UI o estilos 
 Los ejemplos pueden incluir una tarjeta de enlace o un incrustado de YouTube.
 Starlight admite el uso de componentes en archivos [MDX](https://mdxjs.com/) y [Markdoc](https://markdoc.dev/) y proporciona algunos componentes comunes para que los uses.
 
-[Conoce más sobre la construcción de componentes en la documentación de Astro](https://docs.astro.build/es/core-concepts/astro-components/).
+[Conoce más sobre la construcción de componentes en la documentación de Astro](https://docs.astro.build/es/basics/astro-components/).
 
 ## Usando un componente en MDX
 
@@ -32,7 +32,7 @@ import CustomCard from '../../components/CustomCard.astro';
 </CustomCard>
 ```
 
-Debido a que Starlight está impulsado por Astro, puedes agregar soporte para componentes construidos con cualquier [framework de UI compatible (React, Preact, Svelte, Vue, Solid y Alpine)](https://docs.astro.build/es/core-concepts/framework-components/) en tus archivos MDX.
+Debido a que Starlight está impulsado por Astro, puedes agregar soporte para componentes construidos con cualquier [framework de UI compatible (React, Preact, Svelte, Vue, Solid y Alpine)](https://docs.astro.build/es/guides/framework-components/) en tus archivos MDX.
 {/* TODO: Actualizar esta liga cuando los docs en español de Astro incluyan el fragmento de la versión en inglés. */}
 Aprende más sobre [usar componentes en MDX](https://docs.astro.build/en/guides/integrations-guide/mdx/#using-components-in-mdx) en la documentación de Astro.
 
@@ -84,14 +84,14 @@ Si estos estilos entran en conflicto con la apariencia de tu componente, estable
 Usa el tipo [`ComponentProps`](https://docs.astro.build/es/guides/typescript/#tipo-componentprops) de `astro/types` para hacer referencia a las `Props` aceptadas por un componente incluso si no están exportadas por el componente en sí.
 Esto puede ser util al envolver o extender un componente existente.
 
-El siguiente ejemplo usa `ComponentProps` para obtener el tipo de las props aceptadas por el componente `Icon` incorporado de Starlight:
+El siguiente ejemplo usa `ComponentProps` para obtener el tipo de las props aceptadas por el componente `Badge` incorporado de Starlight:
 
 ```astro
 ---
 // src/components/Example.astro
 import type { ComponentProps } from 'astro/types';
-import { Icon } from '@astrojs/starlight/icon';
+import { Badge } from '@astrojs/starlight/components';
 
-type IconProps = ComponentProps<typeof Icon>;
+type BadgeProps = ComponentProps<typeof Badge>;
 ---
 ```

--- a/docs/src/content/docs/es/guides/i18n.mdx
+++ b/docs/src/content/docs/es/guides/i18n.mdx
@@ -326,10 +326,10 @@ El valor de `feature` debe establecerse en un objeto de opciones pasado como seg
 
 ```astro {3}
 <!-- src/components/Example.astro -->
-<a href="https://docs.astro.build/en/guides/astro-db/">
-	{Astro.locals.t('link.astro.custom', { feature: 'Astro DB' })}
+<a href="https://docs.astro.build/en/guides/actions/">
+	{Astro.locals.t('link.astro.custom', { feature: 'Astro Actions' })}
 </a>
-<!-- Renderiza: <a href="...">Astro documentation for Astro DB</a> -->
+<!-- Renderiza: <a href="...">Astro documentation for Astro Actions</a> -->
 ```
 
 Ver la [documentación de i18next](https://www.i18next.com/overview/api#t) para obtener más información sobre cómo usar la función `t()` con interpolación, formato y más.

--- a/docs/src/content/docs/es/reference/icons.mdx
+++ b/docs/src/content/docs/es/reference/icons.mdx
@@ -10,6 +10,19 @@ Starlight proporciona un conjunto de iconos integrados que puedes mostrar en tu 
 Los iconos se pueden mostrar usando el componente [`<Icon>`](/es/components/icons/).
 Estos también se utilizan a menudo en otros componentes, como [tarjetas](/es/components/cards/) o configuraciones como [acciones de hero](/es/reference/frontmatter/#hero).
 
+## Tipo `StarlightIcon`
+
+Usa el tipo de TypeScript `StarlightIcon` para hacer referencia a los nombres de los [iconos integrados de Starlight](#todos-los-iconos).
+
+```ts {2} /icon: (StarlightIcon)/
+// src/icon.ts
+import type { StarlightIcon } from '@astrojs/starlight/types';
+
+function getIconLabel(icon: StarlightIcon) {
+	// …
+}
+```
+
 ## Todos los iconos
 
 Una lista de todos los iconos disponibles se muestra a continuación con sus nombres asociados. Haz clic en un icono para copiar su nombre al portapapeles.

--- a/docs/src/content/docs/es/resources/plugins.mdx
+++ b/docs/src/content/docs/es/resources/plugins.mdx
@@ -91,6 +91,11 @@ import ThirdPartyContent from '~/components/third-party-content.astro';
 			title="starlight-heading-badges"
 			description="Agrega insignias a tus encabezados de Markdown y MDX."
 		/>
+		<LinkCard
+			href="https://github.com/HiDeoo/starlight-to-skills"
+			title="starlight-to-skills"
+			description="Convierte las páginas de documentación de Starlight en skills de agente revisados, fáciles de encontrar y actualizados."
+		/>
 	</CardGrid>
 </ThirdPartyContent>
 
@@ -155,6 +160,11 @@ Estas herramientas e integraciones de la comunidad se pueden utilizar para añad
 			href="https://docs.contentisland.net/templates/starlight/"
 			title="contentisland-cli"
 			description="Conecta y sincroniza tu proyecto Starlight con Content Island Headless CMS para editar y gestionar tu documentación."
+		/>
+		<LinkCard
+			href="https://github.com/joesaby/astro-archify"
+			title="astro-archify"
+			description="Renderiza durante la compilación diagramas de sistema de Archify a partir de bloques de código JSON IR. Compatible con Astro y Starlight."
 		/>
 	</CardGrid>
 </ThirdPartyContent>


### PR DESCRIPTION
## Description

Updates 4 out-of-date Spanish translations to match their current English sources (per the [Lunaria translation dashboard](https://i18n.starlight.astro.build)).

| Page | English-side change(s) synced |
| --- | --- |
| `src/content/docs/es/reference/icons.mdx` | #2805 — adds the new "`StarlightIcon` type" section with its code example |
| `src/content/docs/es/guides/i18n.mdx` | #4120 — the `t()` interpolation example now uses the Astro Actions guide instead of the removed Astro DB guide |
| `src/content/docs/es/components/using-components.mdx` | #2751 — the `ComponentProps` example now uses the `Badge` component; #2612/#3508 era URL migrations for two Astro Docs links (`core-concepts/astro-components` → `basics/astro-components`, `core-concepts/framework-components` → `guides/framework-components`, verified both `/es/` URLs resolve) |
| `src/content/docs/es/resources/plugins.mdx` | #4171 — adds the `starlight-to-skills` community plugin card; #4164 — adds the `astro-archify` community tool card |

Notes:
- Existing Spanish wording and terminology were preserved; only content added or changed on the English side was translated.
- The last commit that touched `es/resources/plugins.mdx` (#4143) was an `[i18nIgnore]` markup reformat, so this page carries an older, pre-existing content gap (several community plugin entries added over the years were never translated). Filling that larger gap is beyond the scope of this update PR; this PR only syncs the changes Lunaria tracks as out-of-date.

No changeset needed: documentation-only change (`docs/*`), exempt per the [contributor manual](https://github.com/withastro/starlight/blob/main/CONTRIBUTING.md#making-a-pull-request).
