### PR TITLE
chore: remove Astro 7 upgrade banner [i18nIgnore]

### DIFF
--- a/docs/src/content/docs/de/index.mdx
+++ b/docs/src/content/docs/de/index.mdx
@@ -7,12 +7,6 @@ description: Erstelle schöne, leistungsstarke Dokumentations-Websites mit Starl
 template: splash
 editUrl: false
 lastUpdated: false
-banner:
-  content: |
-    Auf Astro 7 aktualisieren?
-    <a href="https://github.com/withastro/starlight/releases/tag/%40astrojs/starlight%400.41.0">
-      Erfahre, wie du eine Aktualisierung durchführst
-    </a>
 hero:
   title: Bringe deine Dokumentation mit Starlight zum Leuchten
   tagline: Alles, was du brauchst, um eine erstklassige Dokumentations-Website zu erstellen. Schnell, barrierefrei und einfach zu bedienen.

--- a/docs/src/content/docs/fr/index.mdx
+++ b/docs/src/content/docs/fr/index.mdx
@@ -7,12 +7,6 @@ description: Starlight vous aide à créer de magnifiques sites web de documenta
 template: splash
 editUrl: false
 lastUpdated: false
-banner:
-  content: |
-    En cours de mise à jour vers Astro 7 ?
-    <a href="https://github.com/withastro/starlight/releases/tag/%40astrojs/starlight%400.41.0">
-      Découvrez comment effectuer la mise à niveau
-    </a>
 hero:
   title: Faites briller vos documentations avec Starlight
   tagline: Tout ce dont vous avez besoin pour créer un excellent site web de documentation. Rapide, accessible et facile à utiliser.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -7,12 +7,6 @@ description: Starlight helps you build beautiful, high-performance documentation
 template: splash
 editUrl: false
 lastUpdated: false
-banner:
-  content: |
-    Updating to Astro 7?
-    <a href="https://github.com/withastro/starlight/releases/tag/%40astrojs/starlight%400.41.0">
-      Learn how to upgrade
-    </a>
 hero:
   title: Make your docs shine with Starlight
   tagline: Everything you need to build a stellar documentation website. Fast, accessible, and easy-to-use.

--- a/docs/src/content/docs/ko/index.mdx
+++ b/docs/src/content/docs/ko/index.mdx
@@ -7,12 +7,6 @@ description: Starlight로 아름답고 성능이 좋은 Astro 문서 웹 사이�
 template: splash
 editUrl: false
 lastUpdated: false
-banner:
-  content: |
-    Astro 7로 업데이트하시나요?
-    <a href="https://github.com/withastro/starlight/releases/tag/%40astrojs/starlight%400.41.0">
-      업그레이드 방법 알아보기
-    </a>
 hero:
   title: Starlight로 멋진 문서를 만드세요
   tagline: 아름다운 문서 웹 사이트를 만드는데 필요한 모든 것. 빠르고, 접근성이 좋으며 사용하기 쉽습니다.

--- a/docs/src/content/docs/ru/index.mdx
+++ b/docs/src/content/docs/ru/index.mdx
@@ -7,12 +7,6 @@ description: Starlight помогает вам создавать красивы
 template: splash
 editUrl: false
 lastUpdated: false
-banner:
-  content: |
-    Обновляетесь до Astro 7?
-    <a href="https://github.com/withastro/starlight/releases/tag/%40astrojs/starlight%400.41.0">
-      Узнайте, как выполнить обновление
-    </a>
 hero:
   title: Сделайте свою документацию яркой с помощью Starlight
   tagline: Всё, что вам нужно, чтобы создать впечатляющий сайт с документацией. Быстро, доступно и просто в использовании.

--- a/docs/src/content/docs/zh-cn/index.mdx
+++ b/docs/src/content/docs/zh-cn/index.mdx
@@ -7,12 +7,6 @@ description: Starlight 帮助你使用 Astro 构建漂亮、高性能的文档�
 template: splash
 editUrl: false
 lastUpdated: false
-banner:
-  content: |
-    升级到 Astro 7？
-    <a href="https://github.com/withastro/starlight/releases/tag/%40astrojs/starlight%400.41.0">
-      了解如何升级
-    </a>
 hero:
   title: Starlight <br/> 使你的文档闪耀夺目
   tagline: 快速、易用、易于访问 —— 构建卓越文档网站所需的一切。


### PR DESCRIPTION
#### Description

This PR removes the "Upgrade to Astro 7" banner on the Starlight landing page of all locales because the Astro v7 release was already [almost 3 months ago (June 22)](https://github.com/withastro/astro/releases/tag/astro%407.0.0) and this would give the landing page a fresh look before Astro v8 is released.